### PR TITLE
docs(changelog): add CHANGELOG.md with project history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-04-05
+
+### Added
+- Multi-repo Myrmidon agents and fleet config (issue #8)
+
+## [0.2.0] - 2026-04-03
+
+### Added
+- LICENSE (Apache 2.0)
+- CONTRIBUTING.md with coding standards and PR process
+- SECURITY.md with vulnerability disclosure policy
+- CODE_OF_CONDUCT.md
+- C++20 hello-world pull consumer worker
+- Hello-world Myrmidon pull-based worker
+- Hephaestus@ProjectHephaestus plugin
+
+### Changed
+- CI apply workflow switched from self-hosted to ubuntu-latest
+
+### Removed
+- Python hello-world files (replaced by C++ implementation)
+- `aim_*` backward-compatibility alias functions
+
+### Fixed
+- stdout unbuffering for container logging
+
+## [0.1.0] - 2026-03-28
+
+### Added
+- Migrated from ai-maestro to ProjectAgamemnon (ADR-006)
+- Initial repo scaffolding: justfile, pixi.toml, README, scripts
+- `.gitignore` covering ProjectMnemosyne/ and build/
+
+[Unreleased]: https://github.com/HomericIntelligence/Myrmidons/compare/HEAD...HEAD
+[0.3.0]: https://github.com/HomericIntelligence/Myrmidons/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/HomericIntelligence/Myrmidons/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/HomericIntelligence/Myrmidons/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

- Creates `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com) format
- Populates three historical release sections derived from git log (v0.1.0, v0.2.0, v0.3.0)
- Includes `## [Unreleased]` section at top per convention

The other three files called out in issue #22 (LICENSE, CONTRIBUTING.md, SECURITY.md) already existed as of commit `f8f41f5`. This PR addresses the sole remaining gap.

Closes #22

## Test plan

- [x] File exists at repo root: `ls CHANGELOG.md`
- [x] File contains `## [Unreleased]` section at top
- [x] File contains at least one historical release section populated from git log
- [x] Issue #22 checklist: LICENSE ✓, CONTRIBUTING.md ✓, SECURITY.md ✓, CHANGELOG.md ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)