### PR TITLE
feat(config): source config.sh everywhere, validate URL in all scripts, validate host arg

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -21,13 +21,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
 # shellcheck source=scripts/lib/api.sh
 source "${SCRIPT_DIR}/lib/api.sh"
 # shellcheck source=scripts/lib/reconcile.sh
 source "${SCRIPT_DIR}/lib/reconcile.sh"
 # shellcheck source=scripts/lib/report.sh
 source "${SCRIPT_DIR}/lib/report.sh"
+
+load_config
 
 HOST=""
 PRUNE=0
@@ -95,6 +100,17 @@ main() {
 
     parse_args "$@"
 
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
+    # Validate HOST argument against known agents/ subdirectories (#149)
+    if [[ -n "$HOST" && ! -d "${REPO_ROOT}/agents/${HOST}" ]]; then
+        echo "ERROR: Host '${HOST}' not found — no agents/${HOST}/ directory exists." >&2
+        echo "  Known hosts: $(find "${REPO_ROOT}/agents" -mindepth 1 -maxdepth 1 -type d \
+            ! -name '_templates' -printf '%f ' 2>/dev/null || echo '(none)')" >&2
+        exit 1
+    fi
+
     # Export AIM_LOCK_TIMEOUT for use by child processes (e.g. api.sh)
     export AIM_LOCK_TIMEOUT
 
@@ -129,12 +145,10 @@ main() {
     agamemnon_check_connection
 
     # Check for agents/ and fleets/ directories
-    local repo_root
-    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
     local has_agents=false
     local has_fleets=false
-    [[ -d "${repo_root}/agents/" ]] && has_agents=true
-    [[ -d "${repo_root}/fleets/" ]] && has_fleets=true
+    [[ -d "${REPO_ROOT}/agents/" ]] && has_agents=true
+    [[ -d "${REPO_ROOT}/fleets/" ]] && has_fleets=true
 
     if [[ "$has_agents" == "false" && "$has_fleets" == "false" ]]; then
         log_error "Neither agents/ nor fleets/ directory found — nothing to reconcile"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -17,7 +17,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-AGAMEMNON_URL="${AGAMEMNON_URL:-http://localhost:8080}"
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+load_config
+
+# MYRM_AIM_HOST is populated by load_config; fall back to env/default for safety.
+AGAMEMNON_URL="${AGAMEMNON_URL:-${MYRM_AIM_HOST:-http://localhost:8080}}"
 
 # Flags
 SKIP_CONNECTIVITY=false
@@ -118,6 +123,21 @@ check_connectivity() {
     section "Check 2: Agamemnon connectivity"
 
     printf '  URL: %s\n' "$AGAMEMNON_URL"
+
+    # Validate URL format (#118)
+    if [[ -z "$AGAMEMNON_URL" ]]; then
+        fail "AGAMEMNON_URL is not set" \
+            "Export AGAMEMNON_URL before running (e.g. export AGAMEMNON_URL=http://localhost:8080)"
+        return
+    fi
+    case "$AGAMEMNON_URL" in
+        http://*|https://*) ;;
+        *)
+            fail "AGAMEMNON_URL has an unrecognised scheme: ${AGAMEMNON_URL}" \
+                "Expected a URL beginning with http:// or https://"
+            return
+            ;;
+    esac
 
     if [[ "$SKIP_CONNECTIVITY" == "true" ]]; then
         warn "Agamemnon connectivity (skipped via --skip-connectivity)"

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -16,15 +16,22 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
 # shellcheck source=scripts/lib/log.sh
 source "${SCRIPT_DIR}/lib/log.sh"
 # shellcheck source=scripts/lib/api.sh
 source "${SCRIPT_DIR}/lib/api.sh"
 
+load_config
+
 HOST="${1:-hermes}"
 OUTPUT_DIR="${REPO_ROOT}/agents/${HOST}"
 
 main() {
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
     check_jq
     agamemnon_check_connection
 

--- a/scripts/lib/api.sh
+++ b/scripts/lib/api.sh
@@ -61,6 +61,27 @@ _agamemnon_auth_headers() {
     fi
 }
 
+# Validate that AGAMEMNON_URL is set and has a recognised scheme (http/https).
+# Call this early in any entry-point script before issuing API calls.
+validate_agamemnon_url() {
+    local url="${AGAMEMNON_URL:-}"
+    if [[ -z "$url" ]]; then
+        echo "ERROR: AGAMEMNON_URL is not set." >&2
+        echo "  Export AGAMEMNON_URL before running this script." >&2
+        echo "  Example: export AGAMEMNON_URL=http://localhost:8080" >&2
+        return 1
+    fi
+    case "$url" in
+        http://*|https://*)
+            ;;
+        *)
+            echo "ERROR: AGAMEMNON_URL has an unrecognised scheme: ${url}" >&2
+            echo "  Expected a URL beginning with http:// or https://" >&2
+            return 1
+            ;;
+    esac
+}
+
 # Check that Agamemnon is reachable before making calls.
 agamemnon_check_connection() {
     _agamemnon_auth_headers

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -15,13 +15,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
 # shellcheck source=scripts/lib/log.sh
 source "${SCRIPT_DIR}/lib/log.sh"
 # shellcheck source=scripts/lib/api.sh
 source "${SCRIPT_DIR}/lib/api.sh"
 # shellcheck source=scripts/lib/reconcile.sh
 source "${SCRIPT_DIR}/lib/reconcile.sh"
+
+load_config
 
 HOST=""
 
@@ -47,6 +52,18 @@ usage() {
 
 main() {
     parse_args "$@"
+
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
+    # Validate HOST argument against known agents/ subdirectories (#149)
+    if [[ -n "$HOST" && ! -d "${REPO_ROOT}/agents/${HOST}" ]]; then
+        log_error "Host '${HOST}' not found — no agents/${HOST}/ directory exists."
+        log_error "  Known hosts: $(find "${REPO_ROOT}/agents" -mindepth 1 -maxdepth 1 -type d \
+            ! -name '_templates' -printf '%f ' 2>/dev/null || echo '(none)')"
+        exit 1
+    fi
+
     check_deps
     agamemnon_check_connection
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
 # shellcheck source=scripts/lib/log.sh
 source "${SCRIPT_DIR}/lib/log.sh"
 # shellcheck source=scripts/lib/api.sh
@@ -22,6 +24,8 @@ source "${SCRIPT_DIR}/lib/api.sh"
 source "${SCRIPT_DIR}/lib/reconcile.sh"
 # shellcheck source=scripts/lib/report.sh
 source "${SCRIPT_DIR}/lib/report.sh"
+
+load_config
 
 HOST=""
 OUTPUT_FORMAT="text"   # "text" | "json"
@@ -56,6 +60,9 @@ EOF
 
 main() {
     parse_args "$@"
+
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
 
     check_deps
     agamemnon_check_connection


### PR DESCRIPTION
Closes #118
Closes #149
Closes #234

## Summary

- **#234** — Source `config.sh` and call `load_config` in `apply.sh`, `plan.sh`, `status.sh`, `export.sh`, and `doctor.sh` so `.myrmidons.yaml` settings are applied automatically in every entry-point script.
- **#118** — Add `validate_agamemnon_url()` to `scripts/lib/api.sh`; call it from all entry-point scripts (`apply.sh`, `plan.sh`, `status.sh`, `export.sh`) before issuing any API requests. `doctor.sh` validates inline inside `check_connectivity()` and reports via `fail`/`pass` like its other checks.
- **#149** — After `HOST` is parsed in `apply.sh` and `plan.sh`, check that `agents/<host>/` exists and exit with a helpful error listing known hosts if it does not.

## Test plan

- [ ] `bash -n scripts/{apply,plan,status,export,doctor}.sh scripts/lib/{api,config}.sh` — all pass (confirmed locally)
- [ ] Run `./scripts/plan.sh badhost` — expect error listing known hosts
- [ ] Run `AGAMEMNON_URL=ftp://bad ./scripts/status.sh` — expect scheme validation error
- [ ] Run `AGAMEMNON_URL= ./scripts/export.sh` — expect "not set" error
- [ ] Run `./scripts/doctor.sh --skip-connectivity` with no `.myrmidons.yaml` — expect defaults used without error
- [ ] Run `./scripts/apply.sh hermes` with a valid `.myrmidons.yaml` — expect config loaded before connection attempt

🤖 Generated with [Claude Code](https://claude.ai/claude-code)