### PR TITLE
test(apply-cache): add bash 4+ version guard

### DIFF
--- a/tests/test-apply-cache.sh
+++ b/tests/test-apply-cache.sh
@@ -11,6 +11,12 @@
 
 set -euo pipefail
 
+# Skip entire file on bash < 4 ([[ ]], arrays with [@], and other features require bash 4+)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "SKIP: bash 4+ required (got ${BASH_VERSION})" >&2
+    exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 


### PR DESCRIPTION
Closes #100

Adds a version guard to `tests/test-apply-cache.sh` so it exits gracefully with a clear message (`SKIP: bash 4+ required`) on bash 3 (macOS default) instead of failing cryptically on mapfile / local -n nameref usage.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)