### PR TITLE
fix: filter --dry-run from args before exec'ing plan.sh

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -76,7 +76,10 @@ main() {
     parse_args "$@"
 
     if [[ $DRY_RUN -eq 1 ]]; then
-        exec "${SCRIPT_DIR}/plan.sh" "$@"
+        local plan_args=()
+        [[ -n "$HOST" ]] && plan_args+=("$HOST")
+        [[ -n "$FLEET" ]] && plan_args+=(--fleet "$FLEET")
+        exec "${SCRIPT_DIR}/plan.sh" "${plan_args[@]}"
     fi
 
     check_deps


### PR DESCRIPTION
## Summary

- `apply.sh --dry-run` previously passed the raw `$@` (including `--dry-run`) to `plan.sh` via `exec`
- `plan.sh` doesn't recognize `--dry-run` as a flag, so it treated it as a positional HOST argument
- This caused `plan.sh` to look for agents in `agents/--dry-run/` and silently report "No agent YAML files found"
- The HOST argument was also lost in the process

The fix reconstructs clean args from the already-parsed `HOST` and `FLEET` variables rather than forwarding the raw original `$@`.

## Test plan

- [ ] `./scripts/apply.sh --dry-run` — should behave identically to `./scripts/plan.sh`
- [ ] `./scripts/apply.sh hermes --dry-run` — should behave identically to `./scripts/plan.sh hermes`
- [ ] `./scripts/apply.sh --fleet dev-mesh --dry-run` — should behave identically to `./scripts/plan.sh --fleet dev-mesh`
- [ ] `./scripts/apply.sh hermes --fleet dev-mesh --dry-run` — should pass both HOST and --fleet to plan.sh

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)