### PR TITLE
fix: add nomad schema type, scan .yml flags, fleet in justfile, fix SHA reporting

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -15,7 +15,7 @@ set -euo pipefail
 ERRORS=0
 
 # Get staged YAML files in agents/ and fleets/
-STAGED_YAMLS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(agents|fleets)/.*\.yaml$' || true)
+STAGED_YAMLS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(agents|fleets)/.*\.ya?ml$' || true)
 
 if [[ -z "$STAGED_YAMLS" ]]; then
     exit 0
@@ -92,8 +92,8 @@ while IFS= read -r file; do
     fi
 
     # Validate deployment type
-    if [[ "$deploy_type" != "local" && "$deploy_type" != "docker" ]]; then
-        local_errors+=("spec.deployment.type must be 'local' or 'docker', got '${deploy_type}'")
+    if [[ "$deploy_type" != "local" && "$deploy_type" != "docker" && "$deploy_type" != "nomad" ]]; then
+        local_errors+=("spec.deployment.type must be 'local', 'docker', or 'nomad', got '${deploy_type}'")
     fi
 
     # Validate docker image is present when deployment.type=docker

--- a/justfile
+++ b/justfile
@@ -17,9 +17,13 @@ agamemnon_url := env_var_or_default("AGAMEMNON_URL", "http://localhost:8080")
 # Observability
 # =============================================================================
 
-# Show desired vs actual state for all agents (or a specific host)
-status HOST=host:
-    AGAMEMNON_URL={{agamemnon_url}} bash scripts/status.sh {{HOST}}
+# Show desired vs actual state for all agents (or a specific host); pass fleet="" to filter by fleet
+status HOST=host fleet="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=({{HOST}})
+    if [[ -n "{{fleet}}" ]]; then args+=(--fleet "{{fleet}}"); fi
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/status.sh "${args[@]}"
 
 # Show desired vs actual state for a named fleet
 status-fleet FLEET:
@@ -40,17 +44,25 @@ report:
 # Planning
 # =============================================================================
 
-# Dry-run: show what apply would do (no changes made)
-plan HOST=host:
-    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}} --dry-run
+# Dry-run: show what apply would do (no changes made); pass fleet="<name>" to target a fleet
+plan HOST=host fleet="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=({{HOST}} --dry-run)
+    if [[ -n "{{fleet}}" ]]; then args+=(--fleet "{{fleet}}"); fi
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh "${args[@]}"
 
 # =============================================================================
 # Apply
 # =============================================================================
 
-# Reconcile desired state → Agamemnon (creates/updates/starts/stops)
-apply HOST=host:
-    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh {{HOST}}
+# Reconcile desired state → Agamemnon (creates/updates/starts/stops); pass fleet="<name>" to target a fleet
+apply HOST=host fleet="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=({{HOST}})
+    if [[ -n "{{fleet}}" ]]; then args+=(--fleet "{{fleet}}"); fi
+    AGAMEMNON_URL={{agamemnon_url}} bash scripts/apply.sh "${args[@]}"
 
 # Apply with --prune (removes agents in Agamemnon that are not in YAML)
 apply-prune HOST=host:

--- a/schemas/agent-v1.schema.json
+++ b/schemas/agent-v1.schema.json
@@ -87,8 +87,8 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["local", "docker"],
-              "description": "'local' runs in a tmux session on the host; 'docker' runs in a container"
+              "enum": ["local", "docker", "nomad"],
+              "description": "'local' runs in a tmux session on the host; 'docker' runs in a container; 'nomad' is reserved for future Nomad integration (ADR-008)"
             },
             "docker": {
               "type": "object",

--- a/scripts/lib/git-safety.sh
+++ b/scripts/lib/git-safety.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/lib/git-safety.sh — pre-commit safety guards
+#
+# Provides helpers to detect no-op git commit scenarios (empty staging area)
+# and report the current HEAD SHA clearly, preventing false-positive "commit
+# succeeded" reports when nothing was actually staged.
+#
+# Background: the 29-auto-impl branch exhibited a case where `git commit`
+# printed an already-existing SHA because nothing was staged (see issue #142).
+# These helpers make that scenario detectable and diagnosable before commit.
+#
+# Usage:
+#   source "${SCRIPT_DIR}/lib/git-safety.sh"
+#   assert_staged_nonempty || exit 1
+#   git commit -m "..."
+#   report_commit_sha
+
+set -euo pipefail
+
+# assert_staged_nonempty — exit non-zero with a clear diagnostic if the
+# staging area is empty, so callers can abort before running `git commit`
+# (which would silently succeed and report the existing HEAD SHA).
+#
+# Returns: 0 if something is staged; 1 (with diagnostic) if nothing is staged.
+assert_staged_nonempty() {
+    if git diff --staged --quiet 2>/dev/null; then
+        echo "ERROR: Nothing is staged for commit." >&2
+        echo "  git commit would produce a no-op and report the existing HEAD SHA." >&2
+        echo "  Current HEAD: $(git log --oneline -1 2>/dev/null || echo '(no commits yet)')" >&2
+        echo "  Staged files: (none)" >&2
+        echo "  Run 'git status' to see what is modified but unstaged." >&2
+        return 1
+    fi
+    return 0
+}
+
+# report_commit_sha — print the SHA of the most recent commit with a clear
+# label, so callers can distinguish a new commit from an already-existing one.
+#
+# Usage: call this AFTER `git commit` to log the resulting SHA.
+report_commit_sha() {
+    local sha
+    sha="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+    local oneline
+    oneline="$(git log --oneline -1 2>/dev/null || echo 'unknown')"
+    echo "Committed: ${sha} — ${oneline}"
+}
+
+# is_head_already_pushed — return 0 if the current HEAD has already been
+# pushed to the given remote branch, 1 otherwise.
+#
+# Usage: is_head_already_pushed origin my-branch
+is_head_already_pushed() {
+    local remote="${1:-origin}"
+    local branch="${2:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}"
+    local local_sha remote_sha
+    local_sha="$(git rev-parse HEAD 2>/dev/null || echo '')"
+    remote_sha="$(git ls-remote "${remote}" "refs/heads/${branch}" 2>/dev/null | awk '{print $1}')"
+    if [[ -n "${remote_sha}" && "${local_sha}" == "${remote_sha}" ]]; then
+        return 0
+    fi
+    return 1
+}

--- a/tests/detect-doc-drift.sh
+++ b/tests/detect-doc-drift.sh
@@ -26,7 +26,6 @@ CHECKED=0
 FORBIDDEN_PHRASES=(
     "Myrmidons.*Nomad.*cluster|implies Myrmidons actively drives a Nomad cluster"
     "apply\.sh.*Nomad|implies apply.sh submits Nomad jobs"
-    "deployment\.type.*nomad|implies nomad is a valid deployment type (not yet implemented)"
     "Nomad integration.*implemented|implies Nomad integration is complete"
     "Nomad.*currently supported|implies Nomad is currently supported"
 )


### PR DESCRIPTION
Closes #81
Closes #142
Closes #143
Closes #160

## Changes

- **#81 — Add `nomad` as valid deployment type**: Added `nomad` to the `spec.deployment.type` enum in `schemas/agent-v1.schema.json` (alongside `local` and `docker`). Updated the pre-commit hook to accept `nomad`. Removed the now-stale forbidden pattern `deployment\.type.*nomad` from `tests/detect-doc-drift.sh` (that pattern guarded against overclaiming Nomad was implemented; since the schema now explicitly lists it as a reserved future type, the guard was a false positive).

- **#142 — Fix git commit reporting already-committed SHA**: Created `scripts/lib/git-safety.sh` with three guards: `assert_staged_nonempty()` (aborts with a clear diagnostic before running `git commit` when nothing is staged, preventing the no-op that reported the existing HEAD SHA on 29-auto-impl), `report_commit_sha()` (logs the resulting SHA after commit), and `is_head_already_pushed()` (detects when HEAD is already on the remote).

- **#143 — Extend pre-commit hook to scan `.yml` files**: Changed the staged-file `grep` pattern in `hooks/pre-commit` from `\.yaml$` to `\.ya?ml$` so both `.yaml` and `.yml` agent/fleet files are validated on commit — consistent with `check-dangerous-flags.sh` which already scanned both extensions.

- **#160 — Add `--fleet` support to justfile recipes**: Added an optional `fleet=""` parameter to the `apply`, `plan`, and `status` recipes. When non-empty, `--fleet <name>` is appended to the script invocation. The `status-fleet` and `apply-prune` recipes are unchanged.

## Test plan

- [ ] `bash -n hooks/pre-commit` passes
- [ ] `bash -n scripts/lib/git-safety.sh` passes
- [ ] `bash -n tests/detect-doc-drift.sh` passes
- [ ] Schema accepts `deployment.type: nomad` (validate with `yq` against schema)
- [ ] `just apply fleet=myfleet` passes `--fleet myfleet` to `apply.sh`
- [ ] `just plan fleet=myfleet` passes `--fleet myfleet` to `apply.sh --dry-run`
- [ ] `just status fleet=myfleet` passes `--fleet myfleet` to `status.sh`
- [ ] CI validate workflow passes (detect-doc-drift.sh no longer flags schema nomad entry)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)