### PR TITLE
feat: add model, owner, role, deployment.type to drift detection

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -175,7 +175,8 @@ apply_agent() {
 
     local action
     action="$(compute_drift "$name" "$desired_state" "$actual_json" \
-        "$label" "$program" "$workdir" "$args" "$desc" "$tags")"
+        "$label" "$program" "$workdir" "$args" "$desc" "$tags" \
+        "$model" "$owner" "$role" "$deploy_type")"
 
     case "$action" in
         UNCHANGED)
@@ -205,8 +206,15 @@ apply_agent() {
                 --arg workingDirectory "$workdir" \
                 --arg programArgs "$args" \
                 --arg taskDescription "$desc" \
+                --arg model "$model" \
+                --arg owner "$owner" \
+                --arg role "$role" \
+                --arg deploymentType "$deploy_type" \
                 '{label: $label, program: $program, workingDirectory: $workingDirectory,
-                  programArgs: $programArgs, taskDescription: $taskDescription}')"
+                  programArgs: $programArgs, taskDescription: $taskDescription,
+                  model: $model, owner: $owner, role: $role, deploymentType: $deploymentType}')"
+            # Convert empty model string to JSON null (API expects null, not "")
+            patch_body="$(echo "$patch_body" | jq 'if .model == "" then .model = null else . end')"
 
             if agamemnon_update_agent "$actual_id" "$patch_body" > /dev/null 2>&1; then
                 echo "    Updated."

--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -105,7 +105,21 @@ build_create_json() {
 
 # Compare desired agent state (YAML fields) with actual state (JSON from API).
 # Outputs: "UNCHANGED", "CREATE", "UPDATE:<field1>,<field2>...", "WAKE", "HIBERNATE"
-# Usage: compute_action <yaml_fields_assoc_array_name> <actual_json>
+#
+# Positional parameters:
+#   $1  name              — agent name (for context)
+#   $2  desired_state     — "active" | "hibernated"
+#   $3  actual_json       — full agent JSON from API
+#   $4  desired_label
+#   $5  desired_program
+#   $6  desired_workdir
+#   $7  desired_args
+#   $8  desired_desc
+#   $9  desired_tags_csv
+#   $10 desired_model
+#   $11 desired_owner
+#   $12 desired_role
+#   $13 desired_deploy_type
 compute_drift() {
     local name="$1"
     local desired_state="$2"    # "active" | "hibernated"
@@ -129,6 +143,7 @@ compute_drift() {
     local drifted_fields=()
 
     local actual_label actual_program actual_workdir actual_args actual_desc actual_tags_sorted
+    local actual_model actual_owner actual_role actual_deploy_type
     actual_label="$(echo "$actual_json" | jq -r '.label // ""')"
     actual_program="$(echo "$actual_json" | jq -r '.program // ""')"
     actual_workdir="$(echo "$actual_json" | jq -r '.workingDirectory // ""')"
@@ -136,6 +151,11 @@ compute_drift() {
     actual_desc="$(echo "$actual_json" | jq -r '.taskDescription // ""')"
     # Tags: sorted comma-joined for stable comparison
     actual_tags_sorted="$(echo "$actual_json" | jq -r '.tags // [] | sort | join(",")')"
+    # Normalize null model to empty string to avoid false positives
+    actual_model="$(echo "$actual_json" | jq -r '.model // ""')"
+    actual_owner="$(echo "$actual_json" | jq -r '.owner // ""')"
+    actual_role="$(echo "$actual_json" | jq -r '.role // ""')"
+    actual_deploy_type="$(echo "$actual_json" | jq -r '.deployment.type // "local"')"
 
     # These are passed as positional args from the caller
     local desired_label="$4"
@@ -144,6 +164,10 @@ compute_drift() {
     local desired_args="$7"
     local desired_desc="$8"
     local desired_tags_csv="${9:-}"
+    local desired_model="${10:-}"
+    local desired_owner="${11:-}"
+    local desired_role="${12:-}"
+    local desired_deploy_type="${13:-local}"
 
     # Normalize tilde paths before comparison
     actual_workdir="$(normalize_path "$actual_workdir")"
@@ -161,6 +185,10 @@ compute_drift() {
     [[ "$actual_args" != "$desired_args" ]] && drifted_fields+=("programArgs")
     [[ "$actual_desc" != "$desired_desc" ]] && drifted_fields+=("taskDescription")
     [[ "$actual_tags_sorted" != "$desired_tags_sorted" ]] && drifted_fields+=("tags")
+    [[ "$actual_model" != "$desired_model" ]] && drifted_fields+=("model")
+    [[ "$actual_owner" != "$desired_owner" ]] && drifted_fields+=("owner")
+    [[ "$actual_role" != "$desired_role" ]] && drifted_fields+=("role")
+    [[ "$actual_deploy_type" != "$desired_deploy_type" ]] && drifted_fields+=("deploymentType")
 
     if [[ ${#drifted_fields[@]} -gt 0 ]]; then
         local joined

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -106,6 +106,10 @@ plan_agent() {
     local workdir="${fields[workingDirectory]:-}"
     local args="${fields[programArgs]:-}"
     local desc="${fields[taskDescription]:-}"
+    local model="${fields[model]:-}"
+    local owner="${fields[owner]:-}"
+    local role="${fields[role]:-member}"
+    local deploy_type="${fields[deploymentType]:-local}"
 
     # Look up in actual state
     local actual_json
@@ -122,7 +126,8 @@ plan_agent() {
 
     local action
     action="$(compute_drift "$name" "$desired_state" "$actual_json" \
-        "$label" "$program" "$workdir" "$args" "$desc")"
+        "$label" "$program" "$workdir" "$args" "$desc" "${fields[tags]:-}" \
+        "$model" "$owner" "$role" "$deploy_type")"
 
     case "$action" in
         UNCHANGED)

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -46,7 +46,7 @@ status_agent() {
     local yaml_file="$1"
     local agents_json="$2"
 
-    local name host desired_state label program workdir args desc
+    local name host desired_state label program workdir args desc model owner role deploy_type
     name="$(yq eval '.metadata.name' "$yaml_file")"
     host="$(yq eval '.metadata.host // "hermes"' "$yaml_file")"
     desired_state="$(yq eval '.spec.desiredState // "active"' "$yaml_file")"
@@ -55,6 +55,10 @@ status_agent() {
     workdir="$(yq eval '.spec.workingDirectory // ""' "$yaml_file")"
     args="$(yq eval '.spec.programArgs // ""' "$yaml_file")"
     desc="$(yq eval '.spec.taskDescription // ""' "$yaml_file")"
+    model="$(yq eval '.spec.model // ""' "$yaml_file")"
+    owner="$(yq eval '.spec.owner // ""' "$yaml_file")"
+    role="$(yq eval '.spec.role // "member"' "$yaml_file")"
+    deploy_type="$(yq eval '.spec.deployment.type // "local"' "$yaml_file")"
 
     local actual_json
     actual_json="$(echo "$agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
@@ -70,7 +74,8 @@ status_agent() {
 
     local drift
     drift="$(compute_drift "$name" "$desired_state" "$actual_json" \
-        "$label" "$program" "$workdir" "$args" "$desc")"
+        "$label" "$program" "$workdir" "$args" "$desc" "" \
+        "$model" "$owner" "$role" "$deploy_type")"
 
     local drift_display
     case "$drift" in

--- a/tests/test-compute-drift.sh
+++ b/tests/test-compute-drift.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# tests/test-compute-drift.sh — Unit tests for compute_drift() in scripts/lib/reconcile.sh
+#
+# Tests that model, owner, role, and deployment.type drift is detected correctly,
+# and that existing fields still work (regression).
+#
+# Usage:
+#   ./tests/test-compute-drift.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/reconcile.sh
+source "${REPO_ROOT}/scripts/lib/reconcile.sh"
+
+PASS=0
+FAIL=0
+
+# assert_eq DESCRIPTION EXPECTED ACTUAL
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Base JSON that matches desired state — used as a starting point; override fields per test
+BASE_JSON='{"status":"online","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":"claude-sonnet-4-6","owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+
+echo "=== compute_drift() unit tests ==="
+echo ""
+
+echo "--- UNCHANGED / baseline ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "all fields match → UNCHANGED" "UNCHANGED" "$result"
+
+echo ""
+echo "--- model drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-opus-4-6" "mvillmow" "member" "local")"
+assert_eq "model changed → UPDATE:model" "UPDATE:model" "$result"
+
+# API returns null model — desired is empty string (null YAML)
+NULL_MODEL_JSON='{"status":"online","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":null,"owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+result="$(compute_drift "test" "active" "$NULL_MODEL_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "" "mvillmow" "member" "local")"
+assert_eq "null model vs empty desired → UNCHANGED (null normalization)" "UNCHANGED" "$result"
+
+echo ""
+echo "--- owner drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "other-user" "member" "local")"
+assert_eq "owner changed → UPDATE:owner" "UPDATE:owner" "$result"
+
+echo ""
+echo "--- role drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "admin" "local")"
+assert_eq "role changed → UPDATE:role" "UPDATE:role" "$result"
+
+echo ""
+echo "--- deployment.type drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "docker")"
+assert_eq "deploymentType changed → UPDATE:deploymentType" "UPDATE:deploymentType" "$result"
+
+echo ""
+echo "--- multiple new fields drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-opus-4-6" "other-user" "admin" "docker")"
+assert_eq "model+owner+role+deploymentType changed → UPDATE contains all 4" \
+    "UPDATE:model,owner,role,deploymentType" "$result"
+
+echo ""
+echo "--- regression: existing fields still detected ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "NewLabel" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "label changed → UPDATE:label" "UPDATE:label" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "aider" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "program changed → UPDATE:program" "UPDATE:program" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/other" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "workingDirectory changed → UPDATE:workingDirectory" "UPDATE:workingDirectory" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "--verbose" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "programArgs changed → UPDATE:programArgs" "UPDATE:programArgs" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Different desc" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "taskDescription changed → UPDATE:taskDescription" "UPDATE:taskDescription" "$result"
+
+echo ""
+echo "--- regression: WAKE / HIBERNATE still work ---"
+
+OFFLINE_JSON='{"status":"offline","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":"claude-sonnet-4-6","owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+result="$(compute_drift "test" "active" "$OFFLINE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "desired=active, actual=offline → WAKE" "WAKE" "$result"
+
+ONLINE_JSON='{"status":"online","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":"claude-sonnet-4-6","owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+result="$(compute_drift "test" "hibernated" "$ONLINE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "desired=hibernated, actual=online → HIBERNATE" "HIBERNATE" "$result"
+
+echo ""
+echo "==================================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Expands `compute_drift()` in `scripts/lib/reconcile.sh` with 4 new positional parameters: `desired_model`, `desired_owner`, `desired_role`, `desired_deploy_type`
- Adds corresponding actual-value extraction from API JSON and drift comparison for all 4 fields
- Normalizes `null` model (from API) to `""` to match YAML `model: null` — prevents false positives
- Updates the PATCH body in `apply.sh` to include `model`, `owner`, `role`, `deploymentType` so detected drift is actually fixed, not just reported
- Updates all 3 call sites (`apply.sh`, `status.sh`, `plan.sh`) to parse and pass the new fields

## Test plan

- [x] 14 unit tests in `tests/test-compute-drift.sh` covering:
  - No drift → UNCHANGED
  - Each new field drifting individually (model, owner, role, deploymentType)
  - Null model normalization (API null vs YAML empty → no false positive)
  - Multiple new fields drifting simultaneously
  - Regression: existing fields (label, program, workingDirectory, programArgs, taskDescription) still detected
  - Regression: WAKE and HIBERNATE still trigger correctly
- [x] All 14 tests pass
- [x] Bash syntax check (`bash -n`) on all 4 modified scripts

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)