### PR TITLE
fix(plan): reject unknown args, replace grep -P with -E, fix function name shadowing

### DIFF
--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -34,6 +34,7 @@ parse_args() {
             --fleet)    FLEET_NAME="$2"; shift 2 ;;
             --output)   shift 2 ;;  # Accepted but ignored in plan (no JSON report)
             --webhook)  shift 2 ;;  # Accepted but ignored in plan
+            -*) echo "ERROR: Unknown argument: $1" >&2; usage; exit 1 ;;
             *) HOST="$1"; shift ;;
         esac
     done
@@ -48,6 +49,13 @@ usage() {
     echo "  $0                        # Plan all agents"
     echo "  $0 hermes                 # Plan agents on hermes"
     echo "  $0 --fleet dev-mesh       # Plan agents in the dev-mesh fleet"
+}
+
+# plan_report_unmanaged wraps reconcile.sh's report_unmanaged to avoid
+# shadowing if a local function of the same name were ever defined here.
+# (#273: prevent name collision with reconcile.sh's report_unmanaged)
+plan_report_unmanaged() {
+    report_unmanaged "$@"
 }
 
 main() {
@@ -85,7 +93,7 @@ main() {
     # Report unmanaged agents (in Agamemnon but not in YAML)
     log_info ""
     log_info "Checking for unmanaged agents..."
-    report_unmanaged "$agents_json" "${yaml_files[@]}"
+    plan_report_unmanaged "$agents_json" "${yaml_files[@]}"
 
     log_info ""
     if [[ $has_changes -eq 0 ]]; then

--- a/tests/detect-doc-drift.sh
+++ b/tests/detect-doc-drift.sh
@@ -63,7 +63,7 @@ for file in "${DOC_FILES[@]}"; do
         pattern="${entry%%|*}"
         description="${entry#*|}"
 
-        if grep -Piq "${pattern}" "${file}" 2>/dev/null; then
+        if grep -Eiq "${pattern}" "${file}" 2>/dev/null; then
             if [[ $file_errors -eq 0 ]]; then
                 echo "  FAIL: ${rel}"
             fi


### PR DESCRIPTION
Closes #70
Closes #262
Closes #273

- plan.sh now rejects unknown arguments (flags starting with `-`) with a clear error message and usage hint (#70)
- Replace `grep -Piq` (PCRE, unavailable on macOS BSD grep) with `grep -Eiq` (POSIX ERE) in `tests/detect-doc-drift.sh` (#262)
- Introduce `plan_report_unmanaged` wrapper in `plan.sh` to prevent future shadowing of `reconcile.sh`'s `report_unmanaged` function (#273)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)