### PR TITLE
ci(validate): explicit CI=true and shellcheck step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,8 @@ on:
       - 'fleets/**'
       - 'pixi.toml'
       - 'pixi.lock'
+      - 'scripts/**'
+      - '.github/workflows/validate.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -27,4 +29,13 @@ jobs:
       - uses: ./.github/actions/setup-pixi
 
       - name: Validate all YAML files
+        env:
+          CI: "true"
         run: pixi run test-schema
+
+      - uses: ./.github/actions/setup-pixi
+        with:
+          environment: lint
+
+      - name: Run shellcheck
+        run: pixi run --environment lint lint-shell

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -29,6 +29,7 @@ parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -h|--help) usage; exit 0 ;;
+            --dry-run) shift ;;
             *) HOST="$1"; shift ;;
         esac
     done
@@ -61,6 +62,10 @@ main() {
     fi
 
     local has_changes=0
+    local CREATE_COUNT=0
+    local UPDATE_COUNT=0
+    local WAKE_COUNT=0
+    local HIBERNATE_COUNT=0
 
     log_info "Plan for ${AGAMEMNON_URL} (dry-run — no changes will be made)"
     log_info "================================================================"
@@ -80,6 +85,7 @@ main() {
         log_info "No changes needed. Desired state matches actual state."
         exit 0
     else
+        log_warn "Summary: created=${CREATE_COUNT} updated=${UPDATE_COUNT} woken=${WAKE_COUNT} hibernated=${HIBERNATE_COUNT}"
         log_warn "Changes would be made. Run ./scripts/apply.sh to apply."
         exit 1
     fi
@@ -114,6 +120,7 @@ plan_agent() {
         if [[ "$desired_state" == "active" ]]; then
             log_info "    └─ WAKE after create"
         fi
+        ((CREATE_COUNT++))
         return 1
     fi
 
@@ -127,15 +134,18 @@ plan_agent() {
             ;;
         WAKE)
             log_warn "[!] WAKE ${name} (desired=active, actual=$(echo "$actual_json" | jq -r '.status'))"
+            ((WAKE_COUNT++))
             return 1
             ;;
         HIBERNATE)
             log_warn "[z] HIBERNATE ${name} (desired=hibernated, actual=$(echo "$actual_json" | jq -r '.status'))"
+            ((HIBERNATE_COUNT++))
             return 1
             ;;
         UPDATE:*)
             local fields_changed="${action#UPDATE:}"
             log_warn "[~] UPDATE ${name}: ${fields_changed} differ"
+            ((UPDATE_COUNT++))
             return 1
             ;;
     esac

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -64,9 +64,31 @@ while IFS= read -r -d '' file; do
     fi
 
     if [[ "$kind" == "Fleet" ]]; then
+        field_errors=()
         fleet_name="$(yq eval '.metadata.name // ""' "$file")"
-        [[ -z "$fleet_name" ]] && echo "FAIL (metadata.name required in Fleet)" && ERRORS=$((ERRORS+1)) && continue
-        echo "ok (Fleet: ${fleet_name})"
+        [[ -z "$fleet_name" ]] && field_errors+=("metadata.name is required in Fleet")
+
+        # Validate Fleet filename matches metadata.name (same convention as Agents)
+        if [[ -n "$fleet_name" ]]; then
+            expected_filename="$(echo "$fleet_name" | tr '[:upper:]' '[:lower:]').yaml"
+            actual_filename="$(basename "$file")"
+            if [[ "$actual_filename" != "$expected_filename" ]]; then
+                field_errors+=("filename '$actual_filename' does not match metadata.name '$fleet_name' (expected '$expected_filename')")
+            fi
+        fi
+
+        if [[ ${#field_errors[@]} -gt 0 ]]; then
+            echo "FAIL"
+            for err in "${field_errors[@]}"; do
+                echo "      - ${err}"
+            done
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "ok (Fleet: ${fleet_name})"
+        fi
+
+        # Track names for uniqueness check (only non-empty names to avoid false positives)
+        [[ -n "$fleet_name" ]] && agent_names["$fleet_name"]+=" $file"
         continue
     fi
 


### PR DESCRIPTION
Adds explicit CI=true env to the schema validation step and adds shellcheck with pixi integration to the validate workflow for PR-time shell linting.

Extends trigger paths to include scripts/** and the workflow file itself.

Closes #203
Closes #258
Closes #216