### PR TITLE
fix(schema): enforce workingDirectory is an absolute path

### DIFF
--- a/schemas/agent-v1.schema.json
+++ b/schemas/agent-v1.schema.json
@@ -55,6 +55,7 @@
         "workingDirectory": {
           "type": "string",
           "minLength": 1,
+          "pattern": "^/",
           "description": "Absolute path to the working directory for the agent process"
         },
         "programArgs": {

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -107,6 +107,11 @@ while IFS= read -r -d '' file; do
     [[ -z "$program" ]] && field_errors+=("spec.program is required")
     [[ -z "$workdir" ]] && field_errors+=("spec.workingDirectory is required")
 
+    # Validate workingDirectory is an absolute path
+    if [[ -n "$workdir" && "$workdir" != /* ]]; then
+        field_errors+=("spec.workingDirectory '$workdir' is not an absolute path (must start with /)")
+    fi
+
     # Validate spec.program against known enum
     if [[ -n "$program" ]]; then
         case "$program" in


### PR DESCRIPTION
Adds `pattern: ^/` to the workingDirectory field in agent-v1.schema.json and a corresponding check in validate-schemas.sh so relative paths are rejected at validation time.

Closes #176