### PR TITLE
chore(github): add issue/PR templates, labels, and milestones

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_addition.md
+++ b/.github/ISSUE_TEMPLATE/agent_addition.md
@@ -1,0 +1,17 @@
+---
+name: Agent Addition Request
+about: Request provisioning of a new AI agent
+labels: "kind: agent-addition, status: needs-triage"
+---
+
+## Agent Details
+- **Name:**
+- **Host:**
+- **Program:** (claude-code / aider / other)
+- **Model:**
+- **Working Directory:**
+- **Purpose / Task Description:**
+- **Tags:**
+- **Owner:**
+
+## Justification

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: Something is broken or behaving incorrectly
+labels: "kind: bug, status: needs-triage"
+---
+
+## Description
+<!-- Clear description of the bug -->
+
+## Steps to Reproduce
+1.
+2.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+- Agamemnon version:
+- Host:
+- OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+labels: "kind: feature, status: needs-triage"
+---
+
+## Problem Statement
+
+## Proposed Solution
+
+## Alternatives Considered
+
+## Acceptance Criteria
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+<!-- What does this PR do? Link the issue: Closes #N -->
+
+## Checklist
+- [ ] `./scripts/plan.sh` output reviewed — no unintended changes
+- [ ] YAML schema validation passes (`./scripts/validate.sh` or CI)
+- [ ] Agent tested on target host (if agent YAML changed)
+- [ ] Commit messages follow Conventional Commits format
+- [ ] PR title follows `type(scope): description` format
+- [ ] Documentation updated if behavior changed


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/bug_report.md` — bug report template with description, repro steps, environment
- Add `.github/ISSUE_TEMPLATE/feature_request.md` — feature request with problem/solution/acceptance criteria
- Add `.github/ISSUE_TEMPLATE/agent_addition.md` — agent provisioning request with required agent fields
- Add `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist aligned to `validate.yml` CI gate
- Created 10 GitHub labels: `kind:` (bug, feature, agent-addition, audit) and `severity:` (critical, major, minor, trivial) and `status:` (blocked, needs-triage)
- Created 2 milestones: **Phase 1 — Bootstrap** and **Phase 2 — Fleet Support**
- Applied `status: needs-triage` label to all 20+ existing open issues

Closes #32

## Test plan
- [ ] Open a new issue in the GitHub UI — verify template selector appears with 3 options
- [ ] Open a new PR — verify checklist template renders automatically
- [ ] Run `gh label list` — confirm all 10 new labels exist
- [ ] Run `gh milestone list` — confirm Phase 1 and Phase 2 milestones exist
- [ ] CI `validate.yml` passes (templates are not agent YAML manifests, so schema validation skips them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)