### PR TITLE
refactor: extract get_unmanaged_names into reconcile.sh

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -234,38 +234,22 @@ handle_unmanaged() {
     shift
     local yaml_files=("$@")
 
-    # Collect managed names
-    local managed_names=()
-    for yaml_file in "${yaml_files[@]}"; do
-        local n
-        n="$(yq eval '.metadata.name' "$yaml_file")"
-        managed_names+=("$n")
-    done
-
-    # Find unmanaged
     while IFS= read -r actual_name; do
-        local is_managed=0
-        for mn in "${managed_names[@]}"; do
-            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
-        done
-
-        if [[ $is_managed -eq 0 ]]; then
-            if [[ $PRUNE -eq 1 ]]; then
-                local agent_id
-                agent_id="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
-                    '.[] | select(.name == $n) | .id')"
-                echo "[-] Pruning unmanaged: ${actual_name}"
-                echo "    Hibernating first..."
-                agamemnon_hibernate_agent "$agent_id" > /dev/null || true
-                sleep 2
-                echo "    Deleting..."
-                agamemnon_delete_agent "$agent_id" > /dev/null
-                echo "    Deleted (backup created)."
-            else
-                echo "[-] UNMANAGED: ${actual_name} (in Agamemnon but not in YAML — use --prune to remove)"
-            fi
+        if [[ $PRUNE -eq 1 ]]; then
+            local agent_id
+            agent_id="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
+                '.[] | select(.name == $n) | .id')"
+            echo "[-] Pruning unmanaged: ${actual_name}"
+            echo "    Hibernating first..."
+            agamemnon_hibernate_agent "$agent_id" > /dev/null || true
+            sleep 2
+            echo "    Deleting..."
+            agamemnon_delete_agent "$agent_id" > /dev/null
+            echo "    Deleted (backup created)."
+        else
+            echo "[-] UNMANAGED: ${actual_name} (in Agamemnon but not in YAML — use --prune to remove)"
         fi
-    done < <(echo "$agents_json" | jq -r '.[].name')
+    done < <(get_unmanaged_names "$agents_json" "${yaml_files[@]}")
 }
 
 main "$@"

--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -177,3 +177,31 @@ normalize_path() {
     local p="$1"
     echo "${p/#\~/$HOME}"
 }
+
+# Find agent names that exist in Agamemnon but are not managed by any YAML file.
+# Outputs one unmanaged agent name per line.
+# Usage: get_unmanaged_names <agents_json> <yaml_file>...
+get_unmanaged_names() {
+    local agents_json="$1"
+    shift
+    local yaml_files=("$@")
+
+    # Collect all managed names from YAML files
+    local managed_names=()
+    for yaml_file in "${yaml_files[@]}"; do
+        local n
+        n="$(yq eval '.metadata.name' "$yaml_file")"
+        managed_names+=("$n")
+    done
+
+    # Emit names present in Agamemnon but absent from managed list
+    while IFS= read -r actual_name; do
+        local is_managed=0
+        for mn in "${managed_names[@]}"; do
+            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
+        done
+        if [[ $is_managed -eq 0 ]]; then
+            echo "$actual_name"
+        fi
+    done < <(echo "$agents_json" | jq -r '.[].name')
+}

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -76,7 +76,9 @@ main() {
     # Report unmanaged agents (in Agamemnon but not in YAML)
     echo ""
     echo "Checking for unmanaged agents..."
-    report_unmanaged "$agents_json" "${yaml_files[@]}"
+    while IFS= read -r actual_name; do
+        echo "[-] UNMANAGED ${actual_name} (in Agamemnon but not in desired state — use --prune to remove)"
+    done < <(get_unmanaged_names "$agents_json" "${yaml_files[@]}")
 
     echo ""
     if [[ $has_changes -eq 0 ]]; then
@@ -144,31 +146,6 @@ plan_agent() {
     esac
 
     return 0
-}
-
-report_unmanaged() {
-    local agents_json="$1"
-    shift
-    local yaml_files=("$@")
-
-    # Collect all managed names
-    local managed_names=()
-    for yaml_file in "${yaml_files[@]}"; do
-        local name
-        name="$(yq eval '.metadata.name' "$yaml_file")"
-        managed_names+=("$name")
-    done
-
-    # Find agents not in managed list
-    echo "$agents_json" | jq -r '.[].name' | while IFS= read -r actual_name; do
-        local is_managed=0
-        for mn in "${managed_names[@]}"; do
-            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
-        done
-        if [[ $is_managed -eq 0 ]]; then
-            echo "[-] UNMANAGED ${actual_name} (in Agamemnon but not in desired state — use --prune to remove)"
-        fi
-    done
 }
 
 main "$@"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -39,7 +39,13 @@ main() {
     done
 
     # Unmanaged agents
-    report_unmanaged "$agents_json" "${yaml_files[@]}"
+    while IFS= read -r actual_name; do
+        local actual_status
+        actual_status="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
+            '.[] | select(.name == $n) | .status // "unknown"')"
+        printf "%-22s %-10s %-12s %-12s %s\n" \
+            "${actual_name:0:21}" "-" "-" "$actual_status" "UNMANAGED"
+    done < <(get_unmanaged_names "$agents_json" "${yaml_files[@]}")
 }
 
 status_agent() {
@@ -93,34 +99,6 @@ status_agent() {
 
     printf "%-22s %-10s %-12s %-12s %s\n" \
         "${name:0:21}" "${host:0:9}" "$desired_state" "$actual_status" "$drift_display"
-}
-
-report_unmanaged() {
-    local agents_json="$1"
-    shift
-    local yaml_files=("$@")
-
-    local managed_names=()
-    for yaml_file in "${yaml_files[@]}"; do
-        local n
-        n="$(yq eval '.metadata.name' "$yaml_file")"
-        managed_names+=("$n")
-    done
-
-    while IFS= read -r actual_name; do
-        local is_managed=0
-        for mn in "${managed_names[@]}"; do
-            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
-        done
-
-        if [[ $is_managed -eq 0 ]]; then
-            local actual_status
-            actual_status="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
-                '.[] | select(.name == $n) | .status // "unknown"')"
-            printf "%-22s %-10s %-12s %-12s %s\n" \
-                "${actual_name:0:21}" "-" "-" "$actual_status" "UNMANAGED"
-        fi
-    done < <(echo "$agents_json" | jq -r '.[].name')
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Adds `get_unmanaged_names()` to `scripts/lib/reconcile.sh` — the single source of truth for finding agents present in Agamemnon but absent from YAML
- Removes the duplicated O(n*m) name-matching loops from `plan.sh`, `status.sh`, and `apply.sh`'s `handle_unmanaged()`
- Each script retains its own display logic (plan.sh/apply.sh emit text lines; status.sh emits formatted table rows)

Closes #15

## Test plan

- [ ] `bash -n scripts/lib/reconcile.sh` passes
- [ ] `bash -n scripts/plan.sh` passes
- [ ] `bash -n scripts/status.sh` passes
- [ ] `bash -n scripts/apply.sh` passes
- [ ] Manual: `./scripts/plan.sh` output for unmanaged agents is unchanged
- [ ] Manual: `./scripts/status.sh` UNMANAGED rows still appear correctly
- [ ] Manual: `./scripts/apply.sh --prune` still prunes unmanaged agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)