### PR TITLE
feat(apply): add fail-fast, per-agent error tracking, and retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tests/*.log
 
 # Local state (not config)
 *.bak
+.myrmidons/
 
 # Rollback snapshots (machine-local, not versioned)
 .myrmidons/

--- a/justfile
+++ b/justfile
@@ -41,6 +41,14 @@ apply HOST=host:
 apply-prune HOST=host:
     AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}} --prune
 
+# Apply with --fail-fast (stop on first error)
+apply-fail-fast HOST=host:
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}} --fail-fast
+
+# Re-apply only the agents that failed in the previous apply run
+retry:
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh --retry
+
 # =============================================================================
 # Bootstrap
 # =============================================================================

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -10,11 +10,17 @@
 #   ./scripts/apply.sh --fleet dev-mesh
 #   ./scripts/apply.sh --prune         # Also hibernate+delete unmanaged agents
 #   ./scripts/apply.sh --dry-run       # Same as plan.sh
+#   ./scripts/apply.sh --fail-fast     # Stop on first error
 #
 # Safety:
 #   - Never auto-deletes agents without --prune flag
 #   - Always hibernates before deleting
 #   - Prints a summary of what was done
+#
+# Exit codes:
+#   0 = all agents applied successfully
+#   1 = partial failure (some agents failed)
+#   2 = total failure (all processed agents failed)
 
 set -euo pipefail
 
@@ -30,6 +36,8 @@ HOST=""
 FLEET=""
 PRUNE=0
 DRY_RUN=0
+FAIL_FAST=0
+RETRY=0
 
 CREATED=0
 UPDATED=0
@@ -38,13 +46,24 @@ HIBERNATED=0
 UNCHANGED=0
 ERRORS=0
 
+# Per-agent error tracking: parallel arrays of (agent_name, http_status, error_message)
+FAILED_AGENT_NAMES=()
+FAILED_AGENT_STATUSES=()
+FAILED_AGENT_MESSAGES=()
+
+# Directory for state files
+MYRMIDONS_STATE_DIR="${REPO_ROOT}/.myrmidons"
+FAILED_AGENTS_FILE="${MYRMIDONS_STATE_DIR}/failed-agents.txt"
+
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --prune)   PRUNE=1; shift ;;
-            --dry-run) DRY_RUN=1; shift ;;
-            --fleet)   FLEET="$2"; shift 2 ;;
-            -h|--help) usage; exit 0 ;;
+            --prune)     PRUNE=1; shift ;;
+            --dry-run)   DRY_RUN=1; shift ;;
+            --fail-fast) FAIL_FAST=1; shift ;;
+            --retry)     RETRY=1; shift ;;
+            --fleet)     FLEET="$2"; shift 2 ;;
+            -h|--help)   usage; exit 0 ;;
             *) HOST="$1"; shift ;;
         esac
     done
@@ -52,7 +71,7 @@ parse_args() {
 
 usage() {
     cat <<EOF
-Usage: $0 [host] [--fleet <name>] [--prune] [--dry-run]
+Usage: $0 [host] [--fleet <name>] [--prune] [--dry-run] [--fail-fast]
 
 Reconciles agent YAML definitions against Agamemnon's actual state.
 
@@ -62,24 +81,78 @@ Options:
   --prune        Hibernate and delete unmanaged agents (agents in Agamemnon
                  but not in YAML). DEFAULT: warn only.
   --dry-run      Show what would happen, make no changes (same as plan.sh)
+  --fail-fast    Stop on first error (default: continue processing all agents)
+  --retry        Re-apply only agents listed in .myrmidons/failed-agents.txt
   -h, --help     Show this help
+
+Exit codes:
+  0  All agents applied successfully
+  1  Partial failure (some agents failed)
+  2  Total failure (all processed agents failed)
+
+Failed agents are written to: .myrmidons/failed-agents.txt
+Use 'just retry' to re-apply only previously failed agents.
 
 Examples:
   $0                         # Reconcile everything
   $0 hermes                  # Reconcile hermes only
   $0 --fleet dev-mesh        # Reconcile dev-mesh fleet
   $0 --prune                 # Reconcile + remove unmanaged agents
+  $0 --fail-fast             # Stop on first error
 EOF
+}
+
+# Record a per-agent failure and increment error counter.
+# Usage: record_failure <agent_name> <http_status> <error_message>
+record_failure() {
+    local agent_name="$1"
+    local http_status="$2"
+    local error_message="$3"
+
+    ERRORS=$((ERRORS + 1))
+    FAILED_AGENT_NAMES+=("$agent_name")
+    FAILED_AGENT_STATUSES+=("$http_status")
+    FAILED_AGENT_MESSAGES+=("$error_message")
+}
+
+# Write failed agent names to .myrmidons/failed-agents.txt for use by 'just retry'.
+write_failed_agents_file() {
+    mkdir -p "${MYRMIDONS_STATE_DIR}"
+    : > "${FAILED_AGENTS_FILE}"
+    for name in "${FAILED_AGENT_NAMES[@]}"; do
+        echo "$name" >> "${FAILED_AGENTS_FILE}"
+    done
+}
+
+# Print a detailed per-agent error summary.
+print_error_summary() {
+    echo ""
+    echo "================================================"
+    echo "FAILED AGENTS (${ERRORS}):"
+    echo ""
+    local i
+    for i in "${!FAILED_AGENT_NAMES[@]}"; do
+        local agent_name="${FAILED_AGENT_NAMES[$i]}"
+        local http_status="${FAILED_AGENT_STATUSES[$i]}"
+        local error_msg="${FAILED_AGENT_MESSAGES[$i]}"
+        echo "  [FAIL] ${agent_name}"
+        if [[ -n "$http_status" ]]; then
+            echo "         HTTP status: ${http_status}"
+        fi
+        if [[ -n "$error_msg" ]]; then
+            echo "         Error: ${error_msg}"
+        fi
+    done
+    echo ""
+    echo "Failed agents written to: ${FAILED_AGENTS_FILE}"
+    echo "Run 'just retry' to re-apply only failed agents."
 }
 
 main() {
     parse_args "$@"
 
     if [[ $DRY_RUN -eq 1 ]]; then
-        local plan_args=()
-        [[ -n "$HOST" ]]  && plan_args+=("$HOST")
-        [[ -n "$FLEET" ]] && plan_args+=("--fleet" "$FLEET")
-        exec "${SCRIPT_DIR}/plan.sh" "${plan_args[@]}"
+        exec "${SCRIPT_DIR}/plan.sh" "$@"
     fi
 
     check_deps
@@ -91,6 +164,36 @@ main() {
     local yaml_files
     mapfile -t yaml_files < <(get_agent_files "$HOST")
 
+    if [[ $RETRY -eq 1 ]]; then
+        if [[ ! -f "${FAILED_AGENTS_FILE}" ]] || [[ ! -s "${FAILED_AGENTS_FILE}" ]]; then
+            echo "No failed agents to retry (${FAILED_AGENTS_FILE} is empty or missing)."
+            exit 0
+        fi
+        local failed_names=()
+        mapfile -t failed_names < "${FAILED_AGENTS_FILE}"
+        echo "Retrying ${#failed_names[@]} previously failed agent(s):"
+        for fn in "${failed_names[@]}"; do echo "  - ${fn}"; done
+        echo ""
+
+        local filtered_files=()
+        for yaml_file in "${yaml_files[@]}"; do
+            local yname
+            yname="$(yq eval '.metadata.name' "$yaml_file")"
+            for fn in "${failed_names[@]}"; do
+                if [[ "$yname" == "$fn" ]]; then
+                    filtered_files+=("$yaml_file")
+                    break
+                fi
+            done
+        done
+        yaml_files=("${filtered_files[@]}")
+
+        if [[ ${#yaml_files[@]} -eq 0 ]]; then
+            echo "WARNING: None of the failed agents were found in agents/. They may have been removed."
+            exit 1
+        fi
+    fi
+
     if [[ ${#yaml_files[@]} -eq 0 ]]; then
         echo "No agent YAML files found."
         exit 0
@@ -100,11 +203,17 @@ main() {
     echo "================================================"
     echo ""
 
+    local processed=0
     for yaml_file in "${yaml_files[@]}"; do
-        if ! apply_agent "$yaml_file" "$agents_json"; then
-            echo "ERROR: apply_agent failed for ${yaml_file}" >&2
-            ERRORS=$((ERRORS + 1))
+        apply_agent "$yaml_file" "$agents_json"
+        processed=$((processed + 1))
+
+        if [[ $FAIL_FAST -eq 1 && $ERRORS -gt 0 ]]; then
+            echo ""
+            echo "ERROR: --fail-fast enabled, stopping after first failure." >&2
+            break
         fi
+
         # Refresh actual state after each change
         agents_json="$(agamemnon_list_agents)"
     done
@@ -117,7 +226,20 @@ main() {
     echo "Summary: created=${CREATED} updated=${UPDATED} woken=${WOKEN} hibernated=${HIBERNATED} unchanged=${UNCHANGED} errors=${ERRORS}"
 
     if [[ $ERRORS -gt 0 ]]; then
+        print_error_summary
+        write_failed_agents_file
+
+        local total_processed=$(( CREATED + UPDATED + WOKEN + HIBERNATED + UNCHANGED + ERRORS ))
+        # Total failure: every processed agent either failed or none succeeded
+        if [[ $(( total_processed - ERRORS )) -eq 0 ]]; then
+            exit 2
+        fi
         exit 1
+    fi
+
+    # Clear any stale failed-agents file on full success
+    if [[ -f "${FAILED_AGENTS_FILE}" ]]; then
+        : > "${FAILED_AGENTS_FILE}"
     fi
 }
 
@@ -150,7 +272,8 @@ apply_agent() {
         local create_body
         create_body="$(build_create_json "$name" "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$owner" "$role")"
 
-        local result
+        local result http_status
+        http_status=""
         if result="$(agamemnon_create_agent "$create_body" 2>&1)"; then
             local new_id
             new_id="$(echo "$result" | jq -r '.id // empty')"
@@ -160,13 +283,21 @@ apply_agent() {
             # Wake if desired
             if [[ "$desired_state" == "active" && -n "$new_id" ]]; then
                 echo "    Starting ${name}..."
-                agamemnon_wake_agent "$new_id" > /dev/null
+                if ! agamemnon_wake_agent "$new_id" > /dev/null 2>&1; then
+                    echo "    ERROR starting ${name} after create" >&2
+                    record_failure "$name" "" "Failed to wake agent after creation (id=${new_id})"
+                    return
+                fi
                 echo "    Started."
                 WOKEN=$((WOKEN + 1))
             fi
         else
-            echo "    ERROR creating ${name}: ${result}" >&2
-            ERRORS=$((ERRORS + 1))
+            # Try to extract HTTP status from error output
+            http_status="$(echo "$result" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+            local err_msg
+            err_msg="$(echo "$result" | tail -1)"
+            echo "    ERROR creating ${name}: ${err_msg}" >&2
+            record_failure "$name" "$http_status" "$err_msg"
         fi
         return
     fi
@@ -187,15 +318,31 @@ apply_agent() {
             ;;
         WAKE)
             echo "[!] Starting ${name} (status=${actual_status}, desired=active)..."
-            agamemnon_wake_agent "$actual_id" > /dev/null
-            echo "    Started."
-            WOKEN=$((WOKEN + 1))
+            local wake_out
+            if wake_out="$(agamemnon_wake_agent "$actual_id" 2>&1)"; then
+                echo "    Started."
+                WOKEN=$((WOKEN + 1))
+            else
+                local http_status
+                http_status="$(echo "$wake_out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+                local err_msg="$(echo "$wake_out" | tail -1)"
+                echo "    ERROR starting ${name}: ${err_msg}" >&2
+                record_failure "$name" "$http_status" "Failed to wake agent: ${err_msg}"
+            fi
             ;;
         HIBERNATE)
             echo "[z] Stopping ${name} (status=${actual_status}, desired=hibernated)..."
-            agamemnon_hibernate_agent "$actual_id" > /dev/null
-            echo "    Hibernated."
-            HIBERNATED=$((HIBERNATED + 1))
+            local hib_out
+            if hib_out="$(agamemnon_hibernate_agent "$actual_id" 2>&1)"; then
+                echo "    Hibernated."
+                HIBERNATED=$((HIBERNATED + 1))
+            else
+                local http_status
+                http_status="$(echo "$hib_out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+                local err_msg="$(echo "$hib_out" | tail -1)"
+                echo "    ERROR stopping ${name}: ${err_msg}" >&2
+                record_failure "$name" "$http_status" "Failed to hibernate agent: ${err_msg}"
+            fi
             ;;
         UPDATE:*)
             local changed_fields="${action#UPDATE:}"
@@ -211,22 +358,26 @@ apply_agent() {
                 '{label: $label, program: $program, workingDirectory: $workingDirectory,
                   programArgs: $programArgs, taskDescription: $taskDescription}')"
 
-            if agamemnon_update_agent "$actual_id" "$patch_body" > /dev/null 2>&1; then
+            local update_out
+            if update_out="$(agamemnon_update_agent "$actual_id" "$patch_body" 2>&1)"; then
                 echo "    Updated."
                 UPDATED=$((UPDATED + 1))
-            else
-                echo "    ERROR updating ${name}" >&2
-                ERRORS=$((ERRORS + 1))
-            fi
 
-            # Also start/stop if state needs to change
-            if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
-                agamemnon_wake_agent "$actual_id" > /dev/null
-                WOKEN=$((WOKEN + 1))
-            elif [[ "$desired_state" == "hibernated" && \
-                    ("$actual_status" == "active" || "$actual_status" == "online") ]]; then
-                agamemnon_hibernate_agent "$actual_id" > /dev/null
-                HIBERNATED=$((HIBERNATED + 1))
+                # Also start/stop if state needs to change
+                if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
+                    agamemnon_wake_agent "$actual_id" > /dev/null
+                    WOKEN=$((WOKEN + 1))
+                elif [[ "$desired_state" == "hibernated" && \
+                        ("$actual_status" == "active" || "$actual_status" == "online") ]]; then
+                    agamemnon_hibernate_agent "$actual_id" > /dev/null
+                    HIBERNATED=$((HIBERNATED + 1))
+                fi
+            else
+                local http_status
+                http_status="$(echo "$update_out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+                local err_msg="$(echo "$update_out" | tail -1)"
+                echo "    ERROR updating ${name}: ${err_msg}" >&2
+                record_failure "$name" "$http_status" "Failed to update fields [${changed_fields}]: ${err_msg}"
             fi
             ;;
     esac


### PR DESCRIPTION
## Summary

- **`--fail-fast` flag**: stops `apply.sh` after the first agent failure instead of continuing and cascading errors across N agents when Agamemnon is unhealthy
- **Per-agent error tracking**: captures agent name, HTTP status code, and error message for every failure; printed as a detailed `FAILED AGENTS` section after the summary line
- **Exit code semantics**: `0` = all success, `1` = partial failure, `2` = total failure (no agents succeeded)
- **`.myrmidons/failed-agents.txt`**: written after any failure, contains one agent name per line; cleared on full success
- **`--retry` flag** on `apply.sh`: reads `failed-agents.txt` and re-applies only those agents, skipping everything else
- **`just retry`** recipe: convenience alias for `apply.sh --retry`
- **`just apply-fail-fast`** recipe: convenience alias for `--fail-fast`
- **`.myrmidons/` in `.gitignore`**: runtime state directory is not committed

## Test plan

- [ ] Run `apply.sh` with a healthy Agamemnon — exit 0, no failed-agents.txt written (or it's cleared)
- [ ] Simulate one API failure — exit 1, error summary lists the failed agent with HTTP status, `failed-agents.txt` written
- [ ] Simulate all API failures — exit 2
- [ ] Run `apply.sh --fail-fast` — stops after the first error, does not process remaining agents
- [ ] Run `apply.sh --retry` after a partial failure — only processes agents in `failed-agents.txt`
- [ ] Run `just retry` with no `failed-agents.txt` — prints "No failed agents to retry" and exits 0
- [ ] Run `bash -n scripts/apply.sh` — syntax check passes

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)