### PR TITLE
ci(lint): pin shellcheck version, add pre-commit CI job, pin hook SHAs, add shellcheck hook

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,12 +7,13 @@ on:
       - 'agents/**'
       - 'fleets/**'
       - 'scripts/**'
+      - 'hooks/**'
       - '.github/workflows/**'
       - 'schemas/**'
       - '.myrmidons.yaml'
+      - '.pre-commit-config.yaml'
       - 'pixi.toml'
       - 'pixi.lock'
-      - 'hooks/**'
       - 'tests/**'
       - 'CHANGELOG.md'
 
@@ -125,6 +126,19 @@ jobs:
           echo "To skip this check, include [skip changelog] in the PR title, body,"
           echo "any commit message, or add the 'skip changelog' label to the PR."
           exit 1
+
+  pre-commit:
+    name: Pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pixi
+        with:
+          environment: lint
+
+      - name: Run pre-commit on all files
+        run: pixi run --environment lint pre-commit run --all-files
 
   validate:
     name: Validate YAML Schemas

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,14 +10,14 @@ repos:
 
   # Shell script linting
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: a23f6b85d0fdd5bb9d564e2579e678033debbdff  # v0.10.0.1
     hooks:
       - id: shellcheck
         args: [--severity=warning]
 
   # YAML linting for agents/ and fleets/
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6  # v1.35.1
     hooks:
       - id: yamllint
         files: ^(agents|fleets)/.*\.yaml$

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ bats-core = ">=1.11,<2"
 curl      = ">=8.0"
 
 [feature.lint.dependencies]
-shellcheck = ">=0.10,<1"
+shellcheck = "0.10.0.*"
 yamllint   = ">=1.35,<2"
 pre-commit = ">=3.0,<5"
 


### PR DESCRIPTION
Closes #136
Closes #188
Closes #189
Closes #215

## Changes

- **#136 — Pin shellcheck version**: `pixi.toml` now specifies `shellcheck = "0.10.0.*"` instead of `>=0.10,<1`, ensuring reproducible lint results across all environments.
- **#188 — Add pre-commit CI job**: New `pre-commit` job in `validate.yml` runs `pre-commit run --all-files` on every PR using the `lint` pixi environment. Also expanded the `paths` trigger to include `hooks/**` and `.pre-commit-config.yaml`.
- **#189 — Pin hook revisions to SHAs**: All three external hooks in `.pre-commit-config.yaml` now use commit SHAs instead of version tags, with the original tag as an inline comment for readability.
  - `pre-commit-hooks` v5.0.0 → `cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b`
  - `shellcheck-py` v0.10.0.1 → `a23f6b85d0fdd5bb9d564e2579e678033debbdff`
  - `yamllint` v1.35.1 → `81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6`
- **#215 — shellcheck pre-commit hook**: The `shellcheck-py` hook was already present in `.pre-commit-config.yaml`; this PR ensures it is retained and now SHA-pinned.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)