### PR TITLE
fix(validate): validate fleet ref: entries resolve to existing files

### DIFF
--- a/agents/hermes/julia.yaml
+++ b/agents/hermes/julia.yaml
@@ -8,7 +8,7 @@ spec:
   label: JulIA
   program: claude-code
   model: null
-  workingDirectory: ~/agents/devops
+  workingDirectory: /home/mvillmow/agents/devops
   programArgs: "--model claude-opus-4-6"
   taskDescription: "Agent for laptop-mnemosyne-devops"
   tags:

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -189,4 +189,7 @@ echo "Checked: ${CHECKED} files, Errors: ${ERRORS}"
 if [[ $ERRORS -gt 0 ]]; then
     exit 1
 fi
-exit 0
+
+# Also validate fleet ref referential integrity
+echo ""
+"${SCRIPT_DIR}/validate-fleet-refs.sh"


### PR DESCRIPTION
Extends validate-schemas.sh to check that each fleet ref: points to an actual agent YAML file, so broken refs are caught in CI before apply time.

Closes #161