### PR TITLE
docs(naming): clarify filename vs metadata.name; add fleet ref CI validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'agents/**'
       - 'fleets/**'
+      - 'tests/**'
 
 jobs:
   validate:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,16 +32,16 @@ Myrmidons is the source of truth for *desired* agent state. Agent definitions li
 
 ## Agent definition format
 
-Every agent is a YAML file in `agents/<host>/<name>.yaml`:
+Every agent is a YAML file in `agents/<host>/<label>.yaml` where `<label>` is the lowercased `spec.label`:
 
 ```yaml
 apiVersion: myrmidons/v1
 kind: Agent
 metadata:
-  name: my-agent-name
+  name: my-agent-name   # Agamemnon API name / tmux session name — NOT the filename
   host: hermes
 spec:
-  label: DisplayName
+  label: DisplayName    # Human-readable name; filename = lowercase(label) + ".yaml"
   program: claude-code
   model: null
   workingDirectory: /home/mvillmow/MyProject
@@ -54,6 +54,20 @@ spec:
     type: local
   desiredState: active
 ```
+
+### Naming convention
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| **Filename** | `aindrea.yaml` | Derived from `spec.label` (lowercased). Used by fleet `ref:` entries. |
+| **`metadata.name`** | `odyssey-mainline-analysis` | Agamemnon API identifier / tmux session name. Used by scripts and the REST API. |
+| **`spec.label`** | `Aindrea` | Display name shown in the Agamemnon UI. |
+
+**Fleet `ref:` entries resolve by filename stem**, not by `metadata.name`:
+- `ref: hermes/aindrea` → `agents/hermes/aindrea.yaml` ✓
+- `ref: hermes/odyssey-mainline-analysis` → `agents/hermes/odyssey-mainline-analysis.yaml` ✗ (file does not exist)
+
+This design is intentional: filenames are label-derived for human readability; `metadata.name` carries the Agamemnon backend identity.
 
 ## Scripts
 
@@ -72,11 +86,12 @@ spec:
 
 ## Adding a new agent
 
-1. Copy a template: `cp agents/_templates/claude-default.yaml agents/hermes/myagent.yaml`
-2. Fill in all required fields
-3. Run `./scripts/plan.sh` to preview the change
-4. Run `./scripts/apply.sh` to create + start the agent
-5. Commit the YAML file
+1. Choose a label (e.g. `MyAgent`) — the filename will be `agents/hermes/myagent.yaml` (lowercase label)
+2. Copy a template: `cp agents/_templates/claude-default.yaml agents/hermes/myagent.yaml`
+3. Fill in all required fields; set `spec.label: MyAgent` and `metadata.name` to the Agamemnon agent name
+4. Run `./scripts/plan.sh` to preview the change
+5. Run `./scripts/apply.sh` to create + start the agent
+6. Commit the YAML file
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ just validate
 apiVersion: myrmidons/v1
 kind: Agent
 metadata:
-  name: my-agent           # Unique per host — matches tmux session name
+  name: my-agent           # Agamemnon API name / tmux session name — NOT the filename
   host: hermes
 spec:
-  label: My Agent          # Display name in Agamemnon UI
+  label: My Agent          # Display name; filename = lowercase(label) + ".yaml"
   program: claude-code     # claude-code | aider | codex | goose | cline | opencode | none
   model: null              # null = Agamemnon default; or "claude-sonnet-4-6"
   workingDirectory: /home/mvillmow/MyProject
@@ -71,11 +71,25 @@ spec:
   desiredState: active     # active | hibernated
 ```
 
+### Naming convention
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| **Filename** | `aindrea.yaml` | Derived from `spec.label` (lowercased). Used by fleet `ref:` entries. |
+| **`metadata.name`** | `odyssey-mainline-analysis` | Agamemnon API identifier / tmux session name. Used by scripts and the REST API. |
+| **`spec.label`** | `Aindrea` | Display name shown in the Agamemnon UI. |
+
+**Fleet `ref:` entries resolve by filename stem**, not by `metadata.name`:
+```
+ref: hermes/aindrea   →   agents/hermes/aindrea.yaml   ✓
+```
+
 ## Adding an agent
 
 ```bash
+# Filename = lowercase(spec.label); e.g. label "MyAgent" → my-agent.yaml
 cp agents/_templates/claude-default.yaml agents/hermes/my-agent.yaml
-# Edit: name, label, workingDirectory, taskDescription, tags
+# Edit: metadata.name (Agamemnon name), spec.label, workingDirectory, taskDescription, tags
 just plan hermes     # preview
 just apply hermes    # create + wake
 git add agents/hermes/my-agent.yaml && git commit -m "add my-agent"

--- a/tests/validate-fleet-refs.sh
+++ b/tests/validate-fleet-refs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/validate-fleet-refs.sh — CI: validate fleet ref referential integrity
+#
+# Checks that every `ref: <host>/<name>` entry in fleet YAML files resolves
+# to an existing `agents/<host>/<name>.yaml` file.
+#
+# Fleet refs resolve by FILENAME STEM (lowercased spec.label), not by
+# metadata.name. This script enforces that no fleet file references a
+# non-existent agent.
+#
+# Usage:
+#   ./tests/validate-fleet-refs.sh
+#
+# Exit codes:
+#   0 = all refs resolve
+#   1 = one or more dangling refs found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ERRORS=0
+CHECKED=0
+
+if ! command -v yq &>/dev/null; then
+    echo "ERROR: yq is required for fleet ref validation." >&2
+    echo "  Install: curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq" >&2
+    exit 1
+fi
+
+echo "Validating fleet ref referential integrity..."
+echo ""
+
+# Iterate over all fleet YAML files
+while IFS= read -r -d '' fleet_file; do
+    kind="$(yq eval '.kind // ""' "$fleet_file")"
+    [[ "$kind" != "Fleet" ]] && continue
+
+    fleet_name="$(yq eval '.metadata.name // ""' "$fleet_file")"
+    fleet_rel="${fleet_file#"${REPO_ROOT}/"}"
+
+    # Extract all ref values (pattern: <host>/<name>)
+    mapfile -t refs < <(yq eval '.spec.agents[].ref // ""' "$fleet_file" 2>/dev/null | grep -v '^$' || true)
+
+    if [[ ${#refs[@]} -eq 0 ]]; then
+        echo "  ${fleet_rel} (${fleet_name}): no refs — skipping"
+        continue
+    fi
+
+    echo "  ${fleet_rel} (${fleet_name}):"
+    for ref in "${refs[@]}"; do
+        CHECKED=$((CHECKED + 1))
+        # ref format: <host>/<name>  →  agents/<host>/<name>.yaml
+        agent_path="${REPO_ROOT}/agents/${ref}.yaml"
+        printf "    ref: %-40s " "${ref}"
+        if [[ -f "$agent_path" ]]; then
+            echo "ok"
+        else
+            echo "FAIL (agents/${ref}.yaml not found)"
+            ERRORS=$((ERRORS + 1))
+        fi
+    done
+    echo ""
+
+done < <(find "${REPO_ROOT}/fleets" -name "*.yaml" -print0 2>/dev/null)
+
+echo "Checked: ${CHECKED} refs, Errors: ${ERRORS}"
+
+if [[ $ERRORS -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -110,4 +110,7 @@ echo "Checked: ${CHECKED} files, Errors: ${ERRORS}"
 if [[ $ERRORS -gt 0 ]]; then
     exit 1
 fi
-exit 0
+
+# Also validate fleet ref referential integrity
+echo ""
+"${SCRIPT_DIR}/validate-fleet-refs.sh"


### PR DESCRIPTION
## Summary

Fixes the ambiguity reported in #11 about whether fleet `ref:` entries resolve by filename or `metadata.name`.

- **Document the naming convention** in both CLAUDE.md and README.md: filenames are derived from `spec.label` (lowercased), while `metadata.name` is the Agamemnon API / tmux session identifier. Fleet `ref:` entries resolve by **filename stem**.
- **Fix misleading comment** in README.md: `metadata.name` comment previously said "matches tmux session name", implying it also matched the filename — now clarified.
- **Add `tests/validate-fleet-refs.sh`**: new CI script that parses all fleet YAML files and verifies every `ref: <host>/<name>` entry resolves to an existing `agents/<host>/<name>.yaml`. Exits 1 on any dangling ref.
- **Chain new script into `tests/validate-schemas.sh`** so `just validate` catches both schema errors and dangling refs in one pass.
- **Extend `.github/workflows/validate.yml`** path triggers to include `tests/**`.

No files were renamed — the label-based filename convention is intentional and preserved.

## Test plan

- [x] Manually verified all 15 existing fleet refs resolve correctly (grep check in PR)
- [x] Both shell scripts pass `bash -n` syntax check
- [x] `tests/validate-fleet-refs.sh` exits 0 when all refs are valid
- [x] `tests/validate-fleet-refs.sh` exits 1 when a dangling ref is introduced (manual test with `echo "    - ref: hermes/nonexistent" >> fleets/production.yaml`)
- [x] CI (`validate.yml`) will run `validate-schemas.sh` which chains `validate-fleet-refs.sh`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)