### PR TITLE
feat: add formal JSON Schema validation for agent and fleet YAML

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,9 @@ jobs:
           chmod +x /usr/local/bin/yq
           yq --version
 
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
       - name: Validate all YAML files
         run: |
           chmod +x tests/validate-schemas.sh

--- a/agents/_templates/aider-default.yaml
+++ b/agents/_templates/aider-default.yaml
@@ -1,5 +1,6 @@
 # Template: Aider agent (Docker deployment)
 # Copy to agents/<host>/<name>.yaml and fill in the metadata fields.
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
 
 apiVersion: myrmidons/v1
 kind: Agent

--- a/agents/_templates/claude-default.yaml
+++ b/agents/_templates/claude-default.yaml
@@ -1,5 +1,6 @@
 # Template: Claude Code agent (local deployment)
 # Copy to agents/<host>/<name>.yaml and fill in the metadata fields.
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
 
 apiVersion: myrmidons/v1
 kind: Agent

--- a/agents/_templates/worker-default.yaml
+++ b/agents/_templates/worker-default.yaml
@@ -1,5 +1,6 @@
 # Template: Shell Worker agent (Docker deployment, no AI tool)
 # Copy to agents/<host>/<name>.yaml and fill in the metadata fields.
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
 
 apiVersion: myrmidons/v1
 kind: Agent

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,13 +4,17 @@
 # Installs to: .git/hooks/pre-commit
 # Setup: cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 #
-# Checks:
-#   1. All staged agent/*.yaml files are valid YAML
-#   2. Required fields (apiVersion, kind, metadata.name, metadata.host, spec.program)
-#   3. desiredState is "active" or "hibernated"
-#   4. apiVersion is "myrmidons/v1"
+# Uses check-jsonschema with schemas/agent-v1.schema.json and fleet-v1.schema.json
+# as the single source of truth for field definitions, types, and enum values.
 
 set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Support both .git/hooks/ (installed) and hooks/ (source)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+AGENT_SCHEMA="${REPO_ROOT}/schemas/agent-v1.schema.json"
+FLEET_SCHEMA="${REPO_ROOT}/schemas/fleet-v1.schema.json"
 
 ERRORS=0
 
@@ -21,10 +25,16 @@ if [[ -z "$STAGED_YAMLS" ]]; then
     exit 0
 fi
 
+if ! command -v check-jsonschema &>/dev/null; then
+    echo "ERROR: check-jsonschema not found — cannot validate YAML before commit" >&2
+    echo "  Install via pixi: pixi install" >&2
+    echo "  Or via pip: pip install check-jsonschema" >&2
+    exit 1
+fi
+
 if ! command -v yq &>/dev/null; then
     echo "ERROR: yq not found — cannot validate YAML before commit" >&2
     echo "  Install: https://github.com/mikefarah/yq" >&2
-    echo "  Or run: just install-hooks  (after installing yq)" >&2
     exit 1
 fi
 
@@ -32,68 +42,42 @@ echo "Validating staged YAML files..."
 
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue
+    [[ "$file" == *"/_templates/"* ]] && continue
 
     echo -n "  ${file}: "
 
     # Check basic YAML validity
-    if ! yq eval '.' "$file" > /dev/null 2>&1; then
+    if ! yq eval '.' "${REPO_ROOT}/${file}" > /dev/null 2>&1; then
         echo "FAIL (invalid YAML)"
         ERRORS=$((ERRORS + 1))
         continue
     fi
 
-    # Check apiVersion
-    api_version="$(yq eval '.apiVersion // ""' "$file")"
-    if [[ "$api_version" != "myrmidons/v1" ]]; then
-        echo "FAIL (apiVersion must be 'myrmidons/v1', got '${api_version}')"
-        ERRORS=$((ERRORS + 1))
-        continue
-    fi
+    kind="$(yq eval '.kind // ""' "${REPO_ROOT}/${file}")"
 
-    # Check kind
-    kind="$(yq eval '.kind // ""' "$file")"
-    if [[ "$kind" != "Agent" && "$kind" != "Fleet" ]]; then
-        echo "FAIL (kind must be 'Agent' or 'Fleet', got '${kind}')"
-        ERRORS=$((ERRORS + 1))
-        continue
-    fi
+    case "$kind" in
+        Agent)
+            schema="$AGENT_SCHEMA"
+            ;;
+        Fleet)
+            schema="$FLEET_SCHEMA"
+            ;;
+        *)
+            echo "FAIL (unknown kind '${kind}'; expected 'Agent' or 'Fleet')"
+            ERRORS=$((ERRORS + 1))
+            continue
+            ;;
+    esac
 
-    # Skip further validation for Fleet kind
-    if [[ "$kind" == "Fleet" ]]; then
-        echo "ok (Fleet)"
-        continue
-    fi
-
-    # Agent-specific validation
-    name="$(yq eval '.metadata.name // ""' "$file")"
-    host="$(yq eval '.metadata.host // ""' "$file")"
-    program="$(yq eval '.spec.program // ""' "$file")"
-    desired_state="$(yq eval '.spec.desiredState // ""' "$file")"
-
-    local_errors=()
-
-    [[ -z "$name" ]] && local_errors+=("metadata.name is required")
-    [[ -z "$host" ]] && local_errors+=("metadata.host is required")
-    [[ -z "$program" ]] && local_errors+=("spec.program is required")
-
-    if [[ -n "$desired_state" && "$desired_state" != "active" && "$desired_state" != "hibernated" ]]; then
-        local_errors+=("spec.desiredState must be 'active' or 'hibernated', got '${desired_state}'")
-    fi
-
-    # Validate deployment type
-    deploy_type="$(yq eval '.spec.deployment.type // "local"' "$file")"
-    if [[ "$deploy_type" != "local" && "$deploy_type" != "docker" ]]; then
-        local_errors+=("spec.deployment.type must be 'local' or 'docker', got '${deploy_type}'")
-    fi
-
-    if [[ ${#local_errors[@]} -gt 0 ]]; then
-        echo "FAIL"
-        for err in "${local_errors[@]}"; do
-            echo "    - ${err}"
-        done
-        ERRORS=$((ERRORS + 1))
-    else
+    if error_output="$(yq eval -o=json '.' "${REPO_ROOT}/${file}" 2>&1 | \
+            check-jsonschema --schemafile "$schema" /dev/stdin 2>&1)"; then
         echo "ok"
+    else
+        echo "FAIL"
+        while IFS= read -r line; do
+            echo "    ${line}"
+        done <<< "$error_output"
+        ERRORS=$((ERRORS + 1))
     fi
 done <<< "$STAGED_YAMLS"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,9 +6,10 @@ channels = ["conda-forge"]
 platforms = ["linux-64"]
 
 [dependencies]
-just = ">=1.13"
-yq   = ">=4.0"
-jq   = ">=1.6"
+just             = ">=1.13"
+yq               = ">=4.0"
+jq               = ">=1.6"
+check-jsonschema = ">=0.28"
 
 [tasks]
 status   = "just status"

--- a/schemas/agent-v1.schema.json
+++ b/schemas/agent-v1.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HomericIntelligence/Myrmidons/schemas/agent-v1.schema.json",
+  "title": "Myrmidons Agent v1",
+  "description": "Schema for agent YAML definitions in the Myrmidons GitOps system",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "myrmidons/v1",
+      "description": "Must be 'myrmidons/v1'"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Agent",
+      "description": "Must be 'Agent'"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "host"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique per host; used as the tmux session name in Agamemnon"
+        },
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Must match the hostId registered in Agamemnon"
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "required": ["program", "workingDirectory"],
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Display name shown in the Agamemnon UI"
+        },
+        "program": {
+          "type": "string",
+          "enum": ["claude-code", "aider", "none"],
+          "description": "The AI tool (or 'none' for shell workers) to run in the agent"
+        },
+        "model": {
+          "type": ["string", "null"],
+          "description": "Override model; null means use the Agamemnon default"
+        },
+        "workingDirectory": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path to the working directory for the agent process"
+        },
+        "programArgs": {
+          "type": "string",
+          "description": "Extra CLI flags passed to the program, e.g. '--model claude-opus-4-6'"
+        },
+        "taskDescription": {
+          "type": "string",
+          "description": "Human-readable description of what this agent does"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Free-form labels for grouping and filtering agents"
+        },
+        "owner": {
+          "type": "string",
+          "description": "Username of the agent owner"
+        },
+        "role": {
+          "type": "string",
+          "enum": ["member", "admin"],
+          "description": "Agent role in Agamemnon: 'member' or 'admin'"
+        },
+        "deployment": {
+          "type": "object",
+          "required": ["type"],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["local", "docker"],
+              "description": "'local' runs in a tmux session on the host; 'docker' runs in a container"
+            },
+            "docker": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "image": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Container image name from the AchaeanFleet repo"
+                },
+                "cpus": {
+                  "type": "number",
+                  "exclusiveMinimum": 0,
+                  "description": "CPU cores allocated to the container"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(\\.[0-9]+)?[gGmM]$",
+                  "description": "Memory limit, e.g. '4g', '512m'"
+                }
+              },
+              "description": "Docker-specific settings; required when deployment.type is 'docker'"
+            }
+          }
+        },
+        "desiredState": {
+          "type": "string",
+          "enum": ["active", "hibernated"],
+          "description": "'active' wakes the agent; 'hibernated' suspends it"
+        }
+      }
+    }
+  }
+}

--- a/schemas/fleet-v1.schema.json
+++ b/schemas/fleet-v1.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HomericIntelligence/Myrmidons/schemas/fleet-v1.schema.json",
+  "title": "Myrmidons Fleet v1",
+  "description": "Schema for fleet YAML definitions in the Myrmidons GitOps system",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "myrmidons/v1",
+      "description": "Must be 'myrmidons/v1'"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Fleet",
+      "description": "Must be 'Fleet'"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique fleet identifier"
+        },
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Default host for agents in this fleet"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the fleet's purpose"
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "required": ["agents"],
+      "additionalProperties": false,
+      "properties": {
+        "agents": {
+          "type": "array",
+          "minItems": 1,
+          "description": "List of agents in this fleet; each may be a ref or an inline definition",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["ref"],
+                "additionalProperties": false,
+                "description": "Reference to an existing agent YAML file",
+                "properties": {
+                  "ref": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9_-]+/[a-z0-9_-]+$",
+                    "description": "Agent reference in the form 'host/name', e.g. 'hermes/aindrea'"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["name", "program", "workingDirectory"],
+                "additionalProperties": false,
+                "description": "Inline agent definition embedded directly in the fleet",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Agent name; must be unique within the fleet"
+                  },
+                  "program": {
+                    "type": "string",
+                    "enum": ["claude-code", "aider", "none"],
+                    "description": "The AI tool (or 'none' for shell workers) to run"
+                  },
+                  "model": {
+                    "type": ["string", "null"],
+                    "description": "Override model; null means use the Agamemnon default"
+                  },
+                  "workingDirectory": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Absolute path to the working directory for the agent process"
+                  },
+                  "programArgs": {
+                    "type": "string",
+                    "description": "Extra CLI flags passed to the program"
+                  },
+                  "taskDescription": {
+                    "type": "string",
+                    "description": "Human-readable description of what this agent does"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Free-form labels for grouping and filtering"
+                  },
+                  "deployment": {
+                    "type": "object",
+                    "required": ["type"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": ["local", "docker"],
+                        "description": "'local' runs in tmux; 'docker' runs in a container"
+                      },
+                      "docker": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "image": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Container image name"
+                          },
+                          "cpus": {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "description": "CPU cores allocated to the container"
+                          },
+                          "memory": {
+                            "type": "string",
+                            "pattern": "^[0-9]+(\\.[0-9]+)?[gGmM]$",
+                            "description": "Memory limit, e.g. '4g', '512m'"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "desiredState": {
+                    "type": "string",
+                    "enum": ["active", "hibernated"],
+                    "description": "'active' wakes the agent; 'hibernated' suspends it"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# tests/validate-schemas.sh — CI: validate all agent YAML files
+# tests/validate-schemas.sh — CI: validate all agent and fleet YAML files
+#
+# Uses check-jsonschema (schemas/agent-v1.schema.json and fleet-v1.schema.json)
+# as the single source of truth for field definitions, types, and enum values.
 #
 # Used by .github/workflows/validate.yml on every PR.
-# Runs the same checks as the pre-commit hook but against ALL YAML files,
-# not just staged ones.
 #
 # Usage:
 #   ./tests/validate-schemas.sh
@@ -17,12 +18,21 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+AGENT_SCHEMA="${REPO_ROOT}/schemas/agent-v1.schema.json"
+FLEET_SCHEMA="${REPO_ROOT}/schemas/fleet-v1.schema.json"
+
 ERRORS=0
 CHECKED=0
 
+if ! command -v check-jsonschema &>/dev/null; then
+    echo "ERROR: check-jsonschema is required for schema validation." >&2
+    echo "  Install via pixi: pixi install" >&2
+    echo "  Or via pip: pip install check-jsonschema" >&2
+    exit 1
+fi
+
 if ! command -v yq &>/dev/null; then
-    echo "ERROR: yq is required for schema validation." >&2
-    echo "  Install: curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq" >&2
+    echo "ERROR: yq is required for YAML parsing." >&2
     exit 1
 fi
 
@@ -34,7 +44,8 @@ while IFS= read -r -d '' file; do
     [[ "$file" == *"/_templates/"* ]] && continue
 
     CHECKED=$((CHECKED + 1))
-    echo -n "  ${file#"${REPO_ROOT}/"}: "
+    rel="${file#"${REPO_ROOT}/"}"
+    echo -n "  ${rel}: "
 
     # YAML syntax check
     if ! yq eval '.' "$file" > /dev/null 2>&1; then
@@ -43,62 +54,34 @@ while IFS= read -r -d '' file; do
         continue
     fi
 
-    api_version="$(yq eval '.apiVersion // ""' "$file")"
     kind="$(yq eval '.kind // ""' "$file")"
 
-    # apiVersion check
-    if [[ "$api_version" != "myrmidons/v1" ]]; then
-        echo "FAIL (expected apiVersion=myrmidons/v1, got '${api_version}')"
-        ERRORS=$((ERRORS + 1))
-        continue
-    fi
+    case "$kind" in
+        Agent)
+            schema="$AGENT_SCHEMA"
+            ;;
+        Fleet)
+            schema="$FLEET_SCHEMA"
+            ;;
+        *)
+            echo "FAIL (unknown kind '${kind}'; expected 'Agent' or 'Fleet')"
+            ERRORS=$((ERRORS + 1))
+            continue
+            ;;
+    esac
 
-    # kind check
-    if [[ "$kind" != "Agent" && "$kind" != "Fleet" ]]; then
-        echo "FAIL (expected kind=Agent or Fleet, got '${kind}')"
-        ERRORS=$((ERRORS + 1))
-        continue
-    fi
-
-    if [[ "$kind" == "Fleet" ]]; then
-        fleet_name="$(yq eval '.metadata.name // ""' "$file")"
-        [[ -z "$fleet_name" ]] && echo "FAIL (metadata.name required in Fleet)" && ERRORS=$((ERRORS+1)) && continue
-        echo "ok (Fleet: ${fleet_name})"
-        continue
-    fi
-
-    # Agent validation
-    field_errors=()
-
-    name="$(yq eval '.metadata.name // ""' "$file")"
-    host="$(yq eval '.metadata.host // ""' "$file")"
-    program="$(yq eval '.spec.program // ""' "$file")"
-    workdir="$(yq eval '.spec.workingDirectory // ""' "$file")"
-    desired_state="$(yq eval '.spec.desiredState // ""' "$file")"
-    deploy_type="$(yq eval '.spec.deployment.type // "local"' "$file")"
-
-    [[ -z "$name" ]] && field_errors+=("metadata.name is required")
-    [[ -z "$host" ]] && field_errors+=("metadata.host is required")
-    [[ -z "$program" ]] && field_errors+=("spec.program is required")
-    [[ -z "$workdir" ]] && field_errors+=("spec.workingDirectory is required")
-
-    if [[ -n "$desired_state" ]]; then
-        [[ "$desired_state" != "active" && "$desired_state" != "hibernated" ]] && \
-            field_errors+=("spec.desiredState must be 'active' or 'hibernated'")
-    fi
-
-    if [[ "$deploy_type" != "local" && "$deploy_type" != "docker" ]]; then
-        field_errors+=("spec.deployment.type must be 'local' or 'docker'")
-    fi
-
-    if [[ ${#field_errors[@]} -gt 0 ]]; then
-        echo "FAIL"
-        for err in "${field_errors[@]}"; do
-            echo "      - ${err}"
-        done
-        ERRORS=$((ERRORS + 1))
+    # check-jsonschema requires JSON; convert YAML on the fly
+    if error_output="$(yq eval -o=json '.' "$file" 2>&1 | \
+            check-jsonschema --schemafile "$schema" /dev/stdin 2>&1)"; then
+        name="$(yq eval '.metadata.name // ""' "$file")"
+        echo "ok (${kind}: ${name})"
     else
-        echo "ok (Agent: ${name})"
+        echo "FAIL"
+        # Indent error output for readability
+        while IFS= read -r line; do
+            echo "      ${line}"
+        done <<< "$error_output"
+        ERRORS=$((ERRORS + 1))
     fi
 
 done < <(find "${REPO_ROOT}/agents" "${REPO_ROOT}/fleets" \


### PR DESCRIPTION
## Summary

- Adds `schemas/agent-v1.schema.json` and `schemas/fleet-v1.schema.json` as the single source of truth for field definitions, types, and allowed enum values
- Rewrites `tests/validate-schemas.sh` to use `check-jsonschema` instead of ad-hoc bash field checks — eliminates the duplication and divergence between the CI script and pre-commit hook
- Updates `hooks/pre-commit` to use the same schema validator, so pre-commit and CI are now consistent
- Adds `check-jsonschema >=0.28` to `pixi.toml` and a `pip install check-jsonschema` step to `.github/workflows/validate.yml`
- Adds `yaml-language-server: $schema=...` comments to all three agent templates, enabling VS Code YAML extension autocompletion

## What's validated by the new schemas

**Agent schema** enforces:
- `apiVersion: myrmidons/v1` (const)
- `kind: Agent` (const)
- Required: `metadata.name`, `metadata.host`, `spec.program`, `spec.workingDirectory`
- `spec.program` enum: `claude-code`, `aider`, `none`
- `spec.desiredState` enum: `active`, `hibernated`
- `spec.deployment.type` enum: `local`, `docker`
- `spec.role` enum: `member`, `admin`
- `additionalProperties: false` on all objects (catches typos)

**Fleet schema** enforces:
- `metadata.name` required
- Each agent entry is either a `ref` (string `host/name`) or a valid inline agent definition
- Same enum and type constraints as the agent schema for inline agents

## Test plan

- [x] All 19 existing agent and fleet YAML files pass (`Checked: 19 files, Errors: 0`)
- [x] Smoke-tested rejection of: missing required field, invalid `program` enum, invalid `desiredState` enum — all caught with clear errors
- [x] Templates excluded from validation (as before)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)