### PR TITLE
fix(ci): add jq install step and pin yq version in apply.yml

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -16,13 +16,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install yq if needed
+      - name: Install yq
+        env:
+          YQ_VERSION: "v4.40.5"
         run: |
-          if ! command -v yq &>/dev/null; then
-            YQ_URL="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
-            curl -fsSL "$YQ_URL" -o /usr/local/bin/yq
-            chmod +x /usr/local/bin/yq
+          curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Install jq if needed
+        run: |
+          if ! command -v jq &>/dev/null; then
+            apt-get install -y jq
           fi
+          jq --version
 
       - name: Plan — show what will change
         run: |


### PR DESCRIPTION
## Summary

- Add `jq` installation step to `apply.yml` — without it, fresh self-hosted runners lacking `jq` would fail with a confusing `check_deps()` error rather than a clear missing-dependency message
- Pin `yq` to `v4.40.5` in `apply.yml` to match `validate.yml`, eliminating version skew between the two workflows
- Drop the conditional `if ! command -v yq` guard in `apply.yml` so the pinned version is always installed (not skipped if an older version is already present)

## Test plan

- [ ] Review diff to confirm `jq` install step is present and correct
- [ ] Confirm `yq` version is `v4.40.5` in both `validate.yml` and `apply.yml`
- [ ] Merge to main and observe apply workflow installs both tools without error

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)