### PR TITLE
fix(security): use private temp dir with trap cleanup in _agamemnon_curl

### DIFF
--- a/scripts/lib/api.sh
+++ b/scripts/lib/api.sh
@@ -26,15 +26,19 @@ agamemnon_check_connection() {
 _agamemnon_curl() {
     local http_code
     local response
+    local tmpdir
     local tmpfile
-    tmpfile="$(mktemp)"
+    tmpdir="$(mktemp -d)"
+    tmpfile="${tmpdir}/response"
+    # Ensure private temp dir is cleaned up on function return, even if interrupted.
+    trap "rm -rf '${tmpdir}'" RETURN
 
     # Write response body to tmpfile; capture HTTP status code separately.
     http_code="$(curl -s --max-time 10 -w "%{http_code}" -o "$tmpfile" "$@")"
     local curl_exit=$?
 
     response="$(cat "$tmpfile")"
-    rm -f "$tmpfile"
+    # tmpdir cleaned up by trap on RETURN
 
     if [[ $curl_exit -ne 0 ]]; then
         echo "ERROR: curl failed (exit ${curl_exit}) for: $*" >&2


### PR DESCRIPTION
## Summary

- Replace `mktemp` (single file) with `mktemp -d` (private directory, mode 0700) so the response file is not discoverable by other processes or the Promtail container's `/tmp:ro` mount
- Add `trap "rm -rf '${tmpdir}'" RETURN` so the directory is always removed — even on early exit via error path or process kill — eliminating the residual-file window described in the issue

## Test plan

- [ ] Verify `_agamemnon_curl` still returns correct JSON on success
- [ ] Verify error path (non-2xx HTTP, curl failure) still prints to stderr and returns non-zero
- [ ] Confirm no temp files remain in `/tmp` after a successful or failed call
- [ ] Confirm no temp files remain after a `kill -9` mid-flight (manual test)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)