### PR TITLE
feat(test): mock server supports per-route responses

### DIFF
--- a/tests/helpers/mock_server.py
+++ b/tests/helpers/mock_server.py
@@ -3,15 +3,22 @@
 Minimal mock HTTP server for Myrmidons test suite.
 
 Reads response configuration from:
-  1. Optional routes config file (second CLI arg)
+  1. Optional routes config file (--routes flag or second CLI arg):
+       JSON array: [{"method": "GET", "path": "/api/v1/agents", "status": 200, "body": {...}}, ...]
+       JSON object: {"routes": [...], "default_status": 200, "default_body": {}}
+     Routes are matched in order; first match wins.
+     Paths support a trailing wildcard segment: "/api/v1/agents/*" matches
+     "/api/v1/agents/foo" and "/api/v1/agents/abc123".
   2. Environment variables (fallback):
      MOCK_STATUS  — HTTP status code to return (default: 200)
      MOCK_BODY    — Response body JSON string (default: {})
 
 Usage:
   MOCK_STATUS=200 MOCK_BODY='[...]' python3 mock_server.py <PORT>
-  python3 mock_server.py <PORT> <routes_config.json>
+  python3 mock_server.py <PORT> --routes <routes_config.json>
+  python3 mock_server.py <PORT> <routes_config.json>   # legacy positional form
 """
+import fnmatch
 import os
 import sys
 import json
@@ -21,15 +28,86 @@ STATUS = int(os.environ.get("MOCK_STATUS", "200"))
 BODY = os.environ.get("MOCK_BODY", "{}")
 ROUTES_CONFIG = None
 
-# Load routes config if provided
-if len(sys.argv) > 2:
-    config_path = sys.argv[2]
+
+def _load_routes(config_path):
+    """Load and normalise a routes config file.
+
+    Accepts two formats:
+    - Flat array: [{"method": ..., "path": ..., "status": ..., "body": ...}, ...]
+    - Object: {"routes": [...], "default_status": ..., "default_body": ...}
+
+    Returns a dict with "routes", optional "default_status", optional "default_body".
+    """
     try:
         with open(config_path, "r") as f:
-            ROUTES_CONFIG = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        print(f"Error loading routes config: {e}", file=sys.stderr)
+            raw = json.load(f)
+    except FileNotFoundError:
+        print(f"Error loading routes config: file not found: {config_path}", file=sys.stderr)
         sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error loading routes config: invalid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(raw, list):
+        return {"routes": raw}
+    if isinstance(raw, dict):
+        return raw
+    print("Error loading routes config: expected a JSON array or object", file=sys.stderr)
+    sys.exit(1)
+
+
+def _parse_args():
+    """Return (port, routes_config_path_or_None)."""
+    args = sys.argv[1:]
+    port = 18080
+    routes_path = None
+
+    i = 0
+    positional = []
+    while i < len(args):
+        if args[i] == "--routes":
+            if i + 1 >= len(args):
+                print("Error: --routes requires a file path argument", file=sys.stderr)
+                sys.exit(1)
+            routes_path = args[i + 1]
+            i += 2
+        else:
+            positional.append(args[i])
+            i += 1
+
+    if positional:
+        try:
+            port = int(positional[0])
+        except ValueError:
+            print(f"Error: invalid port number: {positional[0]}", file=sys.stderr)
+            sys.exit(1)
+        # Legacy form: second positional arg is the routes config file
+        if len(positional) > 1 and routes_path is None:
+            routes_path = positional[1]
+
+    return port, routes_path
+
+
+def _path_matches(pattern, path):
+    """Return True if *path* matches *pattern*.
+
+    Supports a single trailing wildcard segment:
+      /api/v1/agents/*  matches  /api/v1/agents/foo
+    Exact matches are checked first.
+    """
+    if pattern == path:
+        return True
+    # Use fnmatch for simple glob-style wildcard support
+    return fnmatch.fnmatch(path, pattern)
+
+
+# ---------------------------------------------------------------------------
+# Parse arguments and load optional routes config
+# ---------------------------------------------------------------------------
+
+_port, _routes_path = _parse_args()
+if _routes_path is not None:
+    ROUTES_CONFIG = _load_routes(_routes_path)
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -50,6 +128,9 @@ class Handler(BaseHTTPRequestHandler):
 
     def _respond(self, method):
         status, body = self._get_response(method)
+        # body may be a dict/list (from JSON routes config) — serialise it
+        if not isinstance(body, str):
+            body = json.dumps(body)
         encoded = body.encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
@@ -60,15 +141,17 @@ class Handler(BaseHTTPRequestHandler):
     def _get_response(self, method):
         """Get response status and body for the given method and path.
 
-        If routes config is available, match by method+path.
+        If routes config is available, match by method+path (wildcard-aware).
         Otherwise fall back to env vars.
         """
         if ROUTES_CONFIG is None:
             return STATUS, BODY
 
-        # Try to find a matching route
+        # Try to find a matching route (first match wins)
         for route in ROUTES_CONFIG.get("routes", []):
-            if route.get("method") == method and route.get("path") == self.path:
+            route_method = route.get("method", "").upper()
+            route_path = route.get("path", "")
+            if route_method == method and _path_matches(route_path, self.path):
                 return route.get("status", 200), route.get("body", "{}")
 
         # Fall back to default_status/default_body from config, or env vars
@@ -78,6 +161,5 @@ class Handler(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 18080
-    httpd = HTTPServer(("127.0.0.1", port), Handler)
+    httpd = HTTPServer(("127.0.0.1", _port), Handler)
     httpd.serve_forever()

--- a/tests/unit/test_mock_server_routes.bats
+++ b/tests/unit/test_mock_server_routes.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+# tests/unit/test_mock_server_routes.bats
+#
+# Tests for mock_server.py per-route response feature (issue #192).
+# Verifies that a single mock server instance can serve different responses
+# for different method+path combinations, enabling multi-step workflow tests.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18085
+MOCK_PID_FILE="/tmp/bats-mock-routes-$$.pid"
+ROUTES_FILE="/tmp/bats-mock-routes-$$.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_with_routes() {
+    local routes_json="$1"
+    printf '%s' "$routes_json" > "$ROUTES_FILE"
+    python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" --routes "$ROUTES_FILE" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+    rm -f "$ROUTES_FILE"
+}
+
+_curl_get() {
+    # -s: silent, no -f so that 4xx/5xx responses still print the status code
+    curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${MOCK_PORT}${1}"
+}
+
+_curl_get_body() {
+    curl -sf "http://127.0.0.1:${MOCK_PORT}${1}"
+}
+
+_curl_post_code() {
+    curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" -d '{}' \
+        "http://127.0.0.1:${MOCK_PORT}${1}"
+}
+
+teardown() {
+    _stop_mock_server
+}
+
+# ---------------------------------------------------------------------------
+# Flat-array JSON format (issue #192 spec)
+# ---------------------------------------------------------------------------
+
+@test "mock_server: per-route flat-array — GET /api/v1/agents returns 200 with agent list" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"id":"a1","name":"agent-one","status":"active"}]},
+        {"method":"POST","path":"/api/v1/agents","status":201,"body":{"id":"a2","name":"agent-two","status":"offline"}}
+    ]'
+    code="$(_curl_get /api/v1/agents)"
+    [[ "$code" == "200" ]]
+}
+
+@test "mock_server: per-route flat-array — GET body contains expected agent data" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"id":"a1","name":"agent-one","status":"active"}]}
+    ]'
+    body="$(_curl_get_body /api/v1/agents)"
+    name="$(echo "$body" | jq -r '.[0].name')"
+    [[ "$name" == "agent-one" ]]
+}
+
+@test "mock_server: per-route flat-array — POST /api/v1/agents returns 201" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[]},
+        {"method":"POST","path":"/api/v1/agents","status":201,"body":{"id":"new1","name":"new-agent"}}
+    ]'
+    code="$(_curl_post_code /api/v1/agents)"
+    [[ "$code" == "201" ]]
+}
+
+@test "mock_server: per-route — different paths return different responses" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":{"route":"list"}},
+        {"method":"GET","path":"/api/v1/status","status":200,"body":{"route":"status"}}
+    ]'
+    body_agents="$(_curl_get_body /api/v1/agents)"
+    body_status="$(_curl_get_body /api/v1/status)"
+    route_agents="$(echo "$body_agents" | jq -r '.route')"
+    route_status="$(echo "$body_status" | jq -r '.route')"
+    [[ "$route_agents" == "list" ]]
+    [[ "$route_status" == "status" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Wildcard path matching
+# ---------------------------------------------------------------------------
+
+@test "mock_server: wildcard path — GET /api/v1/agents/* matches specific agent ID" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents/*","status":200,"body":{"id":"abc123","name":"my-agent"}}
+    ]'
+    body="$(_curl_get_body /api/v1/agents/abc123)"
+    id="$(echo "$body" | jq -r '.id')"
+    [[ "$id" == "abc123" ]]
+}
+
+@test "mock_server: wildcard path — exact match takes priority over wildcard (first match wins)" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents/special","status":200,"body":{"route":"exact"}},
+        {"method":"GET","path":"/api/v1/agents/*","status":200,"body":{"route":"wildcard"}}
+    ]'
+    body_exact="$(_curl_get_body /api/v1/agents/special)"
+    body_wild="$(_curl_get_body /api/v1/agents/other)"
+    route_exact="$(echo "$body_exact" | jq -r '.route')"
+    route_wild="$(echo "$body_wild" | jq -r '.route')"
+    [[ "$route_exact" == "exact" ]]
+    [[ "$route_wild" == "wildcard" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+@test "mock_server: per-route — unmatched path falls back to default_status/default_body" {
+    _start_mock_with_routes '{
+        "routes":[{"method":"GET","path":"/api/v1/agents","status":200,"body":[]}],
+        "default_status":404,
+        "default_body":{"error":"not found"}
+    }'
+    code="$(_curl_get /api/v1/unknown)"
+    [[ "$code" == "404" ]]
+}
+
+@test "mock_server: per-route — unmatched method falls back to default even if path matches" {
+    _start_mock_with_routes '{
+        "routes":[{"method":"GET","path":"/api/v1/agents","status":200,"body":[]}],
+        "default_status":405,
+        "default_body":{"error":"method not allowed"}
+    }'
+    code="$(_curl_post_code /api/v1/agents)"
+    [[ "$code" == "405" ]]
+}
+
+@test "mock_server: per-route — fallback to MOCK_STATUS env var when no default in config" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[]}
+    ]'
+    # No MOCK_STATUS set → defaults to 200 for unmatched routes
+    code="$(_curl_get /api/v1/unmatched)"
+    [[ "$code" == "200" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Object-wrapper format (legacy / alternative)
+# ---------------------------------------------------------------------------
+
+@test "mock_server: object-format routes config — routes key works correctly" {
+    _start_mock_with_routes '{
+        "routes":[
+            {"method":"GET","path":"/health","status":200,"body":{"healthy":true}}
+        ],
+        "default_status":503,
+        "default_body":{"healthy":false}
+    }'
+    body="$(_curl_get_body /health)"
+    healthy="$(echo "$body" | jq -r '.healthy')"
+    [[ "$healthy" == "true" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Multi-step workflow test (the core use-case from issue #192)
+# ---------------------------------------------------------------------------
+
+@test "mock_server: multi-step workflow — list then get then update use single server" {
+    # Simulates a workflow that: lists agents, fetches one by ID, then patches it.
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"id":"wf1","name":"workflow-agent","status":"offline"}]},
+        {"method":"GET","path":"/api/v1/agents/*","status":200,"body":{"id":"wf1","name":"workflow-agent","status":"offline"}},
+        {"method":"PATCH","path":"/api/v1/agents/*","status":200,"body":{"id":"wf1","name":"workflow-agent","status":"active"}}
+    ]'
+
+    # Step 1: list
+    list_body="$(_curl_get_body /api/v1/agents)"
+    agent_id="$(echo "$list_body" | jq -r '.[0].id')"
+    [[ "$agent_id" == "wf1" ]]
+
+    # Step 2: get by ID
+    get_body="$(_curl_get_body "/api/v1/agents/${agent_id}")"
+    get_status="$(echo "$get_body" | jq -r '.status')"
+    [[ "$get_status" == "offline" ]]
+
+    # Step 3: patch (wake)
+    patch_body="$(curl -sf -X PATCH -H "Content-Type: application/json" -d '{"status":"active"}' \
+        "http://127.0.0.1:${MOCK_PORT}/api/v1/agents/${agent_id}")"
+    patch_status="$(echo "$patch_body" | jq -r '.status')"
+    [[ "$patch_status" == "active" ]]
+}


### PR DESCRIPTION
Closes #192

Extends `mock_server.py` to accept a `--routes` JSON config file mapping method+path to status+body. Enables multi-step workflow tests (e.g., list then update) using a single mock server instance.

## Changes

- **`tests/helpers/mock_server.py`**: Added `--routes <file>` CLI flag (named arg). Legacy positional second arg still works. Accepts flat JSON array format (`[{method, path, status, body}, ...]`) as well as object-wrapper format (`{routes:[...], default_status, default_body}`). Supports wildcard path matching via `fnmatch` (e.g. `/api/v1/agents/*` matches `/api/v1/agents/foo`); first match wins. Body may be a JSON object/array (not just a string).

- **`tests/unit/test_mock_server_routes.bats`**: 11 new bats tests covering flat-array format, wildcard matching, fallback behaviour, object-wrapper format, and a full multi-step workflow test (list → get → patch with a single server instance).

## Routes config format

```json
[
  {"method": "GET",   "path": "/api/v1/agents",   "status": 200, "body": [{"id": "a1"}]},
  {"method": "POST",  "path": "/api/v1/agents",   "status": 201, "body": {"id": "a2"}},
  {"method": "GET",   "path": "/api/v1/agents/*", "status": 200, "body": {"id": "a1"}},
  {"method": "PATCH", "path": "/api/v1/agents/*", "status": 200, "body": {"id": "a1", "status": "active"}}
]
```

## Test plan

- [x] All 11 new tests pass (`bats tests/unit/test_mock_server_routes.bats`)
- [x] All 18 existing `test_api.bats` tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)