### PR TITLE
feat(rollback): snapshot before restore, apply context in snapshots, round-trip test

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -35,6 +35,8 @@ DRY_RUN=0
 OUTPUT_FORMAT="text"   # "text" | "json"
 WEBHOOK_URL=""
 AIM_LOCK_TIMEOUT="${AIM_LOCK_TIMEOUT:-60}"
+SNAPSHOT_DIR=""
+SNAPSHOT_KEEP="${SNAPSHOT_KEEP:-10}"
 
 CREATED=0
 UPDATED=0
@@ -52,6 +54,7 @@ parse_args() {
             --lock-timeout)     AIM_LOCK_TIMEOUT="$2"; shift 2 ;;
             --output)           OUTPUT_FORMAT="$2"; shift 2 ;;
             --webhook)          WEBHOOK_URL="$2"; shift 2 ;;
+            --snapshot-dir)     SNAPSHOT_DIR="$2"; shift 2 ;;
             --force)            shift ;;  # Consume --force (applies during actual apply, not dry-run)
             -h|--help)          usage; exit 0 ;;
             *) HOST="$1"; shift ;;
@@ -76,6 +79,8 @@ Options:
   --output json        Emit a JSON reconciliation report to stdout instead of
                        human-readable text. Also saves to reports/last-reconciliation.json.
   --webhook URL        POST the JSON report to URL after reconciliation completes.
+  --snapshot-dir DIR   Directory for pre-apply snapshots (default: .myrmidons/snapshots).
+                       Also configurable via SNAPSHOT_DIR env var.
   -h, --help           Show this help
 
 Examples:
@@ -112,7 +117,7 @@ main() {
                 --force | --dry-run)
                     continue
                     ;;
-                --lock-timeout)
+                --lock-timeout | --snapshot-dir)
                     skip_next=1
                     continue
                     ;;
@@ -151,6 +156,15 @@ main() {
 
     local agents_json
     agents_json="$(agamemnon_list_agents)"
+
+    # Capture pre-apply snapshot (#228: includes context fields user/branch/host/timestamp)
+    local effective_snapshot_dir="${SNAPSHOT_DIR:-${repo_root}/.myrmidons/snapshots}"
+    local snap_file
+    snap_file="$(snapshot_write "$agents_json" "$effective_snapshot_dir" "${HOST:-all}")"
+    snapshot_prune "$effective_snapshot_dir" "$SNAPSHOT_KEEP"
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo "Snapshot saved: ${snap_file}"
+    fi
 
     local yaml_files
     mapfile -t yaml_files < <(get_agent_files "$HOST")

--- a/scripts/lib/report.sh
+++ b/scripts/lib/report.sh
@@ -190,6 +190,94 @@ report_cleanup() {
     [[ -n "${_REPORT_UNMANAGED_TMP:-}" && -f "$_REPORT_UNMANAGED_TMP" ]] && rm -f "$_REPORT_UNMANAGED_TMP"
 }
 
+# ---------------------------------------------------------------------------
+# Snapshot functions — capture agent state before apply or rollback (#228, #225)
+# ---------------------------------------------------------------------------
+
+# Write a snapshot of current agent state to the snapshot directory.
+# Adds context fields: user, git_branch, host, timestamp.
+#
+# Usage: snapshot_write <agents_json> <snapshot_dir> <host> [suffix]
+#   agents_json   — JSON array string of current agent objects from Agamemnon
+#   snapshot_dir  — directory to write snapshot files into
+#   host          — host argument passed to apply/rollback (or "all")
+#   suffix        — optional filename suffix before .json (e.g. "pre-rollback")
+#
+# Outputs the path of the written snapshot file.
+snapshot_write() {
+    local agents_json="$1"
+    local snapshot_dir="$2"
+    local host="${3:-all}"
+    local suffix="${4:-}"
+
+    mkdir -p "$snapshot_dir"
+
+    local timestamp git_branch run_user
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    git_branch="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../.." rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+    run_user="${USER:-unknown}"
+
+    local filename="${timestamp}"
+    [[ -n "$suffix" ]] && filename="${timestamp}.${suffix}"
+    local snapshot_file="${snapshot_dir}/${filename}.json"
+
+    jq -n \
+        --arg timestamp "$timestamp" \
+        --arg git_branch "$git_branch" \
+        --arg host "$host" \
+        --arg user "$run_user" \
+        --argjson agents "$agents_json" \
+        '{
+            context: {
+                timestamp:  $timestamp,
+                user:       $user,
+                git_branch: $git_branch,
+                host:       $host
+            },
+            agents: $agents
+        }' > "$snapshot_file"
+
+    echo "$snapshot_file"
+}
+
+# Prune old snapshots in a directory, keeping at most SNAPSHOT_KEEP files.
+# Skips files that contain a suffix (e.g. pre-rollback) from pruning count
+# to avoid deleting safety nets.
+#
+# Usage: snapshot_prune <snapshot_dir> [keep_count]
+snapshot_prune() {
+    local snapshot_dir="$1"
+    local keep="${2:-${SNAPSHOT_KEEP:-10}}"
+
+    [[ ! -d "$snapshot_dir" ]] && return 0
+
+    # Only count/prune regular (non-suffixed) snapshots:
+    # Suffixed snapshots (*.pre-rollback.json etc.) are retained separately.
+    local regular_snapshots=()
+    mapfile -t regular_snapshots < <(
+        find "$snapshot_dir" -maxdepth 1 -name "*.json" \
+            | grep -v '\.' | sort || true
+        # fallback: match ISO timestamp pattern only (no dots in stem)
+        find "$snapshot_dir" -maxdepth 1 -name "*T*Z.json" \
+            | grep -E '/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\.json$' \
+            | sort
+    )
+
+    # Deduplicate
+    local -A seen=()
+    local deduped=()
+    for f in "${regular_snapshots[@]}"; do
+        [[ -z "${seen[$f]:-}" ]] && deduped+=("$f") && seen["$f"]=1
+    done
+
+    local count=${#deduped[@]}
+    if [[ $count -gt $keep ]]; then
+        local excess=$(( count - keep ))
+        # Remove oldest first (sort ascending, take head)
+        printf '%s\n' "${deduped[@]}" | sort | head -n "$excess" | xargs rm -f
+    fi
+}
+
 # Build a drift JSON array from an UPDATE:<fields> action string and the actual/desired values.
 # Usage: build_drift_json <action_string> <actual_json> \
 #                         <desired_label> <desired_program> <desired_workdir> \

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -23,6 +23,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # shellcheck source=scripts/lib/api.sh
 source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${SCRIPT_DIR}/lib/report.sh"
 
 SNAPSHOT_DIR="${REPO_ROOT}/.myrmidons/snapshots"
 SNAPSHOT_FILE=""
@@ -87,7 +89,8 @@ list_snapshots() {
         local basename
         basename="$(basename "$snap")"
         local agent_count
-        agent_count="$(jq 'length' "$snap" 2>/dev/null || echo "?")"
+        # Support both new format {context:{}, agents:[]} and legacy plain array
+        agent_count="$(jq 'if type == "object" and has("agents") then .agents | length elif type == "array" then length else 0 end' "$snap" 2>/dev/null || echo "?")"
         local marker=""
         [[ $i -eq 0 ]] && marker=" ← most recent"
         printf "  %s  (%s agents)%s\n" "$basename" "$agent_count" "$marker"
@@ -122,10 +125,20 @@ validate_snapshot() {
         return 1
     fi
 
-    if ! jq -e '. | type == "array"' "$snapshot_file" > /dev/null 2>&1; then
+    # Accept both new format {context:{},agents:[]} and legacy plain array
+    if ! jq -e '(type == "array") or (type == "object" and has("agents") and (.agents | type == "array"))' \
+            "$snapshot_file" > /dev/null 2>&1; then
         echo "ERROR: Snapshot is not a valid JSON array: ${snapshot_file}" >&2
         return 1
     fi
+}
+
+# Extract the agents array from a snapshot file.
+# Handles both new {context,agents} format and legacy plain-array format.
+# Usage: extract_snapshot_agents <snapshot_file>  → JSON array on stdout
+extract_snapshot_agents() {
+    local snapshot_file="$1"
+    jq 'if type == "object" and has("agents") then .agents else . end' "$snapshot_file"
 }
 
 restore_agent() {
@@ -250,7 +263,7 @@ main() {
     echo ""
 
     local snapshot_agents
-    snapshot_agents="$(cat "$SNAPSHOT_FILE")"
+    snapshot_agents="$(extract_snapshot_agents "$SNAPSHOT_FILE")"
 
     local agent_count
     agent_count="$(echo "$snapshot_agents" | jq 'length')"
@@ -264,6 +277,14 @@ main() {
     local current_agents_json="{}"
     if [[ $DRY_RUN -eq 0 ]]; then
         current_agents_json="$(agamemnon_list_agents)"
+    fi
+
+    # (#225) Snapshot current state before restoring, to enable chained rollbacks.
+    if [[ $DRY_RUN -eq 0 ]]; then
+        local pre_rollback_snap
+        pre_rollback_snap="$(snapshot_write "$current_agents_json" "$SNAPSHOT_DIR" "all" "pre-rollback")"
+        echo "Pre-rollback snapshot saved: ${pre_rollback_snap}"
+        echo ""
     fi
 
     # Restore each agent from the snapshot

--- a/tests/integration/test_apply_rollback_roundtrip.bats
+++ b/tests/integration/test_apply_rollback_roundtrip.bats
@@ -1,0 +1,243 @@
+#!/usr/bin/env bats
+# tests/integration/test_apply_rollback_roundtrip.bats
+#
+# Integration test: full apply -> rollback round-trip (#227)
+#
+# Mocks the Agamemnon API, runs apply.sh to snapshot + reconcile, then
+# runs rollback.sh and verifies the pre-rollback snapshot is created and
+# the restore is attempted.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+MOCK_PORT=18082
+MOCK_PID_FILE="/tmp/bats-roundtrip-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+    # Isolated temp workspace for this test run
+    TEST_WORKSPACE="$(mktemp -d)"
+    export TEST_WORKSPACE
+
+    # Create minimal agents directory with one agent YAML
+    mkdir -p "${TEST_WORKSPACE}/agents/hermes"
+    printf 'apiVersion: myrmidons/v1\nkind: Agent\nmetadata:\n  name: roundtrip-agent\n  host: hermes\nspec:\n  label: RoundTrip Agent\n  program: claude-code\n  model: null\n  workingDirectory: /tmp/roundtrip\n  programArgs: ""\n  taskDescription: "Integration test agent"\n  tags: [integration, test]\n  owner: testuser\n  role: member\n  deployment:\n    type: local\n  desiredState: active\n' \
+        > "${TEST_WORKSPACE}/agents/hermes/roundtrip-agent.yaml"
+
+    SNAPSHOT_DIR="${TEST_WORKSPACE}/.myrmidons/snapshots"
+    export SNAPSHOT_DIR
+}
+
+teardown() {
+    _stop_mock_server
+    rm -rf "${TEST_WORKSPACE:-}"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: count files matching a pattern in SNAPSHOT_DIR
+# ---------------------------------------------------------------------------
+
+_count_snapshots() {
+    local pattern="${1:-*.json}"
+    find "$SNAPSHOT_DIR" -maxdepth 1 -name "$pattern" 2>/dev/null | wc -l
+}
+
+# ---------------------------------------------------------------------------
+# Test: apply creates a pre-apply snapshot with context fields (#228)
+# ---------------------------------------------------------------------------
+
+@test "apply: creates snapshot with context fields (user, git_branch, host, timestamp)" {
+    # Mock: health check OK, list returns empty (no existing agents)
+    _start_mock_server 200 '[]'
+
+    # Run apply.sh, pointing snapshot-dir to our isolated workspace
+    run bash "${SCRIPT_DIR}/scripts/apply.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # A snapshot file must have been written
+    local snap_count
+    snap_count="$(_count_snapshots '*.json')"
+    [[ "$snap_count" -ge 1 ]]
+
+    # Find the snapshot and verify context fields
+    local snap_file
+    snap_file="$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*.json' | head -1)"
+    [[ -f "$snap_file" ]]
+
+    local snap_json
+    snap_json="$(cat "$snap_file")"
+
+    # Must have a context object
+    echo "$snap_json" | jq -e '.context' > /dev/null
+
+    # context.user must be non-empty
+    local ctx_user
+    ctx_user="$(echo "$snap_json" | jq -r '.context.user')"
+    [[ -n "$ctx_user" && "$ctx_user" != "null" ]]
+
+    # context.git_branch must be non-empty
+    local ctx_branch
+    ctx_branch="$(echo "$snap_json" | jq -r '.context.git_branch')"
+    [[ -n "$ctx_branch" && "$ctx_branch" != "null" ]]
+
+    # context.timestamp must match ISO-8601 pattern
+    local ctx_ts
+    ctx_ts="$(echo "$snap_json" | jq -r '.context.timestamp')"
+    [[ "$ctx_ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+
+    # context.host field must be present
+    echo "$snap_json" | jq -e '.context.host' > /dev/null
+
+    # agents array must be present
+    echo "$snap_json" | jq -e '.agents | type == "array"' > /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Test: apply -> rollback round-trip (#227)
+# Apply runs, writes a snapshot. Rollback reads it, writes pre-rollback
+# snapshot, and attempts to restore.
+# ---------------------------------------------------------------------------
+
+@test "round-trip: apply creates snapshot, rollback creates pre-rollback snapshot" {
+    # Mock: health OK, list returns one agent already existing
+    local existing_agent
+    existing_agent='[{"id":"existing-id","name":"roundtrip-agent","status":"active","label":"RoundTrip Agent","program":"claude-code","workingDirectory":"/tmp/roundtrip","programArgs":"","taskDescription":"Integration test agent","tags":["integration","test"],"owner":"testuser","role":"member"}]'
+    _start_mock_server 200 "$existing_agent"
+
+    # Step 1: run apply.sh -- should write a pre-apply snapshot
+    run bash "${SCRIPT_DIR}/scripts/apply.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # Verify at least one snapshot was created
+    local snap_count_before
+    snap_count_before="$(_count_snapshots '*.json')"
+    [[ "$snap_count_before" -ge 1 ]]
+
+    _stop_mock_server
+
+    # Step 2: restart mock so rollback can call agamemnon_check_connection and list
+    _start_mock_server 200 "$existing_agent"
+
+    # Step 3: run rollback.sh pointing at our snapshot dir.
+    # It should: (a) find the snapshot, (b) list current agents, (c) write pre-rollback snapshot
+    run bash "${SCRIPT_DIR}/scripts/rollback.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # A pre-rollback snapshot must now exist (filename contains "pre-rollback")
+    local pre_rollback_count
+    pre_rollback_count="$(_count_snapshots '*.pre-rollback.json')"
+    [[ "$pre_rollback_count" -ge 1 ]]
+
+    # The rollback output must mention the pre-rollback snapshot
+    [[ "$output" == *"pre-rollback"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: rollback --dry-run does NOT write a pre-rollback snapshot (#225)
+# ---------------------------------------------------------------------------
+
+@test "rollback --dry-run: does not write pre-rollback snapshot" {
+    # Create a minimal snapshot manually so rollback has something to read
+    mkdir -p "$SNAPSHOT_DIR"
+    local ts
+    ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    jq -n \
+        --arg ts "$ts" \
+        '{context:{timestamp:$ts,user:"ci",git_branch:"main",host:"all"},agents:[{"id":"a1","name":"roundtrip-agent","status":"active"}]}' \
+        > "${SNAPSHOT_DIR}/${ts}.json"
+
+    run bash "${SCRIPT_DIR}/scripts/rollback.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        --dry-run \
+        2>&1
+
+    # No pre-rollback snapshot should have been written during dry-run
+    local pre_rollback_count
+    pre_rollback_count="$(_count_snapshots '*.pre-rollback.json')"
+    [[ "$pre_rollback_count" -eq 0 ]]
+
+    # Output should contain DRY-RUN or Dry run marker
+    [[ "$output" == *"DRY-RUN"* || "$output" == *"Dry run"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: rollback can restore from a snapshot written by apply (#227 full cycle)
+# ---------------------------------------------------------------------------
+
+@test "round-trip: rollback reads apply snapshot and attempts restore of each agent" {
+    # Write a snapshot that looks like it came from apply
+    mkdir -p "$SNAPSHOT_DIR"
+    local ts
+    ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    jq -n \
+        --arg ts "$ts" \
+        '{
+            context: {timestamp:$ts, user:"testuser", git_branch:"main", host:"hermes"},
+            agents: [{
+                id: "agent-id-1",
+                name: "roundtrip-agent",
+                status: "active",
+                label: "RoundTrip Agent",
+                program: "claude-code",
+                workingDirectory: "/tmp/roundtrip",
+                programArgs: "",
+                taskDescription: "Integration test agent",
+                tags: ["integration","test"],
+                owner: "testuser",
+                role: "member"
+            }]
+        }' > "${SNAPSHOT_DIR}/${ts}.json"
+
+    # Mock: current live state (agent exists, will be patched during restore)
+    local live_agents
+    live_agents='[{"id":"agent-id-1","name":"roundtrip-agent","status":"active","label":"RoundTrip Agent","program":"claude-code","workingDirectory":"/tmp/roundtrip","programArgs":"","taskDescription":"Integration test agent","tags":["integration","test"],"owner":"testuser","role":"member"}]'
+    _start_mock_server 200 "$live_agents"
+
+    run bash "${SCRIPT_DIR}/scripts/rollback.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # Rollback must mention the agent being processed
+    [[ "$output" == *"roundtrip-agent"* ]]
+
+    # A pre-rollback snapshot must have been created
+    local pre_rollback_count
+    pre_rollback_count="$(_count_snapshots '*.pre-rollback.json')"
+    [[ "$pre_rollback_count" -ge 1 ]]
+
+    # Verify the pre-rollback snapshot is valid JSON with context
+    local pre_snap
+    pre_snap="$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*.pre-rollback.json' | head -1)"
+    jq -e '.context' "$pre_snap" > /dev/null
+    jq -e '.agents | type == "array"' "$pre_snap" > /dev/null
+}


### PR DESCRIPTION
Closes #225
Closes #227
Closes #228

## Summary

- **#228** — `scripts/lib/report.sh`: new `snapshot_write()` function writes pre-apply/pre-rollback snapshots with `context` object containing `user`, `git_branch`, `host`, and `timestamp` fields. New `snapshot_prune()` keeps the snapshot directory bounded.
- **#228** — `scripts/apply.sh`: calls `snapshot_write()` before reconciling; adds `--snapshot-dir DIR` flag and respects `SNAPSHOT_KEEP` env var.
- **#225** — `scripts/rollback.sh`: sources `report.sh`, captures current live state to a `.pre-rollback`-suffixed snapshot before restoring any agent; handles both new `{context, agents}` and legacy plain-array snapshot formats.
- **#227** — `tests/integration/test_apply_rollback_roundtrip.bats`: 4 bats integration tests covering apply snapshot creation with context fields, full apply→rollback round-trip, dry-run safety (no pre-rollback snapshot written), and end-to-end restore cycle verification.

## Test plan

- [x] `bats tests/integration/test_apply_rollback_roundtrip.bats` — 4/4 pass
- [x] `bash tests/test-rollback.sh` — 20/20 pass (no regressions)
- [x] `bash -n scripts/apply.sh scripts/rollback.sh scripts/lib/report.sh` — all pass syntax check

🤖 Generated with [Claude Code](https://claude.ai/claude-code)