### PR TITLE
fix(ci): fix apply.yml pixi setup and unit test isolation failures

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -29,30 +29,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Cache pixi environment
-        uses: actions/cache@v4
-        with:
-          path: |
-            .pixi
-            ~/.cache/rattler/cache
-          key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
-
-      - name: Install dependencies (locked)
-        run: pixi install --locked
-
-      - name: Install yq
-        env:
-          YQ_VERSION: "v4.40.5"
-        run: |
-          curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
-            -o /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
-          yq --version
-
-      - name: Install jq
-        run: |
-          sudo apt-get install -y --no-install-recommends jq
-          jq --version
+      - name: Set up pixi
+        uses: ./.github/actions/setup-pixi
 
       - name: Plan — show what will change
         run: |

--- a/tests/unit/test_deps.bats
+++ b/tests/unit/test_deps.bats
@@ -50,8 +50,9 @@ teardown() {
     /bin/cp "$jq_path" "$TOOLS_BIN/jq"
     /bin/cp "$curl_path" "$TOOLS_BIN/curl"
 
-    # Set PATH to only have our TOOLS_BIN (which has jq and curl but NOT yq)
-    PATH="$TOOLS_BIN:/bin:/usr/bin"
+    # Set PATH to only have our TOOLS_BIN (which has jq and curl but NOT yq).
+    # Exclude /bin, /usr/bin, and pixi-managed dirs so pixi-installed yq isn't found.
+    PATH="$TOOLS_BIN:/usr/sbin:/sbin"
 
     # check_deps should fail because yq is not in PATH
     ! check_deps

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -190,6 +190,9 @@ if [[ $ERRORS -gt 0 ]]; then
     exit 1
 fi
 
-# Also validate fleet ref referential integrity
-echo ""
-"${SCRIPT_DIR}/validate-fleet-refs.sh"
+# Also validate fleet ref referential integrity (skip if script is not present,
+# e.g. when running from a temp directory in unit tests)
+if [[ -x "${SCRIPT_DIR}/validate-fleet-refs.sh" ]]; then
+    echo ""
+    "${SCRIPT_DIR}/validate-fleet-refs.sh"
+fi


### PR DESCRIPTION
## Summary

- **apply.yml**: replaces the broken `pixi install --locked` (pixi not installed on runner) and manual yq/jq curl installs with `./.github/actions/setup-pixi` — the same composite action used by `lint.yml` and `test.yml`. yq and jq are provided by pixi via conda-forge.
- **test_deps.bats** (#70): restricts PATH to `/usr/sbin:/sbin` in the "yq missing" test, excluding `/bin` and `/usr/bin` where pixi installs yq on CI runners.
- **validate-schemas.sh** (#197, #201, #203): skips `validate-fleet-refs.sh` when the script is not present in the working copy. Unit tests copy `validate-schemas.sh` into a temp dir without `validate-fleet-refs.sh`, causing the exec to fail with a "not found" error.

## Test plan

- [ ] Unit test #70 (`check_deps: returns 1 when yq missing`) passes
- [ ] Unit tests #197, #201, #203 (`valid agent YAML exits 0`, `no YAML files found exits 0`, `valid fleet YAML exits 0`) pass
- [ ] Apply workflow completes without `pixi: command not found`
- [ ] `validate-fleet-refs.sh` still runs on a full repo checkout (script is present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)