### PR TITLE
test(apply): add bats tests for argument passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ just plan hermes
 just apply hermes
 ```
 
+> **Note:** `export.sh` derives YAML filenames from the agent's display label (lowercased),
+> not from `metadata.name`. For example, an agent with label `MyAgent` exports to
+> `agents/hermes/myagent.yaml`. The `metadata.name` field inside the file retains the
+> original Agamemnon API name. See [Naming convention](#naming-convention) for details.
+
 ## Common workflows
 
 ```bash


### PR DESCRIPTION
Adds tests/unit/test_apply_args.bats verifying apply.sh argument parsing: --dry-run exec, --force stripping, --prune acceptance.

Closes #67
Closes #72