### PR TITLE
fix(validate): fleet inline agents, URL security test, dangerous-flags test, mock curl --max-time=

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -246,6 +246,33 @@ else
     echo "WARNING: yq not found — skipping metadata.name uniqueness check" >&2
 fi
 
+# ── Dangerous-flags lint guard ──────────────────────────────────────────────
+# Check staged files for bare --dangerously-skip-permissions usage.
+# Only runs if any staged YAML files exist (already checked above).
+#
+# Use git rev-parse to find the working tree root regardless of where the hook
+# binary lives (e.g. installed at .git/hooks/pre-commit vs hooks/pre-commit).
+REPO_ROOT_HOOK="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+DANGEROUS_FLAGS_SCRIPT="${REPO_ROOT_HOOK}/scripts/check-dangerous-flags.sh"
+
+if [[ -x "$DANGEROUS_FLAGS_SCRIPT" ]]; then
+    # Build list of staged files as arguments
+    mapfile -t STAGED_ARRAY <<< "$STAGED_YAMLS"
+    if [[ ${#STAGED_ARRAY[@]} -gt 0 && -n "${STAGED_ARRAY[0]}" ]]; then
+        # Resolve absolute paths for staged files (git diff gives relative paths)
+        STAGED_ABS=()
+        for f in "${STAGED_ARRAY[@]}"; do
+            [[ -z "$f" ]] && continue
+            STAGED_ABS+=("${REPO_ROOT_HOOK}/${f}")
+        done
+        if ! "$DANGEROUS_FLAGS_SCRIPT" "${STAGED_ABS[@]}"; then
+            echo ""
+            echo "Pre-commit: dangerous-flags lint check failed. Fix before committing."
+            exit 1
+        fi
+    fi
+fi
+
 # ── Issue #146: Optional test suite ─────────────────────────────────────────
 # Set SKIP_TESTS=1 to bypass this step (e.g. when test environment is unavailable).
 if [[ "${SKIP_TESTS:-0}" != "1" ]]; then

--- a/scripts/lib/api.sh
+++ b/scripts/lib/api.sh
@@ -20,6 +20,91 @@ set -euo pipefail
 AGAMEMNON_URL="${AGAMEMNON_URL:-http://localhost:8080}"
 AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
 
+# Validate that AGAMEMNON_URL is a safe http/https URL.
+#
+# Rejects:
+#   - Non-http/https schemes (ftp://, file://, javascript:, etc.)
+#   - URLs with embedded credentials (user:password@)
+#   - URLs with fragment (#) or query (?) components
+#   - Non-numeric port numbers
+#   - IPv6 bracket notation in the hostname field
+#   - Empty or clearly non-URL strings
+#   - Strings with embedded newlines (header injection)
+#
+# Usage:
+#   _agamemnon_validate_url "$AGAMEMNON_URL" || exit 1
+_agamemnon_validate_url() {
+    local url="$1"
+
+    # Reject empty
+    if [[ -z "$url" ]]; then
+        echo "ERROR: AGAMEMNON_URL is empty." >&2
+        return 1
+    fi
+
+    # Reject embedded newlines (header injection)
+    if [[ "$url" == *$'\n'* ]]; then
+        echo "ERROR: AGAMEMNON_URL contains a newline character." >&2
+        return 1
+    fi
+
+    # Must start with http:// or https://
+    if [[ "$url" != http://* && "$url" != https://* ]]; then
+        echo "ERROR: AGAMEMNON_URL must use http or https scheme: ${url}" >&2
+        return 1
+    fi
+
+    # Strip scheme
+    local rest="${url#http://}"
+    rest="${rest#https://}"
+
+    # Reject embedded credentials (user:pass@)
+    if [[ "$rest" == *@* ]]; then
+        echo "ERROR: AGAMEMNON_URL must not contain credentials: ${url}" >&2
+        return 1
+    fi
+
+    # Reject fragment (#) — fragments are client-side and indicate a bad URL
+    if [[ "$url" == *'#'* ]]; then
+        echo "ERROR: AGAMEMNON_URL must not contain a fragment (#): ${url}" >&2
+        return 1
+    fi
+
+    # Reject query string (?) — the API path is fixed; a query in the base URL is suspicious
+    if [[ "$url" == *'?'* ]]; then
+        echo "ERROR: AGAMEMNON_URL must not contain a query string (?): ${url}" >&2
+        return 1
+    fi
+
+    # Reject IPv6 bracket notation in the host field (not supported)
+    if [[ "$rest" == '['* ]]; then
+        echo "ERROR: AGAMEMNON_URL IPv6 bracket notation is not supported: ${url}" >&2
+        return 1
+    fi
+
+    # Extract host[:port][/path] — split off optional path
+    local hostport="${rest%%/*}"
+
+    # If there is a port, validate it is numeric
+    if [[ "$hostport" == *:* ]]; then
+        local port="${hostport##*:}"
+        if [[ -z "$port" || "$port" =~ [^0-9] ]]; then
+            echo "ERROR: AGAMEMNON_URL port must be numeric: ${url}" >&2
+            return 1
+        fi
+    fi
+
+    # Host must be non-empty
+    local host="${hostport%%:*}"
+    if [[ -z "$host" ]]; then
+        echo "ERROR: AGAMEMNON_URL host is empty: ${url}" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+
 # Build the TLS flags array for curl based on environment variables.
 # Populates the global _AGAMEMNON_TLS_FLAGS array; call once at source time.
 _agamemnon_build_tls_flags() {
@@ -83,7 +168,13 @@ validate_agamemnon_url() {
 }
 
 # Check that Agamemnon is reachable before making calls.
+# Also validates that AGAMEMNON_URL is a safe http/https URL (issue #120).
 agamemnon_check_connection() {
+    # Validate the URL before making any network calls.
+    if ! _agamemnon_validate_url "${AGAMEMNON_URL}"; then
+        echo "ERROR: Refusing to connect — AGAMEMNON_URL failed security validation." >&2
+        return 1
+    fi
     _agamemnon_auth_headers
     if ! curl -sf --max-time 5 "${_AGAMEMNON_TLS_FLAGS[@]+"${_AGAMEMNON_TLS_FLAGS[@]}"}" \
             "${_AUTH_HEADERS[@]+"${_AUTH_HEADERS[@]}"}" "${AGAMEMNON_URL}/v1/health" > /dev/null 2>&1; then

--- a/tests/test-api-retry.sh
+++ b/tests/test-api-retry.sh
@@ -99,6 +99,12 @@ mock_sequence() {
 # Override curl so tests don't hit the network.
 # Reads sequence from _SEQ_FILE, writes body from _BODY_FILE to -o target,
 # outputs http_code, returns exit_code.
+#
+# Handles both space-separated and equals-sign forms of flags:
+#   --max-time 30   (space form)
+#   --max-time=30   (equals sign form, issue #265)
+#   -o file         (space form)
+#   -o=file         (equals sign form)
 curl() {
     # Increment call count
     local count
@@ -118,14 +124,27 @@ curl() {
         echo "$rest" > "$_SEQ_FILE"
     fi
 
-    # Write body to -o file
+    # Write body to -o file, handling both "-o file" and "-o=file" / "--output=file"
     local args=("$@")
     local i
     for (( i=0; i<${#args[@]}; i++ )); do
-        if [[ "${args[$i]}" == "-o" ]]; then
-            cat "$_BODY_FILE" > "${args[$((i+1))]}"
-            break
-        fi
+        case "${args[$i]}" in
+            -o)
+                # Space-separated: -o <file>
+                cat "$_BODY_FILE" > "${args[$((i+1))]}"
+                break
+                ;;
+            -o=*)
+                # Equals-sign form: -o=<file>
+                cat "$_BODY_FILE" > "${args[$i]#-o=}"
+                break
+                ;;
+            --output=*)
+                # Long equals-sign form: --output=<file>
+                cat "$_BODY_FILE" > "${args[$i]#--output=}"
+                break
+                ;;
+        esac
     done
 
     echo -n "$http_code"
@@ -250,12 +269,30 @@ curl() {
     [[ "$rest" != "$seq" ]] && echo "$rest" > "$_SEQ_FILE"
     local args=("$@"); local i
     for (( i=0; i<${#args[@]}; i++ )); do
-        if [[ "${args[$i]}" == "-o" ]]; then cat "$_BODY_FILE" > "${args[$((i+1))]}"; break; fi
+        case "${args[$i]}" in
+            -o) cat "$_BODY_FILE" > "${args[$((i+1))]}"; break ;;
+            -o=*) cat "$_BODY_FILE" > "${args[$i]#-o=}"; break ;;
+            --output=*) cat "$_BODY_FILE" > "${args[$i]#--output=}"; break ;;
+        esac
     done
     echo -n "$http_code"
     return "$exit_code"
 }
 assert_contains "AGAMEMNON_TIMEOUT passed as --max-time 42" "--max-time 42" "$CAPTURED_ARGS"
+teardown_mock
+
+# ── Test 7b: mock curl handles --max-time=N (equals sign form, issue #265) ───────
+# Verify the mock curl body-writing loop works correctly when a caller passes
+# --max-time=30 instead of --max-time 30.  We simulate this by calling the
+# mock directly with the equals-sign form and confirming it writes the body.
+setup_mock
+mock_single 0 200
+_EQ_FILE="$(mktemp)"
+# Call the mock curl directly with --max-time=30 (equals sign) and -o <file>
+curl --max-time=30 -o "$_EQ_FILE" "http://mock.test:9999/v1/agents" >/dev/null 2>/dev/null || true
+eq_body="$(cat "$_EQ_FILE")"
+rm -f "$_EQ_FILE"
+assert_eq "mock curl handles --max-time=N: body written via -o" '{"ok":true}' "$eq_body"
 teardown_mock
 
 # ── Test 8: All 3 attempts fail (exit 7 each), non-zero exit returned ──────────

--- a/tests/unit/test_precommit_dangerous_flags.bats
+++ b/tests/unit/test_precommit_dangerous_flags.bats
@@ -1,0 +1,266 @@
+#!/usr/bin/env bats
+# tests/unit/test_precommit_dangerous_flags.bats
+#
+# Issue #147: test coverage for the pre-commit hook's dangerous-flags integration.
+#
+# The pre-commit hook (hooks/pre-commit) calls scripts/check-dangerous-flags.sh
+# on staged agent and fleet YAML files.  These tests set up a temporary git
+# repository, stage agent YAMLs containing (or not) --dangerously-skip-permissions,
+# and verify the hook exits with the correct status.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+HOOK_SCRIPT="${SCRIPT_DIR}/hooks/pre-commit"
+DANGEROUS_FLAGS_SCRIPT="${SCRIPT_DIR}/scripts/check-dangerous-flags.sh"
+
+# Temporary git repo used by the tests — created under SCRIPT_DIR so it stays
+# within the worktree and is removed cleanly by teardown.
+TMP_REPO=""
+
+setup() {
+    # Create a temp directory inside the worktree to avoid safety-net restrictions
+    TMP_REPO="${SCRIPT_DIR}/_precommit_test_$$_${RANDOM}"
+    mkdir -p "$TMP_REPO"
+
+    # Initialise git repo (without gpg signing to avoid prompts)
+    git -C "$TMP_REPO" init -q
+    git -C "$TMP_REPO" config user.email "test@example.com"
+    git -C "$TMP_REPO" config user.name "Test"
+    git -C "$TMP_REPO" config commit.gpgsign false
+
+    # Copy the hook and scripts into the temp repo
+    mkdir -p "${TMP_REPO}/scripts"
+    mkdir -p "${TMP_REPO}/hooks"
+    mkdir -p "${TMP_REPO}/.git/hooks"
+    cp "$HOOK_SCRIPT" "${TMP_REPO}/hooks/pre-commit"
+    cp "$DANGEROUS_FLAGS_SCRIPT" "${TMP_REPO}/scripts/check-dangerous-flags.sh"
+    chmod +x "${TMP_REPO}/hooks/pre-commit"
+    chmod +x "${TMP_REPO}/scripts/check-dangerous-flags.sh"
+
+    # Install the hook
+    cp "${TMP_REPO}/hooks/pre-commit" "${TMP_REPO}/.git/hooks/pre-commit"
+    chmod +x "${TMP_REPO}/.git/hooks/pre-commit"
+
+    # Create the agents directory
+    mkdir -p "${TMP_REPO}/agents/hermes"
+
+    # Create an initial commit so the repo is in a valid state
+    touch "${TMP_REPO}/.gitkeep"
+    git -C "$TMP_REPO" add .gitkeep
+    git -C "$TMP_REPO" commit -q --no-verify -m "init"
+}
+
+teardown() {
+    if [[ -n "$TMP_REPO" && -d "$TMP_REPO" ]]; then
+        rm -rf "$TMP_REPO"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: stage a file and run the hook directly.
+# The hook is run with the mikefarah yq (from pixi) in PATH if available,
+# since the hook uses `yq eval` syntax (yq v4).
+# ---------------------------------------------------------------------------
+
+_stage_and_run_hook() {
+    local file_path="$1"   # absolute path under TMP_REPO
+    local rel_path="${file_path#"${TMP_REPO}/"}"
+
+    git -C "$TMP_REPO" add "$rel_path"
+
+    # Prefer pixi yq (v4/mikefarah) over system yq (may be Python-based v3)
+    local pixi_yq_dir="${SCRIPT_DIR}/.pixi/envs/lint/bin"
+    local run_path="$PATH"
+    if [[ -x "${pixi_yq_dir}/yq" ]]; then
+        run_path="${pixi_yq_dir}:${PATH}"
+    fi
+
+    # Run the pre-commit hook from the repo root
+    (cd "$TMP_REPO" && PATH="$run_path" bash ".git/hooks/pre-commit") 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Bare --dangerously-skip-permissions without suppression → hook rejects
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects agent YAML with bare --dangerously-skip-permissions" {
+    local agent_file="${TMP_REPO}/agents/hermes/danger.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: danger-agent
+  host: hermes
+spec:
+  label: DangerAgent
+  program: claude-code
+  workingDirectory: /tmp/danger
+  programArgs: "--dangerously-skip-permissions"
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dangerously-skip-permissions"* || "$output" == *"dangerous"* || "$output" == *"violation"* || "$output" == *"lint"* || "$output" == *"failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: --dangerously-skip-permissions with suppression annotation → hook accepts
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: accepts agent YAML with suppressed --dangerously-skip-permissions" {
+    local agent_file="${TMP_REPO}/agents/hermes/suppressed.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: suppressed-agent
+  host: hermes
+spec:
+  label: SuppressedAgent
+  program: claude-code
+  workingDirectory: /tmp/suppressed
+  programArgs: "--dangerously-skip-permissions" # skip-permissions-lint: ephemeral container with read-only mount and 30m timeout
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Agent YAML with no dangerous flags → hook accepts
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: accepts agent YAML without --dangerously-skip-permissions" {
+    local agent_file="${TMP_REPO}/agents/hermes/safe.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: safe-agent
+  host: hermes
+spec:
+  label: SafeAgent
+  program: claude-code
+  workingDirectory: /tmp/safe
+  programArgs: "--model claude-sonnet-4-6"
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Fleet YAML with bare --dangerously-skip-permissions → hook rejects
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects fleet YAML with bare --dangerously-skip-permissions" {
+    mkdir -p "${TMP_REPO}/fleets"
+    local fleet_file="${TMP_REPO}/fleets/danger-fleet.yaml"
+    cat > "$fleet_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: danger-fleet
+spec:
+  agents:
+    - name: danger-inline
+      program: claude-code
+      workingDirectory: /tmp/danger
+      programArgs: "--dangerously-skip-permissions"
+      desiredState: active
+YAML
+
+    run _stage_and_run_hook "$fleet_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dangerously-skip-permissions"* || "$output" == *"dangerous"* || "$output" == *"violation"* || "$output" == *"lint"* || "$output" == *"failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Fleet YAML with suppressed --dangerously-skip-permissions → hook accepts
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: accepts fleet YAML with suppressed --dangerously-skip-permissions" {
+    mkdir -p "${TMP_REPO}/fleets"
+    local fleet_file="${TMP_REPO}/fleets/suppressed-fleet.yaml"
+    cat > "$fleet_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: suppressed-fleet
+spec:
+  agents:
+    - name: suppressed-inline
+      program: claude-code
+      workingDirectory: /tmp/suppressed
+      programArgs: "--dangerously-skip-permissions" # skip-permissions-lint: isolated docker container with no network
+      desiredState: active
+YAML
+
+    run _stage_and_run_hook "$fleet_file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Combined flags with bare dangerous flag → hook rejects
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects when --dangerously-skip-permissions combined with other flags" {
+    local agent_file="${TMP_REPO}/agents/hermes/combined.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: combined-agent
+  host: hermes
+spec:
+  label: CombinedAgent
+  program: claude-code
+  workingDirectory: /tmp/combined
+  programArgs: "--dangerously-skip-permissions --model claude-sonnet-4-6"
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: check-dangerous-flags.sh directly — bare flag exits 1
+# ---------------------------------------------------------------------------
+
+@test "check-dangerous-flags.sh: bare flag in file exits 1" {
+    local tmpfile="${TMP_REPO}/direct_test.yaml"
+    cat > "$tmpfile" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: direct-test
+  host: hermes
+spec:
+  programArgs: "--dangerously-skip-permissions"
+YAML
+    run bash "$DANGEROUS_FLAGS_SCRIPT" "$tmpfile"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: check-dangerous-flags.sh directly — suppressed flag exits 0
+# ---------------------------------------------------------------------------
+
+@test "check-dangerous-flags.sh: suppressed flag in file exits 0" {
+    local tmpfile="${TMP_REPO}/direct_suppressed.yaml"
+    cat > "$tmpfile" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: direct-suppressed
+  host: hermes
+spec:
+  programArgs: "--dangerously-skip-permissions" # skip-permissions-lint: test justification
+YAML
+    run bash "$DANGEROUS_FLAGS_SCRIPT" "$tmpfile"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/test_url_security.bats
+++ b/tests/unit/test_url_security.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# tests/unit/test_url_security.bats — integration test: malicious AGAMEMNON_URL
+#
+# Issue #120: verify that apply.sh (via agamemnon_check_connection in api.sh)
+# aborts before making any API calls when AGAMEMNON_URL is set to a malicious
+# value.
+#
+# These tests call agamemnon_check_connection directly (which is the first
+# network-touching call in apply.sh's main()) so they cover the integration
+# point without needing a running Agamemnon server.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Track whether curl was invoked by the mock
+CURL_INVOKED_FILE=""
+
+setup() {
+    CURL_INVOKED_FILE="$(mktemp)"
+    echo "0" > "$CURL_INVOKED_FILE"
+    export CURL_INVOKED_FILE
+
+    # Unset TLS vars so api.sh sources cleanly
+    unset AGAMEMNON_TLS_VERIFY
+    unset AGAMEMNON_CA_CERT
+    unset AGAMEMNON_CLIENT_CERT
+    unset AGAMEMNON_CLIENT_KEY
+    unset AGAMEMNON_API_KEY
+}
+
+teardown() {
+    [[ -n "$CURL_INVOKED_FILE" && -f "$CURL_INVOKED_FILE" ]] && rm -f "$CURL_INVOKED_FILE"
+    unset CURL_INVOKED_FILE
+}
+
+# ---------------------------------------------------------------------------
+# Helper: source api.sh with a given AGAMEMNON_URL in a subshell.
+# Returns the exit code and captured output.
+# ---------------------------------------------------------------------------
+
+_run_check_connection() {
+    local url="$1"
+    AGAMEMNON_URL="$url" bash -c "
+        source '${SCRIPT_DIR}/scripts/lib/api.sh'
+        agamemnon_check_connection
+    " 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Tests: malicious URLs must be rejected before any curl call
+# ---------------------------------------------------------------------------
+
+@test "malicious URL: file:// scheme is rejected" {
+    run _run_check_connection "file:///etc/passwd"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"AGAMEMNON_URL"* || "$output" == *"http"* || "$output" == *"scheme"* || "$output" == *"Invalid"* || "$output" == *"failed"* ]]
+}
+
+@test "malicious URL: ftp:// scheme is rejected" {
+    run _run_check_connection "ftp://evil.example.com"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"http"* || "$output" == *"scheme"* || "$output" == *"Invalid"* || "$output" == *"failed"* ]]
+}
+
+@test "malicious URL: javascript: scheme is rejected" {
+    run _run_check_connection "javascript:alert(1)"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: URL with embedded credentials is rejected" {
+    run _run_check_connection "http://user:password@evil.com"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"credential"* || "$output" == *"Invalid"* || "$output" == *"failed"* || "$output" == *"AGAMEMNON_URL"* ]]
+}
+
+@test "malicious URL: URL with fragment (#) is rejected" {
+    run _run_check_connection "http://evil.com#fragment"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: URL with query string (?) is rejected" {
+    run _run_check_connection "http://evil.com?redirect=http://attacker.com"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: empty string is rejected" {
+    run _run_check_connection ""
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: plain string (not a URL) is rejected" {
+    run _run_check_connection "not-a-url"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: protocol-relative URL is rejected" {
+    run _run_check_connection "//evil.com"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: non-numeric port is rejected" {
+    run _run_check_connection "http://evil.com:abc"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: IPv6 bracket notation is rejected" {
+    run _run_check_connection "http://[evil.com]"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: valid URLs must pass validation (and only fail at connection step)
+# ---------------------------------------------------------------------------
+
+@test "valid URL: http://localhost:8080 passes validation" {
+    # agamemnon_check_connection will fail because nothing is running on the port,
+    # but the error must be about connection (not URL rejection)
+    run _run_check_connection "http://localhost:19998"
+    [ "$status" -ne 0 ]
+    # Should mention that it cannot reach, not that the URL is invalid
+    [[ "$output" == *"Cannot reach"* || "$output" == *"failed"* ]]
+    # Must NOT mention URL validation failure
+    [[ "$output" != *"failed security validation"* ]]
+}
+
+@test "valid URL: https://agamemnon.internal passes validation" {
+    run _run_check_connection "https://agamemnon.internal"
+    [ "$status" -ne 0 ]
+    # Should fail at connect step, not validation step
+    [[ "$output" != *"failed security validation"* ]]
+}
+
+@test "valid URL: http://192.168.1.100:8080 passes validation" {
+    run _run_check_connection "http://192.168.1.100:8080"
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"failed security validation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: apply.sh main entry point aborts on malicious URL
+# ---------------------------------------------------------------------------
+
+@test "apply.sh: aborts early on malicious AGAMEMNON_URL without making API calls" {
+    # We verify apply.sh exits non-zero when AGAMEMNON_URL is malicious.
+    # We use a minimal agents directory so the script would proceed past
+    # argument parsing if the URL were valid.
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    mkdir -p "${tmpdir}/agents/hermes"
+    cat > "${tmpdir}/agents/hermes/testagent.yaml" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-agent
+  host: hermes
+spec:
+  label: TestAgent
+  program: claude-code
+  workingDirectory: /tmp/test
+  desiredState: active
+YAML
+
+    # Run apply.sh with a malicious URL; it must exit non-zero
+    run bash -c "
+        cd '${SCRIPT_DIR}'
+        AGAMEMNON_URL='file:///etc/passwd' \
+        AIM_LOCK_FILE='${tmpdir}/.lock' \
+        bash '${SCRIPT_DIR}/scripts/apply.sh' 2>&1
+    "
+    rm -rf "$tmpdir"
+
+    [ "$status" -ne 0 ]
+    # Output must mention rejection, not just a connection error to the malicious URL
+    [[ "$output" == *"http"* || "$output" == *"scheme"* || "$output" == *"Invalid"* || "$output" == *"failed"* || "$output" == *"AGAMEMNON_URL"* ]]
+}

--- a/tests/validate-fleet-refs.sh
+++ b/tests/validate-fleet-refs.sh
@@ -4,6 +4,9 @@
 # Checks that every `ref: <host>/<name>` entry in fleet YAML files resolves
 # to an existing `agents/<host>/<name>.yaml` file.
 #
+# Also validates inline agent definitions (entries without a `ref:` field)
+# for required fields: name, program, and workingDirectory.
+#
 # Fleet refs resolve by FILENAME STEM (lowercased spec.label), not by
 # metadata.name. This script enforces that no fleet file references a
 # non-existent agent.
@@ -12,8 +15,8 @@
 #   ./tests/validate-fleet-refs.sh
 #
 # Exit codes:
-#   0 = all refs resolve
-#   1 = one or more dangling refs found
+#   0 = all refs resolve and all inline agents are valid
+#   1 = one or more dangling refs or invalid inline agents found
 
 set -euo pipefail
 
@@ -22,6 +25,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 ERRORS=0
 CHECKED=0
+INLINE_CHECKED=0
 
 if ! command -v yq &>/dev/null; then
     echo "ERROR: yq is required for fleet ref validation." >&2
@@ -29,7 +33,7 @@ if ! command -v yq &>/dev/null; then
     exit 1
 fi
 
-echo "Validating fleet ref referential integrity..."
+echo "Validating fleet ref referential integrity and inline agent definitions..."
 echo ""
 
 # Iterate over all fleet YAML files
@@ -40,32 +44,63 @@ while IFS= read -r -d '' fleet_file; do
     fleet_name="$(yq eval '.metadata.name // ""' "$fleet_file")"
     fleet_rel="${fleet_file#"${REPO_ROOT}/"}"
 
-    # Extract all ref values (pattern: <host>/<name>)
-    mapfile -t refs < <(yq eval '.spec.agents[].ref // ""' "$fleet_file" 2>/dev/null | grep -v '^$' || true)
+    # Count total agents in the fleet
+    agent_count="$(yq eval '.spec.agents | length' "$fleet_file" 2>/dev/null || echo 0)"
 
-    if [[ ${#refs[@]} -eq 0 ]]; then
-        echo "  ${fleet_rel} (${fleet_name}): no refs — skipping"
+    if [[ "$agent_count" -eq 0 ]]; then
+        echo "  ${fleet_rel} (${fleet_name}): no agents — skipping"
         continue
     fi
 
     echo "  ${fleet_rel} (${fleet_name}):"
-    for ref in "${refs[@]}"; do
-        CHECKED=$((CHECKED + 1))
-        # ref format: <host>/<name>  →  agents/<host>/<name>.yaml
-        agent_path="${REPO_ROOT}/agents/${ref}.yaml"
-        printf "    ref: %-40s " "${ref}"
-        if [[ -f "$agent_path" ]]; then
-            echo "ok"
+
+    # Process each agent entry by index
+    for (( idx=0; idx<agent_count; idx++ )); do
+        ref="$(yq eval ".spec.agents[${idx}].ref // \"\"" "$fleet_file" 2>/dev/null || true)"
+
+        if [[ -n "$ref" ]]; then
+            # --- ref entry: validate that the target file exists ---
+            CHECKED=$((CHECKED + 1))
+            # ref format: <host>/<name>  →  agents/<host>/<name>.yaml
+            agent_path="${REPO_ROOT}/agents/${ref}.yaml"
+            printf "    ref: %-40s " "${ref}"
+            if [[ -f "$agent_path" ]]; then
+                echo "ok"
+            else
+                echo "FAIL (agents/${ref}.yaml not found)"
+                ERRORS=$((ERRORS + 1))
+            fi
         else
-            echo "FAIL (agents/${ref}.yaml not found)"
-            ERRORS=$((ERRORS + 1))
+            # --- inline agent: validate required fields ---
+            INLINE_CHECKED=$((INLINE_CHECKED + 1))
+            inline_name="$(yq eval ".spec.agents[${idx}].name // \"\"" "$fleet_file" 2>/dev/null || true)"
+            inline_program="$(yq eval ".spec.agents[${idx}].program // \"\"" "$fleet_file" 2>/dev/null || true)"
+            inline_workdir="$(yq eval ".spec.agents[${idx}].workingDirectory // \"\"" "$fleet_file" 2>/dev/null || true)"
+
+            display_name="${inline_name:-<unnamed>}"
+            printf "    inline[%d] %-36s " "${idx}" "${display_name}:"
+
+            inline_errors=()
+            [[ -z "$inline_name" ]] && inline_errors+=("name is required")
+            [[ -z "$inline_program" ]] && inline_errors+=("program is required")
+            [[ -z "$inline_workdir" ]] && inline_errors+=("workingDirectory is required")
+
+            if [[ ${#inline_errors[@]} -eq 0 ]]; then
+                echo "ok"
+            else
+                echo "FAIL"
+                for err in "${inline_errors[@]}"; do
+                    echo "      - ${err}"
+                done
+                ERRORS=$((ERRORS + 1))
+            fi
         fi
     done
     echo ""
 
 done < <(find "${REPO_ROOT}/fleets" -name "*.yaml" -print0 2>/dev/null)
 
-echo "Checked: ${CHECKED} refs, Errors: ${ERRORS}"
+echo "Checked: ${CHECKED} refs, ${INLINE_CHECKED} inline agents, Errors: ${ERRORS}"
 
 if [[ $ERRORS -gt 0 ]]; then
     exit 1


### PR DESCRIPTION
Closes #119
Closes #120
Closes #147
Closes #265

## Summary

- **#119** `tests/validate-fleet-refs.sh` now validates inline agents in fleet specs (entries without `ref:`), checking required fields `name`, `program`, and `workingDirectory` in addition to resolving `ref:` entries. Inline agents are indexed by position and shown alongside ref validation results.

- **#120** Added `_agamemnon_validate_url()` to `scripts/lib/api.sh` that rejects malicious `AGAMEMNON_URL` values (non-http/https schemes, embedded credentials, fragments, query strings, invalid ports, IPv6 bracket notation). `agamemnon_check_connection()` now calls this before any network activity. New `tests/unit/test_url_security.bats` has 15 tests covering all rejection cases plus valid URL acceptance and an end-to-end `apply.sh` abort test.

- **#147** `hooks/pre-commit` now calls `scripts/check-dangerous-flags.sh` on all staged agent/fleet YAML files after schema validation passes. Path resolution uses `git rev-parse --show-toplevel` so the hook works correctly whether installed at `.git/hooks/pre-commit` or run directly. New `tests/unit/test_precommit_dangerous_flags.bats` has 8 tests for the full hook integration (bare flag rejected, suppressed flag accepted, fleet files, combined flags).

- **#265** Mock `curl` in `tests/test-api-retry.sh` now handles `--max-time=N` (equals-sign form) alongside `--max-time N` (space form) when scanning args to write the body to the `-o` file. Both the primary mock and the restore mock in Test 7 are updated. New Test 7b verifies the equals-sign form works correctly.

## Test plan

- [x] `pixi run --environment lint bats tests/unit/` — all 227 tests pass
- [x] `pixi run --environment lint bats tests/integration/` — all 13 tests pass
- [x] `bash tests/test-api-retry.sh` — 25 tests pass (including new Test 7b)
- [x] `bash tests/test-url-validation.sh` — 20 tests pass
- [x] `bash tests/test-check-dangerous-flags.sh` — 9 tests pass
- [x] `pixi run --environment lint bash tests/validate-fleet-refs.sh` — validates 18 refs + 3 inline agents, 0 errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)