### PR TITLE
fix: exit 1 when validate-schemas.sh finds no YAML files

### DIFF
--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -107,6 +107,11 @@ done < <(find "${REPO_ROOT}/agents" "${REPO_ROOT}/fleets" \
 echo ""
 echo "Checked: ${CHECKED} files, Errors: ${ERRORS}"
 
+if [[ $CHECKED -eq 0 ]]; then
+    echo "WARNING: No YAML files found to validate." >&2
+    exit 1
+fi
+
 if [[ $ERRORS -gt 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Added a minimum file count guard in `tests/validate-schemas.sh`
- When no YAML files are found (empty repo, missing `agents/` and `fleets/` dirs), the script now emits a warning to stderr and exits 1 instead of silently passing with "Checked: 0 files, Errors: 0"

## Test plan

- [ ] Verify that running the script in an empty repo (or with both directories absent) now exits 1 with `WARNING: No YAML files found to validate.`
- [ ] Verify that existing behaviour is unchanged when YAML files are present
- [ ] Confirm CI (`validate.yml`) still passes on a normal PR with agent YAML files

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)