### PR TITLE
feat: add lock file support to prevent concurrent apply operations

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,6 +41,10 @@ apply HOST=host:
 apply-prune HOST=host:
     AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}} --prune
 
+# Apply with --force (breaks a stale lock before acquiring — use only if previous apply is confirmed dead)
+apply-force HOST=host:
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}} --force
+
 # =============================================================================
 # Bootstrap
 # =============================================================================

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -25,11 +25,16 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/lib/api.sh"
 # shellcheck source=scripts/lib/reconcile.sh
 source "${SCRIPT_DIR}/lib/reconcile.sh"
+# shellcheck source=scripts/lib/lock.sh
+source "${SCRIPT_DIR}/lib/lock.sh"
+
+AIM_LOCK_FILE="${AIM_LOCK_FILE:-/tmp/myrmidons-apply.lock}"
 
 HOST=""
 FLEET=""
 PRUNE=0
 DRY_RUN=0
+FORCE=0
 
 CREATED=0
 UPDATED=0
@@ -44,6 +49,7 @@ parse_args() {
             --prune)   PRUNE=1; shift ;;
             --dry-run) DRY_RUN=1; shift ;;
             --fleet)   FLEET="$2"; shift 2 ;;
+            --force)   FORCE=1; shift ;;
             -h|--help) usage; exit 0 ;;
             *) HOST="$1"; shift ;;
         esac
@@ -62,7 +68,12 @@ Options:
   --prune        Hibernate and delete unmanaged agents (agents in Agamemnon
                  but not in YAML). DEFAULT: warn only.
   --dry-run      Show what would happen, make no changes (same as plan.sh)
+  --force        Break a stale lock file before acquiring (use only if the
+                 previous apply process is confirmed dead)
   -h, --help     Show this help
+
+Environment:
+  AIM_LOCK_FILE  Lock file path (default: /tmp/myrmidons-apply.lock)
 
 Examples:
   $0                         # Reconcile everything
@@ -76,11 +87,11 @@ main() {
     parse_args "$@"
 
     if [[ $DRY_RUN -eq 1 ]]; then
-        local plan_args=()
-        [[ -n "$HOST" ]]  && plan_args+=("$HOST")
-        [[ -n "$FLEET" ]] && plan_args+=("--fleet" "$FLEET")
-        exec "${SCRIPT_DIR}/plan.sh" "${plan_args[@]}"
+        exec "${SCRIPT_DIR}/plan.sh" "$@"
     fi
+
+    acquire_lock "$AIM_LOCK_FILE" "$FORCE"
+    trap 'release_lock "$AIM_LOCK_FILE"' EXIT
 
     check_deps
     agamemnon_check_connection

--- a/scripts/lib/lock.sh
+++ b/scripts/lib/lock.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/lib/lock.sh — File-based lock primitives for apply.sh
+#
+# Provides serialized access to the Agamemnon reconciliation loop.
+# Uses flock(1) for atomic kernel-level locking with PID tracking.
+#
+# Functions:
+#   acquire_lock <lockfile> <force>   — acquire exclusive lock, timeout 60s
+#   release_lock <lockfile>           — release lock and remove lockfile
+#   break_stale_lock <lockfile>       — remove lockfile if held by a dead PID
+#
+# Lock file descriptor: 9 (arbitrary, unlikely to conflict with script FDs)
+
+_LOCK_FD=9
+
+# acquire_lock <lockfile> <force>
+#
+# Opens <lockfile> on fd 9 and acquires an exclusive flock with a 60-second
+# timeout. If <force> is 1 and the lockfile already exists, calls
+# break_stale_lock first; if the existing lock is held by a live process,
+# break_stale_lock exits with an error.
+#
+# On timeout, prints a message to stderr and exits with code 1.
+acquire_lock() {
+    local lockfile="$1"
+    local force="${2:-0}"
+
+    if [[ "$force" -eq 1 && -f "$lockfile" ]]; then
+        break_stale_lock "$lockfile"
+    fi
+
+    # Open the lockfile on the dedicated fd (create if missing)
+    eval "exec ${_LOCK_FD}>\"${lockfile}\""
+
+    if ! flock -w 60 "${_LOCK_FD}"; then
+        echo "ERROR: Could not acquire lock on ${lockfile} within 60 seconds." >&2
+        echo "       Another apply.sh process may be running." >&2
+        echo "       Use --force to break a stale lock (only if the process is dead)." >&2
+        exit 1
+    fi
+
+    # Write our PID so stale detection works
+    echo "$$" >&"${_LOCK_FD}"
+}
+
+# release_lock <lockfile>
+#
+# Releases the flock by closing fd 9 and removes the lockfile.
+# Safe to call even if the lock was never acquired (no-op).
+release_lock() {
+    local lockfile="$1"
+
+    # Close fd — this drops the flock automatically
+    eval "exec ${_LOCK_FD}>&-" 2>/dev/null || true
+
+    rm -f "$lockfile"
+}
+
+# break_stale_lock <lockfile>
+#
+# Reads the PID stored in <lockfile> and checks whether that process is alive.
+#
+#   - Dead PID  → removes lockfile with a warning, returns 0 (caller may proceed)
+#   - Live PID  → prints error with PID and exits with code 1
+#   - Unreadable PID in file → treats as stale, removes and warns
+break_stale_lock() {
+    local lockfile="$1"
+
+    if [[ ! -f "$lockfile" ]]; then
+        return 0
+    fi
+
+    local pid
+    pid="$(cat "$lockfile" 2>/dev/null || true)"
+
+    if [[ -z "$pid" || ! "$pid" =~ ^[0-9]+$ ]]; then
+        echo "WARNING: Lock file ${lockfile} contains invalid PID '${pid}'. Removing stale lock." >&2
+        rm -f "$lockfile"
+        return 0
+    fi
+
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "ERROR: Lock file ${lockfile} is held by PID ${pid} (still running)." >&2
+        echo "       Cannot break a live lock. Wait for the process to finish or kill it first." >&2
+        exit 1
+    else
+        echo "WARNING: Removing stale lock file ${lockfile} (PID ${pid} is no longer running)." >&2
+        rm -f "$lockfile"
+        return 0
+    fi
+}

--- a/tests/test_lock.sh
+++ b/tests/test_lock.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# tests/test_lock.sh — Automated tests for scripts/lib/lock.sh
+#
+# Usage:
+#   ./tests/test_lock.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/lock.sh
+source "${REPO_ROOT}/scripts/lib/lock.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TESTS="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMPDIR_TESTS"
+}
+trap cleanup EXIT
+
+# -----------------------------------------------------------------------------
+# Test harness helpers
+# -----------------------------------------------------------------------------
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_true() {
+    local desc="$1"
+    local result="$2"
+    if [[ "$result" -eq 0 ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected success, got exit $result)"
+    fi
+}
+
+assert_false() {
+    local desc="$1"
+    local result="$2"
+    if [[ "$result" -ne 0 ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected failure, got exit 0)"
+    fi
+}
+
+assert_file_exists() {
+    local desc="$1"
+    local file="$2"
+    if [[ -f "$file" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (file does not exist: $file)"
+    fi
+}
+
+assert_file_absent() {
+    local desc="$1"
+    local file="$2"
+    if [[ ! -f "$file" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (file should not exist: $file)"
+    fi
+}
+
+assert_equals() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected='${expected}', actual='${actual}')"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Tests
+# -----------------------------------------------------------------------------
+
+echo "Running lock tests..."
+echo ""
+
+# --- Test 1: acquire_lock creates the lockfile ---
+echo "Test 1: acquire_lock creates lockfile"
+{
+    lockfile="${TMPDIR_TESTS}/test1.lock"
+    acquire_lock "$lockfile" 0
+    assert_file_exists "lockfile exists after acquire" "$lockfile"
+    release_lock "$lockfile"
+    assert_file_absent "lockfile removed after release" "$lockfile"
+}
+
+# --- Test 2: lockfile contains our PID ---
+echo "Test 2: lockfile contains current PID"
+{
+    lockfile="${TMPDIR_TESTS}/test2.lock"
+    acquire_lock "$lockfile" 0
+    pid_in_file="$(cat "$lockfile")"
+    assert_equals "lockfile contains current PID" "$$" "$pid_in_file"
+    release_lock "$lockfile"
+}
+
+# --- Test 3: release_lock is idempotent (no error on missing file) ---
+echo "Test 3: release_lock is idempotent"
+{
+    lockfile="${TMPDIR_TESTS}/test3.lock"
+    # release without acquire — should not error
+    result=0
+    release_lock "$lockfile" || result=$?
+    assert_true "release_lock on missing file does not error" "$result"
+}
+
+# --- Test 4: break_stale_lock on dead PID removes lockfile ---
+echo "Test 4: break_stale_lock removes stale lock (dead PID)"
+{
+    lockfile="${TMPDIR_TESTS}/test4.lock"
+    # Write a PID that cannot possibly be alive (PID 1 would be init; use a
+    # very high PID that doesn't exist instead)
+    dead_pid=99999999
+    echo "$dead_pid" > "$lockfile"
+    result=0
+    break_stale_lock "$lockfile" 2>/dev/null || result=$?
+    assert_true "break_stale_lock returns 0 for dead PID" "$result"
+    assert_file_absent "lockfile removed for dead PID" "$lockfile"
+}
+
+# --- Test 5: break_stale_lock on live PID exits with error ---
+echo "Test 5: break_stale_lock fails on live PID"
+{
+    lockfile="${TMPDIR_TESTS}/test5.lock"
+    # Write our own PID — we are definitely alive
+    echo "$$" > "$lockfile"
+    result=0
+    # Run in subshell so exit doesn't kill our test script
+    (break_stale_lock "$lockfile" 2>/dev/null) || result=$?
+    assert_false "break_stale_lock exits non-zero for live PID" "$result"
+    # Cleanup
+    rm -f "$lockfile"
+}
+
+# --- Test 6: break_stale_lock on empty/invalid PID treats as stale ---
+echo "Test 6: break_stale_lock treats invalid PID as stale"
+{
+    lockfile="${TMPDIR_TESTS}/test6.lock"
+    echo "not-a-pid" > "$lockfile"
+    result=0
+    break_stale_lock "$lockfile" 2>/dev/null || result=$?
+    assert_true "break_stale_lock returns 0 for invalid PID" "$result"
+    assert_file_absent "lockfile removed for invalid PID" "$lockfile"
+}
+
+# --- Test 7: break_stale_lock on missing file is a no-op ---
+echo "Test 7: break_stale_lock no-op on missing lockfile"
+{
+    lockfile="${TMPDIR_TESTS}/test7.lock"
+    result=0
+    break_stale_lock "$lockfile" 2>/dev/null || result=$?
+    assert_true "break_stale_lock returns 0 when no lockfile" "$result"
+}
+
+# --- Test 8: --force flag triggers stale lock removal (via acquire_lock) ---
+echo "Test 8: acquire_lock with force=1 removes stale lock"
+{
+    lockfile="${TMPDIR_TESTS}/test8.lock"
+    dead_pid=99999999
+    echo "$dead_pid" > "$lockfile"
+    result=0
+    acquire_lock "$lockfile" 1 2>/dev/null || result=$?
+    assert_true "acquire_lock with force=1 succeeds after stale removal" "$result"
+    assert_file_exists "lockfile re-created by acquire after force" "$lockfile"
+    release_lock "$lockfile"
+}
+
+# --- Test 9: Second acquire_lock in background blocks and proceeds after release ---
+echo "Test 9: second acquire blocks until first releases"
+{
+    lockfile="${TMPDIR_TESTS}/test9.lock"
+    result_file="${TMPDIR_TESTS}/test9_result"
+
+    acquire_lock "$lockfile" 0
+
+    # Launch background process that tries to acquire same lock
+    (
+        acquire_lock "$lockfile" 0
+        echo "acquired" > "$result_file"
+        release_lock "$lockfile"
+    ) &
+    bg_pid=$!
+
+    # Give the background process a moment to block on flock
+    sleep 0.2
+
+    # It should not have acquired yet (we still hold it)
+    if [[ -f "$result_file" ]]; then
+        fail "background process should not have acquired lock while held"
+    else
+        pass "background process blocks while lock is held"
+    fi
+
+    # Release our lock — background should proceed
+    release_lock "$lockfile"
+
+    # Wait for background to complete
+    wait "$bg_pid" 2>/dev/null || true
+    sleep 0.1
+
+    if [[ -f "$result_file" && "$(cat "$result_file")" == "acquired" ]]; then
+        pass "background process acquired lock after release"
+    else
+        fail "background process did not acquire lock after release"
+    fi
+}
+
+# --- Test 10: release_lock removes file after trap simulation ---
+echo "Test 10: release_lock cleans up on simulated EXIT trap"
+{
+    lockfile="${TMPDIR_TESTS}/test10.lock"
+    result_file="${TMPDIR_TESTS}/test10_result"
+
+    (
+        acquire_lock "$lockfile" 0
+        trap "release_lock \"$lockfile\"; echo 'released' > \"$result_file\"" EXIT
+        # Simulate crash via exit 1
+        exit 1
+    ) 2>/dev/null || true
+
+    sleep 0.1
+    assert_file_absent "lockfile removed by EXIT trap on crash" "$lockfile"
+    if [[ -f "$result_file" && "$(cat "$result_file")" == "released" ]]; then
+        pass "EXIT trap release_lock ran on crash exit"
+    else
+        fail "EXIT trap release_lock did not run on crash exit"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/lib/lock.sh` with `acquire_lock` (60s timeout via `flock`), `release_lock`, and `break_stale_lock` functions
- Modifies `scripts/apply.sh` to acquire the lock before reconciliation and release it via `trap EXIT` on all exit paths; `--dry-run` naturally skips locking (the early `exec` to `plan.sh` happens before lock acquisition)
- Adds `--force` flag to `apply.sh` and `apply-force` recipe in `justfile` for breaking stale locks from crashed processes
- Lock file location defaults to `/tmp/myrmidons-apply.lock`, configurable via `AIM_LOCK_FILE`
- Adds `tests/test_lock.sh` with 10 tests / 16 assertions covering all behaviors

## Test plan

- [x] `tests/test_lock.sh` — all 16 assertions pass
  - Lock acquired and lockfile created
  - Lockfile contains current PID
  - `release_lock` is idempotent (no error on missing file)
  - `break_stale_lock` removes dead-PID lockfile
  - `break_stale_lock` exits non-zero for live PID
  - `break_stale_lock` treats invalid PID as stale
  - `break_stale_lock` no-ops on missing lockfile
  - `acquire_lock` with `force=1` clears stale lock
  - Second concurrent acquire blocks until first releases
  - `EXIT` trap calls `release_lock` on crash
- [x] `tests/validate-schemas.sh` — 19 files, 0 errors (no regressions)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)