### PR TITLE
fix: add ProjectMnemosyne/ and build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ tests/*.log
 
 # Local state (not config)
 *.bak
+
+# Cloned repos from /advise skill
+ProjectMnemosyne/
+build/


### PR DESCRIPTION
## Summary
- **I9**: Add `ProjectMnemosyne/` and `build/` to `.gitignore` to prevent `/advise` skill clone artifacts from being tracked

## Test plan
- [x] Verify `.gitignore` entries are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)