### PR TITLE
ci: dependency checks in validate.yml, YAML lint, pixi PATH, actionlint shellcheck

### DIFF
--- a/.actionlint.yaml
+++ b/.actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+
+# Explicitly enable shellcheck integration so actionlint lints the shell
+# scripts inside run: steps (#139). By default actionlint skips shellcheck
+# when the binary is not found; with this config the CI step passes
+# -shellcheck shellcheck on the command line so it is always enabled.
+self-hosted-runner:
+  labels: []

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -22,3 +22,11 @@ runs:
           ~/.cache/rattler/cache
         key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
         restore-keys: pixi-${{ runner.os }}-
+
+    - name: Add pixi env tools to PATH
+      shell: bash
+      run: |
+        env_bin=".pixi/envs/${{ inputs.environment }}/bin"
+        if [[ -d "$env_bin" ]]; then
+          echo "$(pwd)/${env_bin}" >> "$GITHUB_PATH"
+        fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,9 @@ jobs:
           actionlint --version
 
       - name: Run actionlint
-        run: actionlint
+        # Pass -shellcheck explicitly so actionlint always lints run: step
+        # scripts through shellcheck even if auto-detection would skip it (#139).
+        run: actionlint -shellcheck shellcheck
 
   security:
     name: Security Scan
@@ -75,6 +77,23 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-pixi
+
+      - name: Check dependencies
+        run: |
+          echo "--- Checking required tools ---"
+          yq --version
+          jq --version
+          bash --version | head -1
+          echo "All required dependencies present."
+
+      - name: Lint workflow YAML files
+        run: |
+          echo "--- Validating workflow YAML files ---"
+          find .github/workflows -name '*.yml' | sort | while read -r f; do
+            echo "  checking: $f"
+            yq eval '.' "$f" > /dev/null
+          done
+          echo "All workflow YAML files are well-formed."
 
       - name: Validate all YAML files
         env:


### PR DESCRIPTION
Closes #75
Closes #83
Closes #134
Closes #139

## Summary

- **#134**: Add a `Add pixi env tools to PATH` step in the `setup-pixi` composite action that appends `.pixi/envs/<environment>/bin` to `$GITHUB_PATH`, ensuring tools like `yq`, `jq`, and `just` installed by pixi are available to all subsequent `run:` steps without prefixing `pixi run`.
- **#75**: Add a `Check dependencies` step to the `validate` job in `validate.yml` that explicitly verifies `yq`, `jq`, and `bash` are present after pixi setup, failing fast with a clear message if any dependency is missing.
- **#83**: Add a `Lint workflow YAML files` step to the `validate` job that iterates over all `.github/workflows/*.yml` files and passes them through `yq eval '.'` to confirm each is well-formed YAML.
- **#139**: Change `actionlint` invocation from `actionlint` to `actionlint -shellcheck shellcheck` so shellcheck is explicitly enabled for `run:` step linting (rather than relying on auto-detection which may silently skip it). Also add `.actionlint.yaml` configuration file documenting this intent.

## Test plan

- [ ] Verify the `validate` CI job passes on this PR
- [ ] Confirm `Check dependencies` step shows `yq`, `jq`, and `bash` versions in the log
- [ ] Confirm `Lint workflow YAML files` step reports all `.github/workflows/*.yml` as well-formed
- [ ] Confirm actionlint now reports shellcheck errors in `run:` blocks if any are introduced
- [ ] Confirm subsequent workflow steps after `setup-pixi` can call `yq`/`jq` directly without `pixi run`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)