### PR TITLE
fix(tests): resolve run_validate command not found in test_validate.bats

### DIFF
--- a/tests/unit/test_validate.bats
+++ b/tests/unit/test_validate.bats
@@ -18,16 +18,20 @@ teardown() {
     [[ -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
 }
 
-# Helper function to run validate script in temp directory
+# Helper function to run validate script in temp directory.
+# NOTE: must be exported so BATS's `run` subshell can resolve it.
 run_validate() {
     cd "$TEST_TMPDIR"
     # The script uses REPO_ROOT derived from its own path, so we need to run it
     # in a way that makes it think the temp dir is the root.
-    # We'll create a tests/validate-schemas.sh symlink in the temp dir
+    # Copy both validate-schemas.sh and validate-fleet-refs.sh so the
+    # in-script call to "${SCRIPT_DIR}/validate-fleet-refs.sh" resolves.
     mkdir -p "$TEST_TMPDIR/tests"
     cp "$SCRIPT_DIR/tests/validate-schemas.sh" "$TEST_TMPDIR/tests/"
+    cp "$SCRIPT_DIR/tests/validate-fleet-refs.sh" "$TEST_TMPDIR/tests/"
     bash "$TEST_TMPDIR/tests/validate-schemas.sh"
 }
+export -f run_validate
 
 # ---------------------------------------------------------------------------
 # Test 1: Valid agent YAML exits 0


### PR DESCRIPTION
## Summary

- BATS's `run` executes in a subshell where bash functions defined in the test file are not visible, causing `run run_validate` to exit with code 127 (command not found).
- Added `export -f run_validate` after the function definition so it is available in BATS's subshell when `run` is called.
- Also copied `validate-fleet-refs.sh` alongside `validate-schemas.sh` in the `run_validate` helper — `validate-schemas.sh` calls it unconditionally on success, so without it the three "valid-input" tests (1, 5, 7) failed even after the export fix.

## Root cause

Two issues combined:
1. `run run_validate` → 127 because BATS subshell can't see the function (fixed by `export -f`)
2. Tests 1, 5, 7 still failed because `validate-schemas.sh` calls `${SCRIPT_DIR}/validate-fleet-refs.sh` at the end, which did not exist in the temp directory (fixed by copying both scripts)

## Test plan

- [ ] `bats tests/unit/test_validate.bats` runs 8/8 tests passing locally
- [ ] CI unit-tests job passes on this PR

Fixes CI run 24872136905 (tests 197, 201, 203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)