### PR TITLE
refactor: deduplicate report_unmanaged (DRY fix, issue #26)

### DIFF
--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -332,6 +332,17 @@ normalize_path() {
     echo "${p/#\~/$HOME}"
 }
 
+# Report agents that exist in Agamemnon but are not managed by any YAML file.
+# Prints a log_warn line for each unmanaged agent.
+# Usage: report_unmanaged <agents_json> <yaml_file>...
+report_unmanaged() {
+    local agents_json="$1"
+    shift
+    while IFS= read -r actual_name; do
+        log_warn "[-] UNMANAGED ${actual_name} (in Agamemnon but not in desired state — use --prune to remove)"
+    done < <(get_unmanaged_names "$agents_json" "$@")
+}
+
 # Find agent names that exist in Agamemnon but are not managed by any YAML file.
 # Outputs one unmanaged agent name per line.
 # Usage: get_unmanaged_names <agents_json> <yaml_file>...

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -148,29 +148,4 @@ plan_agent() {
     return 0
 }
 
-report_unmanaged() {
-    local agents_json="$1"
-    shift
-    local yaml_files=("$@")
-
-    # Collect all managed names
-    local managed_names=()
-    for yaml_file in "${yaml_files[@]}"; do
-        local name
-        name="$(yq eval '.metadata.name' "$yaml_file")"
-        managed_names+=("$name")
-    done
-
-    # Find agents not in managed list
-    echo "$agents_json" | jq -r '.[].name' | while IFS= read -r actual_name; do
-        local is_managed=0
-        for mn in "${managed_names[@]}"; do
-            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
-        done
-        if [[ $is_managed -eq 0 ]]; then
-            log_warn "[-] UNMANAGED ${actual_name} (in Agamemnon but not in desired state — use --prune to remove)"
-        fi
-    done
-}
-
 main "$@"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -168,34 +168,19 @@ status_agent() {
 report_unmanaged() {
     local agents_json="$1"
     shift
-    local yaml_files=("$@")
-
-    local managed_names=()
-    for yaml_file in "${yaml_files[@]}"; do
-        local n
-        n="$(yq eval '.metadata.name' "$yaml_file")"
-        managed_names+=("$n")
-    done
 
     while IFS= read -r actual_name; do
-        local is_managed=0
-        for mn in "${managed_names[@]}"; do
-            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
-        done
+        local actual_status
+        actual_status="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
+            '.[] | select(.name == $n) | .status // "unknown"')"
 
-        if [[ $is_managed -eq 0 ]]; then
-            local actual_status
-            actual_status="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
-                '.[] | select(.name == $n) | .status // "unknown"')"
+        report_add_unmanaged "$actual_name"
 
-            report_add_unmanaged "$actual_name"
-
-            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
-                printf "%-22s %-10s %-12s %-12s %s\n" \
-                    "${actual_name:0:21}" "-" "-" "$actual_status" "UNMANAGED"
-            fi
+        if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+            printf "%-22s %-10s %-12s %-12s %s\n" \
+                "${actual_name:0:21}" "-" "-" "$actual_status" "UNMANAGED"
         fi
-    done < <(echo "$agents_json" | jq -r '.[].name')
+    done < <(get_unmanaged_names "$agents_json" "$@")
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Added `report_unmanaged()` to `scripts/lib/reconcile.sh`, which wraps `get_unmanaged_names()` and emits `log_warn` lines — the pattern used by `plan.sh`
- Removed the duplicate `report_unmanaged()` from `scripts/plan.sh`; it now uses the shared version from `reconcile.sh`
- Simplified `status.sh`'s local `report_unmanaged()` to delegate name discovery to `get_unmanaged_names()`, eliminating the duplicated collection loop while keeping the status-specific table/JSON output

The core unmanaged-agent detection logic now lives in exactly one place (`get_unmanaged_names()` in `reconcile.sh`), satisfying DRY.

## Test plan

- [x] `bash -n` syntax check passes on all three modified files
- [x] `tests/test-compute-drift.sh` — 14/14 pass
- [x] Manual review: `plan.sh` call to `report_unmanaged` resolves to `reconcile.sh`'s definition; `status.sh` shadows it correctly with its own status-aware version

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)