### PR TITLE
feat(diff): field preview on CREATE, --agent filter in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -44,6 +44,19 @@ report:
 plan HOST=host:
     AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}} --dry-run
 
+# Field-level diff: desired YAML vs actual Agamemnon state (optional --agent filter)
+# Usage: just diff               — diff all agents
+#        just diff hermes        — diff agents for a specific host
+#        just diff "" my-agent   — diff a single agent across all hosts
+#        just diff hermes my-agent — diff a single agent on a specific host
+diff HOST="" AGENT="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=()
+    if [[ -n "{{HOST}}" ]]; then args+=({{HOST}}); fi
+    if [[ -n "{{AGENT}}" ]]; then args+=(--agent "{{AGENT}}"); fi
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/diff.sh "${args[@]+"${args[@]}"}"
+
 # =============================================================================
 # Apply
 # =============================================================================

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -173,6 +173,20 @@ diff_agent() {
 
     if [[ -z "$actual_json" ]]; then
         printf "${BOLD}${GREEN}[+] %s${RESET} — not in Agamemnon (would be created)\n" "$name"
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "label:"            "$desired_label"
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "program:"          "$desired_program"
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "workingDirectory:" "$desired_workdir"
+        if [[ -n "$desired_args" ]]; then
+            printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "programArgs:"  "$desired_args"
+        fi
+        if [[ -n "$desired_desc" ]]; then
+            printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "taskDescription:" "$desired_desc"
+        fi
+        if [[ -n "$desired_tags_csv" ]]; then
+            printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "tags:"         "$desired_tags_csv"
+        fi
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "desiredState:"     "$desired_state"
+        echo ""
         return 1
     fi
 


### PR DESCRIPTION
Closes #196
Closes #197

## Summary

- **#197**: When `diff.sh` encounters a CREATE (new agent not yet in Agamemnon), it previously showed only a `[+] <name> — not in Agamemnon (would be created)` banner. Now it also prints all key field values (`label`, `program`, `workingDirectory`, `programArgs`, `taskDescription`, `tags`, `desiredState`) in green so the operator can review exactly what will be created before applying. Optional fields (`programArgs`, `taskDescription`, `tags`) are omitted from the preview when empty.
- **#196**: Added a `diff` recipe to the `justfile` with optional `HOST` and `AGENT` parameters. When `AGENT` is provided it is passed through as `--agent <name>` to `diff.sh` (which already supported that flag). Usage: `just diff`, `just diff hermes`, `just diff "" my-agent`, `just diff hermes my-agent`.

## Test plan

- [ ] `bash -n scripts/diff.sh` — syntax clean (verified)
- [ ] `just diff` — runs diff.sh with no filters
- [ ] `just diff hermes` — runs diff.sh with host filter
- [ ] `just diff "" my-agent` — runs diff.sh with `--agent my-agent`
- [ ] `just diff hermes my-agent` — runs diff.sh with both filters
- [ ] Point to an Agamemnon instance where a new YAML agent hasn't been applied yet; confirm CREATE output now shows field values

🤖 Generated with [Claude Code](https://claude.ai/claude-code)