### PR TITLE
fix(validate): read staged content in pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -35,15 +35,22 @@ while IFS= read -r file; do
 
     echo -n "  ${file}: "
 
+    # Helper function to extract YAML field from staged content
+    # Uses `git show :path` to read the staged version, not the working tree
+    get_staged_field() {
+        local yaml_path="$1"
+        git show ":${file}" 2>/dev/null | yq eval "$yaml_path // \"\"" - 2>/dev/null || echo ""
+    }
+
     # Check basic YAML validity
-    if ! yq eval '.' "$file" > /dev/null 2>&1; then
+    if ! git show ":${file}" 2>/dev/null | yq eval '.' - > /dev/null 2>&1; then
         echo "FAIL (invalid YAML)"
         ERRORS=$((ERRORS + 1))
         continue
     fi
 
     # Check apiVersion
-    api_version="$(yq eval '.apiVersion // ""' "$file")"
+    api_version="$(get_staged_field '.apiVersion')"
     if [[ "$api_version" != "myrmidons/v1" ]]; then
         echo "FAIL (apiVersion must be 'myrmidons/v1', got '${api_version}')"
         ERRORS=$((ERRORS + 1))
@@ -51,7 +58,7 @@ while IFS= read -r file; do
     fi
 
     # Check kind
-    kind="$(yq eval '.kind // ""' "$file")"
+    kind="$(get_staged_field '.kind')"
     if [[ "$kind" != "Agent" && "$kind" != "Fleet" ]]; then
         echo "FAIL (kind must be 'Agent' or 'Fleet', got '${kind}')"
         ERRORS=$((ERRORS + 1))
@@ -65,14 +72,14 @@ while IFS= read -r file; do
     fi
 
     # Agent-specific validation
-    name="$(yq eval '.metadata.name // ""' "$file")"
-    host="$(yq eval '.metadata.host // ""' "$file")"
-    program="$(yq eval '.spec.program // ""' "$file")"
-    desired_state="$(yq eval '.spec.desiredState // ""' "$file")"
+    name="$(get_staged_field '.metadata.name')"
+    host="$(get_staged_field '.metadata.host')"
+    program="$(get_staged_field '.spec.program')"
+    desired_state="$(get_staged_field '.spec.desiredState')"
 
     local_errors=()
-    workdir="$(yq eval '.spec.workingDirectory // ""' "$file")"
-    deploy_type="$(yq eval '.spec.deployment.type // "local"' "$file")"
+    workdir="$(get_staged_field '.spec.workingDirectory')"
+    deploy_type="$(get_staged_field '.spec.deployment.type | select(. != null) // "local"')"
 
     [[ -z "$name" ]] && local_errors+=("metadata.name is required")
     [[ -z "$host" ]] && local_errors+=("metadata.host is required")
@@ -98,7 +105,7 @@ while IFS= read -r file; do
 
     # Validate docker image is present when deployment.type=docker
     if [[ "$deploy_type" == "docker" ]]; then
-        docker_image="$(yq eval '.spec.deployment.docker.image // ""' "$file")"
+        docker_image="$(get_staged_field '.spec.deployment.docker.image')"
         [[ -z "$docker_image" ]] && local_errors+=("spec.deployment.docker.image is required when deployment.type is 'docker'")
     fi
 


### PR DESCRIPTION
Closes #107

Updates `hooks/pre-commit` to validate YAML files using `git show ":${file}"` (staged content) instead of reading directly from the working tree. This prevents broken schemas from being committed when a working-tree edit happens to fix staged schema errors.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)