### PR TITLE
fix(reconcile): empty array guard, temp file cleanup, tags CSV, bulk yq parse

### DIFF
--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -187,6 +187,15 @@ resolve_fleet_files() {
     local repo_root
     repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+    # Trap to clean up any FLEET_TMPDIR we create on error exit (#158)
+    _resolve_fleet_cleanup() {
+        if [[ -n "${FLEET_TMPDIR:-}" && -d "${FLEET_TMPDIR}" ]]; then
+            rm -rf "${FLEET_TMPDIR}"
+            FLEET_TMPDIR=""
+        fi
+    }
+    trap '_resolve_fleet_cleanup' ERR
+
     local fleet_host
     fleet_host="$(yq eval '.metadata.host // ""' "$fleet_file")"
 
@@ -419,6 +428,8 @@ report_unmanaged() {
     # Guard: nothing to check if Agamemnon returned no agents
     [[ -z "$agents_json" || "$agents_json" == '[]' ]] && return 0
     shift
+    # Guard: nothing to check if no YAML files are managed (#130)
+    [[ $# -eq 0 ]] && return 0
     while IFS= read -r actual_name; do
         log_warn "[-] UNMANAGED ${actual_name} (in Agamemnon but not in desired state — use --prune to remove)"
     done < <(get_unmanaged_names "$agents_json" "$@")
@@ -432,15 +443,15 @@ get_unmanaged_names() {
     # Guard: nothing to check if Agamemnon returned no agents
     [[ -z "$agents_json" || "$agents_json" == '[]' ]] && return 0
     shift
+    # Guard: nothing to check if no YAML files are managed (#130)
+    [[ $# -eq 0 ]] && return 0
     local yaml_files=("$@")
 
-    # Collect all managed names from YAML files
+    # Collect all managed names from YAML files in a single yq invocation (#233)
     local managed_names=()
-    for yaml_file in "${yaml_files[@]}"; do
-        local n
-        n="$(yq eval '.metadata.name' "$yaml_file")"
-        managed_names+=("$n")
-    done
+    while IFS= read -r n; do
+        [[ -n "$n" ]] && managed_names+=("$n")
+    done < <(yq eval '.metadata.name' "${yaml_files[@]}")
 
     # Emit names present in Agamemnon but absent from managed list
     while IFS= read -r actual_name; do


### PR DESCRIPTION
Closes #130
Closes #158
Closes #198
Closes #233

## Summary

- **#130**: Add `[[ $# -eq 0 ]] && return 0` guard at the start of both `report_unmanaged` and `get_unmanaged_names` (after shifting off `agents_json`) to prevent all Agamemnon agents from being falsely reported as unmanaged when no YAML files are managed
- **#158**: Add an `ERR` trap in `resolve_fleet_files` that calls `_resolve_fleet_cleanup` to remove `FLEET_TMPDIR` if any command fails unexpectedly, preventing temp directory leaks on error exit
- **#198**: Extract `tags` from the parsed YAML fields in `plan.sh` `plan_agent` and pass it as `$9` to `compute_drift`, matching how `apply.sh` and `status.sh` already call it — so tag drift is now correctly detected during dry-run planning
- **#233**: Replace the per-file `yq` loop in `get_unmanaged_names` with a single `yq eval '.metadata.name' "${yaml_files[@]}"` call across all files, reducing O(N) yq spawns to a single invocation

## Test plan

- [ ] `bash -n scripts/lib/reconcile.sh` passes (confirmed)
- [ ] `bash -n scripts/plan.sh` passes (confirmed)
- [ ] Call `report_unmanaged '[]' ` with empty yaml_files — returns 0 immediately without output
- [ ] Call `report_unmanaged '[{"name":"foo"}]'` with no yaml_files — returns 0 without flagging `foo` as unmanaged
- [ ] Run `resolve_fleet_files` against a fleet with a bad ref; verify FLEET_TMPDIR is cleaned up
- [ ] Run `plan.sh` against an agent with changed tags — verify it shows an UPDATE action
- [ ] Run `plan.sh` against a large agent fleet — confirm only one `yq` process spawns for unmanaged check

🤖 Generated with [Claude Code](https://claude.ai/claude-code)