### PR TITLE
fix: confirm pixi.toml present and fix README yq install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Container images are built separately in [AchaeanFleet](../AchaeanFleet).
 
 ```bash
 # Install dependencies (yq, jq, just)
-pixi install   # or: apt install jq && curl -fsSL .../yq_linux_amd64 -o /usr/local/bin/yq
+pixi install   # or: apt install jq && curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 # Install pre-commit hook
 just install-hooks


### PR DESCRIPTION
## Summary

- `pixi.toml` already exists with the correct dependencies (`just >=1.13`, `yq >=4.0`, `jq >=1.6`) — issue #14 was filed before the file was added
- Fixed the placeholder `...` URL in the README manual install fallback with the real yq GitHub releases URL
- Added the required `chmod +x` step to the manual install command

## Changes

- `README.md`: Replace `curl -fsSL .../yq_linux_amd64` placeholder with `https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64` and add `chmod +x /usr/local/bin/yq`

## Test plan

- [ ] `pixi install` succeeds (installs `just`, `yq`, `jq` from conda-forge)
- [ ] `pixi run just --version` shows ≥1.13
- [ ] `pixi run yq --version` shows ≥4.0
- [ ] `pixi run jq --version` shows ≥1.6
- [ ] Manual install fallback URL is reachable and downloads a valid binary

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)