### PR TITLE
fix: replace check_jq with check_deps in export.sh

### DIFF
--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -18,12 +18,14 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # shellcheck source=scripts/lib/api.sh
 source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/reconcile.sh
+source "${SCRIPT_DIR}/lib/reconcile.sh"
 
 HOST="${1:-hermes}"
 OUTPUT_DIR="${REPO_ROOT}/agents/${HOST}"
 
 main() {
-    check_jq
+    check_deps
     agamemnon_check_connection
 
     echo "Exporting agents from Agamemnon (${AGAMEMNON_URL}) for host: ${HOST}"
@@ -48,13 +50,6 @@ main() {
 
     echo ""
     echo "Exported ${count} agents to ${OUTPUT_DIR}/"
-}
-
-check_jq() {
-    if ! command -v jq &>/dev/null; then
-        echo "ERROR: jq is required. Install: apt install jq" >&2
-        exit 1
-    fi
 }
 
 # Derive a safe filename from agent name (replaces - and _ with -)


### PR DESCRIPTION
## Summary

- Source `scripts/lib/reconcile.sh` in `export.sh`
- Replace the partial `check_jq()` function with a call to `check_deps()` from `reconcile.sh`
- `check_deps()` checks for all three required tools: `yq`, `jq`, and `curl`
- Removes the now-redundant local `check_jq()` definition

This brings `export.sh` in line with `apply.sh`, `plan.sh`, and `status.sh` which all use `check_deps()`. Previously, if `curl` was missing, `export.sh` would fail with an opaque error during the API call rather than a clean dependency error message.

## Test plan

- [ ] Verify `export.sh` fails cleanly with a clear error message when `jq`, `yq`, or `curl` is missing
- [ ] Verify `export.sh` runs successfully when all deps are present and Agamemnon is reachable

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)