### PR TITLE
feat(export): enforce label-derived filename convention

### DIFF
--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -59,11 +59,11 @@ check_jq() {
     fi
 }
 
-# Derive a safe filename from agent name (replaces - and _ with -)
-agent_filename() {
-    local name="$1"
-    # Use label (lowercased) if available, else use name
-    echo "${name}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-'
+# Derive the canonical filename stem from a label (lowercase, spaces→hyphens)
+# Convention: filename = lowercase(spec.label) + ".yaml"
+label_to_stem() {
+    local lbl="$1"
+    echo "${lbl}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-'
 }
 
 # Map program name → default AchaeanFleet image name
@@ -109,10 +109,18 @@ export_agent() {
     local tags_yaml
     tags_yaml="$(echo "$agent_json" | jq -r '.tags // [] | if length == 0 then "  tags: []" else "  tags:\n" + (map("    - " + .) | join("\n")) end')"
 
-    # Determine filename from label (lowercased, spaces→dashes)
+    # Derive filename from label per convention: filename = lowercase(spec.label) + ".yaml"
     local label_lower
-    label_lower="$(echo "$label" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
+    label_lower="$(label_to_stem "$label")"
     local outfile="${OUTPUT_DIR}/${label_lower}.yaml"
+
+    # Warn if a stale file exists under the old name-derived path that would not be overwritten
+    local name_lower
+    name_lower="$(label_to_stem "$name")"
+    local name_outfile="${OUTPUT_DIR}/${name_lower}.yaml"
+    if [[ "$name_lower" != "$label_lower" && -e "$name_outfile" ]]; then
+        log_warn "  WARN: stale file '${name_outfile}' may exist from a prior name-based export; label-derived path is '${outfile}'"
+    fi
 
     # Handle model: if "null" string, write null (no quotes)
     local model_yaml

--- a/tests/fixtures/agents/hermes/duplicate-name-a.yaml
+++ b/tests/fixtures/agents/hermes/duplicate-name-a.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-duplicate-name
   host: hermes
 spec:
-  label: DuplicateA
+  label: Duplicate-Name-A
   program: claude-code
   model: null
   workingDirectory: /tmp

--- a/tests/fixtures/agents/hermes/duplicate-name-b.yaml
+++ b/tests/fixtures/agents/hermes/duplicate-name-b.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-duplicate-name
   host: hermes
 spec:
-  label: DuplicateB
+  label: Duplicate-Name-B
   program: aider
   model: null
   workingDirectory: /tmp

--- a/tests/fixtures/agents/hermes/invalid-docker-no-image.yaml
+++ b/tests/fixtures/agents/hermes/invalid-docker-no-image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-docker-no-image
   host: hermes
 spec:
-  label: DockerNoImage
+  label: Invalid-Docker-No-Image
   program: claude-code
   model: null
   workingDirectory: /tmp

--- a/tests/fixtures/agents/hermes/invalid-label-mismatch.yaml
+++ b/tests/fixtures/agents/hermes/invalid-label-mismatch.yaml
@@ -1,15 +1,15 @@
 apiVersion: myrmidons/v1
 kind: Agent
 metadata:
-  name: test-host-mismatch
+  name: test-label-mismatch
   host: hermes
 spec:
-  label: Invalid-Host-Mismatch
+  label: WrongLabelName
   program: claude-code
   model: null
   workingDirectory: /tmp
   programArgs: ""
-  taskDescription: "Agent where host does not match directory"
+  taskDescription: "Agent where filename stem does not match lowercase(spec.label)"
   tags: [test]
   owner: mvillmow
   role: member

--- a/tests/fixtures/agents/hermes/invalid-program.yaml
+++ b/tests/fixtures/agents/hermes/invalid-program.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-invalid-program
   host: hermes
 spec:
-  label: BadProgram
+  label: Invalid-Program
   program: badvalue
   model: null
   workingDirectory: /tmp

--- a/tests/fixtures/agents/hermes/valid-agent.yaml
+++ b/tests/fixtures/agents/hermes/valid-agent.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-valid-agent
   host: hermes
 spec:
-  label: ValidAgent
+  label: Valid-Agent
   program: claude-code
   model: null
   workingDirectory: /tmp

--- a/tests/fixtures/agents/hermes/valid-docker-agent.yaml
+++ b/tests/fixtures/agents/hermes/valid-docker-agent.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-valid-docker-agent
   host: hermes
 spec:
-  label: ValidDockerAgent
+  label: Valid-Docker-Agent
   program: claude-code
   model: null
   workingDirectory: /tmp

--- a/tests/test-validate-schemas.sh
+++ b/tests/test-validate-schemas.sh
@@ -213,6 +213,26 @@ rm -rf "$tree"
 assert_exit "unique names exits 0" 0 "$rc" "$output"
 assert_output_not_contains "no duplicate error when names unique" "duplicate metadata.name" "$output"
 
+# ─── Test 9: valid agent with matching label/filename passes without warning ───
+echo ""
+echo "Test 9: agent with matching filename stem and spec.label passes without naming warning"
+tree=$(make_tree "${FIXTURES_DIR}/agents/hermes/valid-agent.yaml")
+output=$(run_validator "$tree" 2>&1)
+rc=$?
+rm -rf "$tree"
+assert_exit "matching label/filename exits 0" 0 "$rc" "$output"
+assert_output_not_contains "no naming warning when convention followed" "does not match lowercase(spec.label)" "$output"
+
+# ─── Test 10: agent with mismatched label/filename emits naming warning ────────
+echo ""
+echo "Test 10: agent with filename stem not matching lowercase(spec.label) warns"
+tree=$(make_tree "${FIXTURES_DIR}/agents/hermes/invalid-label-mismatch.yaml")
+output=$(run_validator "$tree" 2>&1)
+rc=$?
+rm -rf "$tree"
+assert_exit "mismatched label/filename still exits 0 (warning only)" 0 "$rc" "$output"
+assert_output_contains "naming mismatch warning emitted" "does not match lowercase(spec.label)" "$output"
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/tests/validate-schemas.sh
+++ b/tests/validate-schemas.sh
@@ -143,6 +143,17 @@ while IFS= read -r -d '' file; do
         fi
     fi
 
+    # Warn if filename stem does not match lowercase(spec.label) per naming convention
+    # Convention: filename = lowercase(spec.label) + ".yaml"  (see CLAUDE.md)
+    lbl="$(yq eval '.spec.label // ""' "$file")"
+    if [[ -n "$lbl" ]]; then
+        expected_stem="$(echo "$lbl" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
+        actual_stem="$(basename "$file" .yaml)"
+        if [[ "$actual_stem" != "$expected_stem" ]]; then
+            echo "WARNING: ${file#"${REPO_ROOT}/"}: filename stem '${actual_stem}' does not match lowercase(spec.label) '${expected_stem}' (label='${lbl}')" >&2
+        fi
+    fi
+
     # Warn if workingDirectory does not exist (skipped in CI)
     if [[ -n "$workdir" && "${CI:-}" != "true" ]]; then
         if [[ ! -d "$workdir" ]]; then


### PR DESCRIPTION
Closes #55
Closes #252

## Summary

- **`scripts/export.sh`**: Renames the dead `agent_filename()` helper to `label_to_stem()` (clearly documenting the convention), uses it consistently in `export_agent`, and adds a warning when a stale name-derived file exists alongside the correct label-derived path (catches prior-export drift).
- **`tests/validate-schemas.sh`**: Adds a naming-convention check for Agent files — warns to stderr when the filename stem doesn't match `lowercase(spec.label)`. Non-blocking (warning only) to stay backward-compatible with pre-existing files like the `issue8-*` agents whose labels contain spaces and punctuation.
- **`tests/test-validate-schemas.sh`**: Two new tests (9 & 10) covering matching and mismatching label/filename cases. All 27 tests pass.
- **Fixtures**: Updated all fixture `spec.label` values to follow the convention; added `invalid-label-mismatch.yaml` for the warning test.

## Test plan

- [x] `bash -n scripts/export.sh` — syntax OK
- [x] `pixi run --environment lint bash tests/test-validate-schemas.sh` — 27/27 pass
- [x] `CI=true pixi run --environment lint bash tests/validate-schemas.sh` — 0 errors; issue8-* files emit expected warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)