### PR TITLE
chore: add .pixi/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/
 
 # Old/unused implementations
 hello-world/main.py
+
+# Pixi
+.pixi/


### PR DESCRIPTION
## Summary

- Added `.pixi/` to `.gitignore` to prevent the pixi local environment directory from being accidentally committed

## Test plan

- [ ] Verify `.pixi/` is ignored: create the directory locally and confirm `git status` does not show it

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)