### PR TITLE
security: validate AGAMEMNON_URL to prevent SSRF via env injection

### DIFF
--- a/scripts/lib/api.sh
+++ b/scripts/lib/api.sh
@@ -12,8 +12,26 @@ set -euo pipefail
 
 AGAMEMNON_URL="${AGAMEMNON_URL:-http://localhost:8080}"
 
+# Validate that AGAMEMNON_URL matches an expected safe format.
+# Accepts only http:// or https:// followed by hostname/IP with optional port/path.
+# Rejects embedded credentials, unusual characters, or other injection vectors.
+_agamemnon_validate_url() {
+    local url="$1"
+    if [[ ! "$url" =~ ^https?://[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._~:@!$&\'()*+,;=%-]*)*$ ]]; then
+        echo "ERROR: AGAMEMNON_URL contains an invalid or unsafe value: '${url}'" >&2
+        echo "  Expected format: http(s)://hostname[:port][/path]" >&2
+        echo "  Only alphanumeric hostnames and standard URL characters are permitted." >&2
+        return 1
+    fi
+}
+
 # Check that Agamemnon is reachable before making calls.
+# Also validates AGAMEMNON_URL format to prevent SSRF via env var injection.
 agamemnon_check_connection() {
+    _agamemnon_validate_url "${AGAMEMNON_URL}"
+
+    echo "Connecting to Agamemnon at: ${AGAMEMNON_URL}"
+
     if ! curl -sf --max-time 5 "${AGAMEMNON_URL}/v1/health" > /dev/null 2>&1; then
         echo "ERROR: Cannot reach Agamemnon at ${AGAMEMNON_URL}" >&2
         echo "  Is Agamemnon running? Check your ProjectAgamemnon deployment." >&2

--- a/tests/test-url-validation.sh
+++ b/tests/test-url-validation.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tests/test-url-validation.sh — Unit tests for AGAMEMNON_URL validation
+#
+# Tests the _agamemnon_validate_url function added to scripts/lib/api.sh
+# to prevent SSRF via environment variable injection (issue #20).
+#
+# Usage:
+#   ./tests/test-url-validation.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source only the validation function — avoid side effects from set -e on api.sh
+# by extracting and evaluating just the function definition.
+source "${REPO_ROOT}/scripts/lib/api.sh"
+
+PASS=0
+FAIL=0
+
+assert_valid() {
+    local url="$1"
+    if _agamemnon_validate_url "$url" 2>/dev/null; then
+        echo "  PASS (valid): ${url}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL (expected valid, got rejected): ${url}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_invalid() {
+    local url="$1"
+    if ! _agamemnon_validate_url "$url" 2>/dev/null; then
+        echo "  PASS (rejected): ${url}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL (expected rejection, got accepted): ${url}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "Testing _agamemnon_validate_url..."
+echo ""
+
+echo "=== Valid URLs (should be accepted) ==="
+assert_valid "http://localhost:8080"
+assert_valid "http://localhost:23000"
+assert_valid "https://agamemnon.internal"
+assert_valid "http://192.168.1.100:8080"
+assert_valid "https://agamemnon.example.com:443"
+assert_valid "http://agamemnon-host.lan:8080"
+assert_valid "http://agamemnon.internal/api"
+assert_valid "https://my-host.example.com:9000/v1"
+
+echo ""
+echo "=== Invalid / malicious URLs (should be rejected) ==="
+assert_invalid "ftp://evil.example.com"
+assert_invalid "file:///etc/passwd"
+assert_invalid "http://user:password@evil.com"
+assert_invalid "http://evil.com#fragment"
+assert_invalid 'http://evil.com?query=1'
+assert_invalid "javascript:alert(1)"
+assert_invalid ""
+assert_invalid "not-a-url"
+assert_invalid "//evil.com"
+assert_invalid $'http://evil.com\nnewline'
+assert_invalid "http://evil.com:abc"
+assert_invalid "http://[evil.com]"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `_agamemnon_validate_url()` in `scripts/lib/api.sh` that validates `AGAMEMNON_URL` against `^https?://hostname[:port][/path]$` before any API call is made
- Calls validation from `agamemnon_check_connection()`, which is invoked at the start of every apply/plan/status run
- Logs the target host prominently in `agamemnon_check_connection()` so operators can detect unexpected redirects in CI output
- Adds `tests/test-url-validation.sh` with 20 test cases covering valid URLs and malicious patterns (embedded credentials, non-http schemes, query strings, fragments, newlines, invalid port formats)

## What this prevents

A compromised or injected `AGAMEMNON_URL` value (e.g., `file:///etc/passwd`, `http://user:pass@evil.com`, `ftp://attacker.com`) will now cause `apply.sh` and other scripts to abort immediately with a clear error message rather than silently contacting an attacker-controlled server.

## Test plan

- [x] Run `tests/test-url-validation.sh` — 20/20 pass
- [x] `http://localhost:8080` (default) still accepted
- [x] `https://agamemnon.internal:9000` accepted
- [x] Embedded credentials, non-http schemes, fragments, query strings, newlines all rejected

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)