### PR TITLE
feat: add shellcheck CI and fix existing warnings (#45)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+name: Lint and Test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        env:
+          SHELLCHECK_VERSION: "v0.10.0"
+        run: |
+          curl -fsSL \
+            "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJ --strip-components=1 -C /usr/local/bin \
+                "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          shellcheck --version
+
+      - name: Run shellcheck on all shell scripts
+        run: |
+          find scripts tests hooks -name '*.sh' -o -name 'pre-commit' \
+            | sort \
+            | xargs shellcheck --severity=warning
+
+  test:
+    name: Schema Validation Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install yq
+        env:
+          YQ_VERSION: "v4.40.5"
+        run: |
+          curl -fsSL \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Run schema validation tests
+        run: |
+          chmod +x tests/validate-schemas.sh
+          ./tests/validate-schemas.sh
+
+      - name: Run any additional tests
+        run: |
+          # Run all test scripts discovered under tests/
+          find tests -name '*.sh' ! -name 'validate-schemas.sh' \
+            | sort \
+            | while IFS= read -r test_script; do
+                echo "Running ${test_script}..."
+                chmod +x "${test_script}"
+                "${test_script}"
+              done

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,19 @@
+# .shellcheckrc — shellcheck configuration for Myrmidons
+#
+# Applied automatically when shellcheck runs from the repo root.
+# See: https://www.shellcheck.net/wiki/Directive
+
+# Minimum severity to report (style < info < warning < error)
+# Set to "warning" so style nits don't block CI, but real bugs do.
+severity=warning
+
+# All scripts in this repo target bash explicitly.
+shell=bash
+
+# SC2034: variable appears unused — suppress for lib files that are sourced.
+# Enable per-file with: # shellcheck disable=SC2034
+# (not disabled globally; callers should declare variables they actually use)
+
+# SC1091: Not following sourced file — suppressed because lib files are sourced
+# with shellcheck source= directives already present on each source line.
+disable=SC1091

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Myrmidons
 
+[![Lint and Test](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lint.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lint.yml)
+[![Validate YAML](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/validate.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/validate.yml)
+
 GitOps agent provisioning for the HomericIntelligence mesh.
 Agent YAML files are the source of truth for **desired** state.
 Scripts reconcile against [ProjectAgamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon) via its REST API.

--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -75,10 +75,10 @@ get_agent_files() {
 
     if [[ -n "$host" ]]; then
         find "${repo_root}/agents/${host}" -name "*.yaml" \
-            ! -path "*/\_templates/*" 2>/dev/null || true
+            ! -path "*/_templates/*" 2>/dev/null || true
     else
         find "${repo_root}/agents" -name "*.yaml" \
-            ! -path "*/\_templates/*" 2>/dev/null || true
+            ! -path "*/_templates/*" 2>/dev/null || true
     fi
 }
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/lint.yml`: two-job CI workflow that runs shellcheck (pinned at v0.10.0) on all `.sh` files and the `pre-commit` hook, and runs `tests/validate-schemas.sh` plus any future test scripts. Triggers on all PRs to main and pushes to main.
- Add `.shellcheckrc`: sets `severity=warning` (blocks on warnings, not style), `shell=bash`, and disables SC1091 (sourced-file warnings already handled via `shellcheck source=` directives in each script).
- Fix SC1001 warning in `scripts/lib/reconcile.sh`: remove unnecessary backslash escape before `_` in `find -path` patterns (`*/\_templates/*` → `*/_templates/*`).
- Add workflow status badges for `lint.yml` and `validate.yml` to `README.md`.

## Test plan

- [ ] All existing scripts pass shellcheck at `warning` severity (SC1001 fix verified)
- [ ] `tests/validate-schemas.sh` runs successfully in the `test` job
- [ ] PR CI run completes in under 60 seconds (shellcheck is fast; schema validation has no network calls)
- [ ] A PR introducing a shellcheck violation (e.g. unquoted variable) should be blocked by the `shellcheck` job

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)