### PR TITLE
chore(justfile): add lint-names, shellcheck to validate; add status-fleet

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -9,6 +9,9 @@ on:
       - 'pixi.toml'
       - 'pixi.lock'
 
+permissions:
+  contents: read
+
 jobs:
   apply:
     name: Reconcile Desired State
@@ -17,6 +20,12 @@ jobs:
       AGAMEMNON_URL: ${{ secrets.AGAMEMNON_URL }}
       AGAMEMNON_API_KEY: ${{ secrets.AGAMEMNON_API_KEY }}
     steps:
+      - name: Mask secrets
+        run: |
+          if [[ -n "$AGAMEMNON_API_KEY" ]]; then
+            echo "::add-mask::$AGAMEMNON_API_KEY"
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Cache pixi environment

--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ agamemnon_url := env_var_or_default("AGAMEMNON_URL", "http://localhost:8080")
 status HOST=host:
     AGAMEMNON_URL={{agamemnon_url}} bash scripts/status.sh {{HOST}}
 
+# Show desired vs actual state for a named fleet
+status-fleet FLEET:
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/status.sh --fleet {{FLEET}}
+
 # Display the last reconciliation report (JSON)
 report:
     #!/usr/bin/env bash
@@ -94,6 +98,12 @@ validate:
         exit 1
     fi
     echo "All YAML files valid."
+    echo ""
+    echo "Checking name uniqueness..."
+    pixi run lint-names
+    echo ""
+    echo "Running shellcheck..."
+    pixi run lint-shell
 
 # =============================================================================
 # Testing

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,8 +12,10 @@ jq   = ">=1.6"
 # Install manually: see scripts/lib/reconcile.sh or CI workflows.
 
 [tasks]
-status   = "just status"
-plan     = "just plan"
-apply    = "just apply"
-validate = "just validate"
-export   = "just export"
+status        = "just status"
+plan          = "just plan"
+apply         = "just apply"
+validate      = "just validate"
+export        = "just export"
+lint-names    = "bash scripts/lint-names.sh"
+lint-shell    = "bash scripts/lint-shell.sh"

--- a/scripts/lint-names.sh
+++ b/scripts/lint-names.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/lint-names.sh — Check for duplicate metadata.name across agents and fleets
+#
+# This script validates that all metadata.name values are unique across all agent
+# and fleet YAML files in the agents/ and fleets/ directories.
+#
+# Usage:
+#   ./scripts/lint-names.sh
+#
+# Exit codes:
+#   0 = all names are unique
+#   1 = duplicate names found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ERRORS=0
+
+if ! command -v yq &>/dev/null; then
+    echo "ERROR: yq is required for name validation." >&2
+    echo "  Install: https://github.com/mikefarah/yq" >&2
+    exit 1
+fi
+
+echo "Checking metadata.name uniqueness across all agents and fleets..."
+
+# Associative array to track names for uniqueness check
+declare -A metadata_names
+
+# Find all YAML files (excluding templates)
+while IFS= read -r -d '' file; do
+    [[ "$file" == *"/_templates/"* ]] && continue
+
+    # Extract metadata.name
+    name="$(yq eval '.metadata.name // ""' "$file" 2>/dev/null || true)"
+
+    # Track names for uniqueness check (only non-empty names to avoid false positives)
+    if [[ -n "$name" ]]; then
+        metadata_names["$name"]+=" $file"
+    fi
+
+done < <(find "${REPO_ROOT}/agents" "${REPO_ROOT}/fleets" \
+    -name "*.yaml" -print0 2>/dev/null)
+
+# Cross-file name uniqueness check
+for name in "${!metadata_names[@]}"; do
+    files_with_name="${metadata_names[$name]}"
+    # Count non-empty tokens (file paths are separated by spaces)
+    count=0
+    for f in $files_with_name; do
+        [[ -n "$f" ]] && count=$((count + 1))
+    done
+    if [[ $count -gt 1 ]]; then
+        echo "ERROR: duplicate metadata.name '${name}' found in:"
+        for f in $files_with_name; do
+            [[ -n "$f" ]] && echo "  - ${f#"${REPO_ROOT}/"}"
+        done
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo ""
+    echo "lint-names: ${ERRORS} duplicate name(s) found."
+    exit 1
+fi
+
+echo "All metadata.name values are unique."
+exit 0

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/lint-shell.sh — Run shellcheck on all shell scripts
+#
+# This script runs shellcheck (with --severity=warning) on all shell scripts
+# found in the scripts/, tests/, and hooks/ directories.
+#
+# Usage:
+#   ./scripts/lint-shell.sh
+#
+# Exit codes:
+#   0 = no shellcheck warnings or errors
+#   1 = shellcheck warnings or errors found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Find shellcheck: try system first, then pixi lint environment
+SHELLCHECK_CMD="shellcheck"
+if ! command -v shellcheck &>/dev/null; then
+    if [[ -f "${REPO_ROOT}/.pixi/envs/lint/bin/shellcheck" ]]; then
+        SHELLCHECK_CMD="${REPO_ROOT}/.pixi/envs/lint/bin/shellcheck"
+    else
+        echo "ERROR: shellcheck is required for shell linting." >&2
+        echo "  Install: https://www.shellcheck.net/wiki/Install" >&2
+        echo "  Or run: pixi run lint-shell" >&2
+        exit 1
+    fi
+fi
+
+echo "Running shellcheck on all shell scripts..."
+echo ""
+
+# Find and check all shell scripts
+find "${REPO_ROOT}/scripts" "${REPO_ROOT}/tests" "${REPO_ROOT}/hooks" \
+    -name '*.sh' -o -name 'pre-commit' \
+    | sort \
+    | xargs "$SHELLCHECK_CMD" --severity=warning
+
+echo ""
+echo "Shell script linting complete."


### PR DESCRIPTION
Makes `just validate` run name-uniqueness lint and shellcheck in addition to YAML schema validation. Adds `just status-fleet` recipe for fleet-scoped status.

Closes #253
Closes #218
Closes #204