### PR TITLE
ci(apply): upload snapshots directory as build artifact

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   apply:
@@ -67,3 +68,12 @@ jobs:
         run: |
           chmod +x scripts/status.sh
           ./scripts/status.sh
+
+      - name: Upload snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: myrmidons-snapshots-${{ github.run_id }}
+          path: .myrmidons/snapshots/
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
Adds an upload-artifact step (if: always()) after apply so .myrmidons/snapshots/ survives the ephemeral CI runner. Retention is 30 days. Adds actions: write to permissions block.

Closes #226