### PR TITLE
feat(plan): --output json for dry-run, integration tests for JSON output and diff.sh

### DIFF
--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -7,6 +7,7 @@
 # Usage:
 #   ./scripts/plan.sh                  # Plan all agents on all hosts
 #   ./scripts/plan.sh hermes           # Plan agents for a specific host
+#   ./scripts/plan.sh --output json    # Emit machine-readable JSON summary
 #
 # Exit codes:
 #   0 = no changes needed
@@ -25,11 +26,24 @@ source "${SCRIPT_DIR}/lib/log.sh"
 source "${SCRIPT_DIR}/lib/api.sh"
 # shellcheck source=scripts/lib/reconcile.sh
 source "${SCRIPT_DIR}/lib/reconcile.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${SCRIPT_DIR}/lib/report.sh"
 
 load_config
 
 HOST=""
 FLEET_NAME=""
+OUTPUT_FORMAT="text"   # "text" | "json"
+
+# Counters for JSON output
+CREATE_COUNT=0
+UPDATE_COUNT=0
+WAKE_COUNT=0
+HIBERNATE_COUNT=0
+UNCHANGED_COUNT=0
+
+# Accumulate planned_changes entries (one JSON object per line, NDJSON)
+_PLAN_CHANGES_TMP=""
 
 parse_args() {
     while [[ $# -gt 0 ]]; do
@@ -37,7 +51,7 @@ parse_args() {
             -h|--help)  usage; exit 0 ;;
             --dry-run)  shift ;;
             --fleet)    FLEET_NAME="$2"; shift 2 ;;
-            --output)   shift 2 ;;  # Accepted but ignored in plan (no JSON report)
+            --output)   OUTPUT_FORMAT="$2"; shift 2 ;;
             --webhook)  shift 2 ;;  # Accepted but ignored in plan
             -*) echo "ERROR: Unknown argument: $1" >&2; usage; exit 1 ;;
             *) HOST="$1"; shift ;;
@@ -46,14 +60,22 @@ parse_args() {
 }
 
 usage() {
-    echo "Usage: $0 [host] [--fleet <name>]"
+    echo "Usage: $0 [host] [--fleet <name>] [--output json]"
     echo ""
     echo "Shows what apply.sh would do without making any changes."
+    echo ""
+    echo "Options:"
+    echo "  host           Only plan agents for this host (default: all)"
+    echo "  --fleet <name> Only plan agents in the named fleet"
+    echo "  --output json  Emit a machine-readable JSON plan report to stdout"
+    echo "  -h, --help     Show this help"
     echo ""
     echo "Examples:"
     echo "  $0                        # Plan all agents"
     echo "  $0 hermes                 # Plan agents on hermes"
     echo "  $0 --fleet dev-mesh       # Plan agents in the dev-mesh fleet"
+    echo "  $0 --output json          # Machine-readable JSON summary"
+    echo "  $0 hermes --output json | jq .summary"
 }
 
 # plan_report_unmanaged wraps reconcile.sh's report_unmanaged to avoid
@@ -61,6 +83,19 @@ usage() {
 # (#273: prevent name collision with reconcile.sh's report_unmanaged)
 plan_report_unmanaged() {
     report_unmanaged "$@"
+}
+
+# Record one planned change entry into the temp file
+_plan_record_change() {
+    local name="$1"
+    local action="$2"       # CREATE | UPDATE | WAKE | HIBERNATE | UNCHANGED
+    local details="${3:-}"  # human-readable detail string
+
+    jq -n \
+        --arg name "$name" \
+        --arg action "$action" \
+        --arg details "$details" \
+        '{name: $name, action: $action, details: $details}' >> "$_PLAN_CHANGES_TMP"
 }
 
 main() {
@@ -80,7 +115,9 @@ main() {
     check_deps
     agamemnon_check_connection
 
-    trap 'cleanup_fleet_tmpdir' EXIT
+    # Initialise temp file for planned changes and register fleet cleanup
+    _PLAN_CHANGES_TMP="$(mktemp)"
+    trap 'rm -f "$_PLAN_CHANGES_TMP"; cleanup_fleet_tmpdir' EXIT
 
     local agents_json
     agents_json="$(agamemnon_list_agents)"
@@ -89,48 +126,97 @@ main() {
     mapfile -t yaml_files < <(get_agent_files "$HOST" "$FLEET_NAME")
 
     if [[ ${#yaml_files[@]} -eq 0 ]]; then
-        log_info "No agent YAML files found."
+        if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+            _emit_json_plan 0
+        else
+            log_info "No agent YAML files found."
+        fi
         exit 0
     fi
 
     local has_changes=0
-    local CREATE_COUNT=0
-    local UPDATE_COUNT=0
-    local WAKE_COUNT=0
-    local HIBERNATE_COUNT=0
 
-    log_info "Plan for ${AGAMEMNON_URL} (dry-run — no changes will be made)"
-    log_info "================================================================"
-    log_info ""
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        log_info "Plan for ${AGAMEMNON_URL} (dry-run — no changes will be made)"
+        log_info "================================================================"
+        log_info ""
+    fi
 
     for yaml_file in "${yaml_files[@]}"; do
         plan_agent "$yaml_file" "$agents_json" || has_changes=1
     done
 
-    # Report unmanaged agents (in Agamemnon but not in YAML).
-    # When --fleet is active, scope the check to only agents that belong to the
-    # fleet so agents managed by other fleets are not flagged as unmanaged.
-    local scoped_agents_json
-    if [[ -n "$FLEET_NAME" ]]; then
-        local fleet_names_json
-        fleet_names_json="$(for f in "${yaml_files[@]}"; do yq eval '.metadata.name' "$f"; done | jq -Rsc 'split("\n") | map(select(length > 0))')"
-        scoped_agents_json="$(echo "$agents_json" | jq --argjson names "$fleet_names_json" '[.[] | select(.name as $n | $names | index($n) != null)]')"
-    else
-        scoped_agents_json="$agents_json"
-    fi
-    log_info ""
-    log_info "Checking for unmanaged agents..."
-    plan_report_unmanaged "$scoped_agents_json" "${yaml_files[@]}"
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        # Report unmanaged agents (in Agamemnon but not in YAML).
+        # When --fleet is active, scope the check to only agents that belong to the
+        # fleet so agents managed by other fleets are not flagged as unmanaged.
+        local scoped_agents_json
+        if [[ -n "$FLEET_NAME" ]]; then
+            local fleet_names_json
+            fleet_names_json="$(for f in "${yaml_files[@]}"; do yq eval '.metadata.name' "$f"; done | jq -Rsc 'split("\n") | map(select(length > 0))')"
+            scoped_agents_json="$(echo "$agents_json" | jq --argjson names "$fleet_names_json" '[.[] | select(.name as $n | $names | index($n) != null)]')"
+        else
+            scoped_agents_json="$agents_json"
+        fi
+        log_info ""
+        log_info "Checking for unmanaged agents..."
+        plan_report_unmanaged "$scoped_agents_json" "${yaml_files[@]}"
 
-    log_info ""
-    if [[ $has_changes -eq 0 ]]; then
-        log_info "No changes needed. Desired state matches actual state."
-        exit 0
+        log_info ""
+        if [[ $has_changes -eq 0 ]]; then
+            log_info "No changes needed. Desired state matches actual state."
+            exit 0
+        else
+            log_warn "Summary: created=${CREATE_COUNT} updated=${UPDATE_COUNT} woken=${WAKE_COUNT} hibernated=${HIBERNATE_COUNT}"
+            log_warn "Changes would be made. Run ./scripts/apply.sh to apply."
+            exit 1
+        fi
     else
-        log_warn "Summary: created=${CREATE_COUNT} updated=${UPDATE_COUNT} woken=${WAKE_COUNT} hibernated=${HIBERNATE_COUNT}"
-        log_warn "Changes would be made. Run ./scripts/apply.sh to apply."
-        exit 1
+        _emit_json_plan "$has_changes"
+        exit "$has_changes"
     fi
+}
+
+# Emit the JSON plan report and exit
+_emit_json_plan() {
+    local has_changes="$1"
+
+    # Build planned_changes JSON array from NDJSON temp file
+    local changes_json="[]"
+    if [[ -s "$_PLAN_CHANGES_TMP" ]]; then
+        changes_json="$(jq -s '.' "$_PLAN_CHANGES_TMP")"
+    fi
+
+    local timestamp
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+    jq -n \
+        --arg timestamp "$timestamp" \
+        --arg host "${HOST:-all}" \
+        --arg url "${AGAMEMNON_URL:-http://localhost:8080}" \
+        --argjson changes_needed "$has_changes" \
+        --argjson agents_checked "$((CREATE_COUNT + UPDATE_COUNT + WAKE_COUNT + HIBERNATE_COUNT + UNCHANGED_COUNT))" \
+        --argjson to_create "$CREATE_COUNT" \
+        --argjson to_update "$UPDATE_COUNT" \
+        --argjson to_wake "$WAKE_COUNT" \
+        --argjson to_hibernate "$HIBERNATE_COUNT" \
+        --argjson unchanged "$UNCHANGED_COUNT" \
+        --argjson planned_changes "$changes_json" \
+        '{
+            timestamp:     $timestamp,
+            host:          $host,
+            agamemnon_url: $url,
+            summary: {
+                agents_checked: $agents_checked,
+                changes_needed: ($changes_needed == 1),
+                to_create:      $to_create,
+                to_update:      $to_update,
+                to_wake:        $to_wake,
+                to_hibernate:   $to_hibernate,
+                unchanged:      $unchanged
+            },
+            planned_changes: $planned_changes
+        }'
 }
 
 plan_agent() {
@@ -151,6 +237,11 @@ plan_agent() {
     local workdir="${fields[workingDirectory]:-}"
     local args="${fields[programArgs]:-}"
     local desc="${fields[taskDescription]:-}"
+    local tags="${fields[tags]:-}"
+    local model="${fields[model]:-}"
+    local owner="${fields[owner]:-}"
+    local role="${fields[role]:-member}"
+    local deploy_type="${fields[deploymentType]:-local}"
 
     # Look up in actual state
     local actual_json
@@ -158,35 +249,55 @@ plan_agent() {
         '.[] | select(.name == $name)')"
 
     if [[ -z "$actual_json" ]]; then
-        log_info "[+] CREATE ${name} (program=${program}, deploy=${fields[deploymentType]:-local})"
-        if [[ "$desired_state" == "active" ]]; then
-            log_info "    └─ WAKE after create"
+        if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+            log_info "[+] CREATE ${name} (program=${program}, deploy=${deploy_type})"
+            if [[ "$desired_state" == "active" ]]; then
+                log_info "    └─ WAKE after create"
+            fi
         fi
+        _plan_record_change "$name" "CREATE" \
+            "program=${program} deploy=${deploy_type} desired_state=${desired_state}"
         ((CREATE_COUNT++))
         return 1
     fi
 
     local action
     action="$(compute_drift "$name" "$desired_state" "$actual_json" \
-        "$label" "$program" "$workdir" "$args" "$desc")"
+        "$label" "$program" "$workdir" "$args" "$desc" \
+        "$tags" "$model" "$owner" "$role" "$deploy_type")"
 
     case "$action" in
         UNCHANGED)
-            log_info "[=] UNCHANGED ${name}"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_info "[=] UNCHANGED ${name}"
+            fi
+            _plan_record_change "$name" "UNCHANGED" ""
+            ((UNCHANGED_COUNT++))
             ;;
         WAKE)
-            log_warn "[!] WAKE ${name} (desired=active, actual=$(echo "$actual_json" | jq -r '.status'))"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_warn "[!] WAKE ${name} (desired=active, actual=$(echo "$actual_json" | jq -r '.status'))"
+            fi
+            _plan_record_change "$name" "WAKE" \
+                "desired=active actual=$(echo "$actual_json" | jq -r '.status')"
             ((WAKE_COUNT++))
             return 1
             ;;
         HIBERNATE)
-            log_warn "[z] HIBERNATE ${name} (desired=hibernated, actual=$(echo "$actual_json" | jq -r '.status'))"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_warn "[z] HIBERNATE ${name} (desired=hibernated, actual=$(echo "$actual_json" | jq -r '.status'))"
+            fi
+            _plan_record_change "$name" "HIBERNATE" \
+                "desired=hibernated actual=$(echo "$actual_json" | jq -r '.status')"
             ((HIBERNATE_COUNT++))
             return 1
             ;;
         UPDATE:*)
             local fields_changed="${action#UPDATE:}"
-            log_warn "[~] UPDATE ${name}: ${fields_changed} differ"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_warn "[~] UPDATE ${name}: ${fields_changed} differ"
+            fi
+            _plan_record_change "$name" "UPDATE" "fields=${fields_changed}"
             ((UPDATE_COUNT++))
             return 1
             ;;

--- a/tests/integration/test_diff.bats
+++ b/tests/integration/test_diff.bats
@@ -1,0 +1,466 @@
+#!/usr/bin/env bats
+# tests/integration/test_diff.bats
+#
+# Shell-level tests for scripts/diff.sh against a mock Agamemnon server.
+# Verifies output format, exit codes, and correct drift detection.
+#
+# Covers issue #199.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+DIFF_SH="${SCRIPT_DIR}/scripts/diff.sh"
+MOCK_PORT=18084
+MOCK_PID_FILE="/tmp/bats-diff-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: create a unique temp host directory under the real agents/ tree
+# so diff.sh's BASH_SOURCE-based repo root discovery finds the YAML files.
+# ---------------------------------------------------------------------------
+
+_DIFF_TEST_HOST=""
+
+_setup_test_agent() {
+    local agent_yaml="$1"
+    _DIFF_TEST_HOST="difftest-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${_DIFF_TEST_HOST}"
+    cp "$agent_yaml" "${SCRIPT_DIR}/agents/${_DIFF_TEST_HOST}/"
+}
+
+_cleanup_test_agent() {
+    if [[ -n "${_DIFF_TEST_HOST:-}" ]]; then
+        rm -rf "${SCRIPT_DIR}/agents/${_DIFF_TEST_HOST}"
+        _DIFF_TEST_HOST=""
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    # Disable ANSI colors so output comparisons work reliably
+    export NO_COLOR=1
+}
+
+teardown() {
+    _stop_mock_server
+    _cleanup_test_agent
+    unset NO_COLOR
+}
+
+# ---------------------------------------------------------------------------
+# Helper: place a YAML fixture in a temp host dir and run diff.sh
+# ---------------------------------------------------------------------------
+
+_run_diff() {
+    local agent_yaml="$1"
+    shift  # remaining args forwarded to diff.sh
+
+    _setup_test_agent "$agent_yaml"
+    run bash "$DIFF_SH" "$_DIFF_TEST_HOST" "$@"
+    _cleanup_test_agent
+}
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: exits 0 when agent matches Agamemnon exactly (no drift)" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "diff.sh: exits 1 when agent is absent from Agamemnon (CREATE drift)" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+@test "diff.sh: exits 1 when label has drifted" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Old Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+@test "diff.sh: exits 1 when agent needs WAKE (offline but desired active)" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+@test "diff.sh: exits 1 when agent needs HIBERNATE (active but desired hibernated)" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-456",
+        "name": "sleeping-agent",
+        "status": "active",
+        "label": "Sleeping Agent",
+        "program": "aider",
+        "workingDirectory": "/home/mvillmow/SleepProject",
+        "programArgs": "",
+        "taskDescription": "A hibernated agent",
+        "tags": ["hibernated"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-hibernated.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Output format: no-drift case
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: prints 'No drift detected' message when no drift" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"No drift detected"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Output format: drift cases
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: includes agent name in output when CREATE drift detected" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"test-agent"* ]]
+}
+
+@test "diff.sh: shows [+] marker when agent would be created" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"[+]"* ]]
+}
+
+@test "diff.sh: shows [!] marker when agent needs WAKE" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"[!]"* ]]
+}
+
+@test "diff.sh: shows [z] marker when agent needs HIBERNATE" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-456",
+        "name": "sleeping-agent",
+        "status": "active",
+        "label": "Sleeping Agent",
+        "program": "aider",
+        "workingDirectory": "/home/mvillmow/SleepProject",
+        "programArgs": "",
+        "taskDescription": "A hibernated agent",
+        "tags": ["hibernated"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-hibernated.yaml"
+
+    [[ "$output" == *"[z]"* ]]
+}
+
+@test "diff.sh: shows [~] marker when scalar field has drifted" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Stale Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"[~]"* ]]
+}
+
+@test "diff.sh: shows drifted field name in output for label drift" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Stale Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"label"* ]]
+}
+
+@test "diff.sh: shows old and new values in output for label drift" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Stale Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    # Should show old value and new value (arrow format: old → new)
+    [[ "$output" == *"Stale Label"* ]]
+    [[ "$output" == *"Test Agent"* ]]
+}
+
+@test "diff.sh: shows tag changes when tags have drifted" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["old-tag"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"tags"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing: --agent filter
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: --agent filter limits output to named agent" {
+    # Two agents in Agamemnon; only the matching one should appear
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml" --agent test-agent
+
+    [[ "$output" == *"test-agent"* ]]
+}
+
+@test "diff.sh: --agent filter with non-matching name produces no drift output" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml" --agent nonexistent-agent
+
+    # No drift because the filter excludes the drifting agent
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# API connection handling
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: fails gracefully when Agamemnon is unreachable" {
+    # Don't start mock server → connection refused
+    export AGAMEMNON_URL="http://127.0.0.1:19999"
+
+    _setup_test_agent "${FIXTURES_DIR}/agent-valid.yaml"
+    run bash "$DIFF_SH" "$_DIFF_TEST_HOST"
+    _cleanup_test_agent
+
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: minimal agent YAML produces valid diff output" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-minimal.yaml"
+
+    # agent-minimal.yaml has name=minimal-agent; should show as [+] CREATE
+    [[ "$output" == *"[+]"* ]]
+    [[ "$output" == *"minimal-agent"* ]]
+}
+
+@test "diff.sh: program drift is detected and reported" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "aider",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"program"* ]]
+}

--- a/tests/integration/test_plan_json_output.bats
+++ b/tests/integration/test_plan_json_output.bats
@@ -1,0 +1,303 @@
+#!/usr/bin/env bats
+# tests/integration/test_plan_json_output.bats
+#
+# Integration tests for plan.sh --output json.
+# Runs plan.sh against a mock Agamemnon API and validates that:
+#   - The output is valid JSON
+#   - The top-level schema fields (timestamp, host, agamemnon_url, summary, planned_changes) are present
+#   - summary counts match the expected planned actions
+#   - planned_changes entries have name/action/details fields
+#
+# Covers issue #183.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+PLAN_SH="${SCRIPT_DIR}/scripts/plan.sh"
+MOCK_PORT=18083
+MOCK_PID_FILE="/tmp/bats-plan-json-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: create a minimal temp repo root so plan.sh can find agents/
+# ---------------------------------------------------------------------------
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    export NO_COLOR=1
+
+    # Build a temp repo root that mirrors the real one:
+    #   <root>/scripts/ → symlinked to real scripts/
+    #   <root>/agents/testhost/<agent>.yaml
+    REPO_TMP="$(mktemp -d)"
+    mkdir -p "${REPO_TMP}/agents/testhost"
+
+    # Symlink scripts/ into temp root so BASH_SOURCE resolves plan.sh → lib/
+    ln -s "${SCRIPT_DIR}/scripts" "${REPO_TMP}/scripts"
+}
+
+teardown() {
+    _stop_mock_server
+    [[ -n "${REPO_TMP:-}" ]] && rm -rf "$REPO_TMP"
+    unset NO_COLOR
+}
+
+# ---------------------------------------------------------------------------
+# Helper: place a YAML file in the temp repo and run plan.sh --output json
+# plan.sh finds agents/ relative to its own BASH_SOURCE directory.
+# Since scripts/ is a symlink resolving to the real scripts/, the repo root
+# computed by BASH_SOURCE is the real repo root — not REPO_TMP.
+# We therefore copy the agent YAML into the real agents/ under a temp host dir
+# and pass that host name to plan.sh to scope the search.
+# ---------------------------------------------------------------------------
+
+# Unique host name per test to avoid collisions
+_PLAN_TEST_HOST=""
+
+_setup_test_agent() {
+    local agent_yaml="$1"
+    # Use a unique host dir under the real agents/ directory
+    _PLAN_TEST_HOST="plantest-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${_PLAN_TEST_HOST}"
+    cp "$agent_yaml" "${SCRIPT_DIR}/agents/${_PLAN_TEST_HOST}/"
+}
+
+_cleanup_test_agent() {
+    if [[ -n "${_PLAN_TEST_HOST:-}" ]]; then
+        rm -rf "${SCRIPT_DIR}/agents/${_PLAN_TEST_HOST}"
+        _PLAN_TEST_HOST=""
+    fi
+}
+
+# Run plan.sh --output json with a given agent fixture, scoped to the temp host.
+# Sets $output and $status from bats `run`.
+_run_plan_json() {
+    local agent_yaml="$1"
+    shift  # remaining args forwarded to plan.sh
+
+    _setup_test_agent "$agent_yaml"
+    run bash "$PLAN_SH" "$_PLAN_TEST_HOST" --output json "$@"
+    _cleanup_test_agent
+}
+
+# ---------------------------------------------------------------------------
+# Tests: schema and JSON validity
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: produces valid JSON (CREATE scenario)" {
+    # Mock: Agamemnon returns empty list → agent would be created
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    # Output must parse as JSON regardless of exit code
+    echo "$output" | jq . > /dev/null
+}
+
+@test "plan.sh --output json: top-level schema fields are present" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    echo "$output" | jq -e 'has("timestamp")'        > /dev/null
+    echo "$output" | jq -e 'has("host")'             > /dev/null
+    echo "$output" | jq -e 'has("agamemnon_url")'    > /dev/null
+    echo "$output" | jq -e 'has("summary")'          > /dev/null
+    echo "$output" | jq -e 'has("planned_changes")'  > /dev/null
+}
+
+@test "plan.sh --output json: summary has all expected keys" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    echo "$output" | jq -e '.summary | has("agents_checked")'  > /dev/null
+    echo "$output" | jq -e '.summary | has("changes_needed")'  > /dev/null
+    echo "$output" | jq -e '.summary | has("to_create")'       > /dev/null
+    echo "$output" | jq -e '.summary | has("to_update")'       > /dev/null
+    echo "$output" | jq -e '.summary | has("to_wake")'         > /dev/null
+    echo "$output" | jq -e '.summary | has("to_hibernate")'    > /dev/null
+    echo "$output" | jq -e '.summary | has("unchanged")'       > /dev/null
+}
+
+@test "plan.sh --output json: planned_changes is a JSON array" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    arr_kind="$(echo "$output" | jq -r '.planned_changes | type')"
+    [[ "$arr_kind" == "array" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: CREATE scenario
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: to_create incremented when agent absent from Agamemnon" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    to_create="$(echo "$output" | jq -r '.summary.to_create')"
+    [[ "$to_create" -ge 1 ]]
+}
+
+@test "plan.sh --output json: changes_needed is true when CREATE detected" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    changes_needed="$(echo "$output" | jq -r '.summary.changes_needed')"
+    [[ "$changes_needed" == "true" ]]
+}
+
+@test "plan.sh --output json: planned_changes entries have name, action, details fields" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    len="$(echo "$output" | jq '.planned_changes | length')"
+    [[ "$len" -ge 1 ]]
+
+    echo "$output" | jq -e '.planned_changes[0] | has("name")'    > /dev/null
+    echo "$output" | jq -e '.planned_changes[0] | has("action")'  > /dev/null
+    echo "$output" | jq -e '.planned_changes[0] | has("details")' > /dev/null
+}
+
+@test "plan.sh --output json: CREATE action recorded in planned_changes" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    action="$(echo "$output" | jq -r '.planned_changes[0].action')"
+    [[ "$action" == "CREATE" ]]
+}
+
+@test "plan.sh --output json: agent name is correct in planned_changes" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    name="$(echo "$output" | jq -r '.planned_changes[0].name')"
+    [[ "$name" == "test-agent" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: UNCHANGED scenario
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: UNCHANGED when agent matches Agamemnon exactly" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    echo "$output" | jq . > /dev/null
+
+    changes_needed="$(echo "$output" | jq -r '.summary.changes_needed')"
+    [[ "$changes_needed" == "false" ]]
+
+    unchanged="$(echo "$output" | jq -r '.summary.unchanged')"
+    [[ "$unchanged" -eq 1 ]]
+}
+
+@test "plan.sh --output json: UNCHANGED exits 0" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "plan.sh --output json: CREATE exits 1" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: metadata fields
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: agamemnon_url field matches AGAMEMNON_URL env var" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    url="$(echo "$output" | jq -r '.agamemnon_url')"
+    [[ "$url" == "http://127.0.0.1:${MOCK_PORT}" ]]
+}
+
+@test "plan.sh --output json: host field reflects the host argument" {
+    _start_mock_server 200 '[]'
+
+    # The test host is set inside _run_plan_json; capture it before running
+    _setup_test_agent "${FIXTURES_DIR}/agent-valid.yaml"
+    local test_host="$_PLAN_TEST_HOST"
+    run bash "$PLAN_SH" "$test_host" --output json
+    _cleanup_test_agent
+
+    host="$(echo "$output" | jq -r '.host')"
+    [[ "$host" == "$test_host" ]]
+}
+
+@test "plan.sh --output json: stdout contains only valid JSON with no preamble" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    # jq -r 'type' fails on non-JSON; must return 'object'
+    parsed="$(echo "$output" | jq -r 'type')"
+    [[ "$parsed" == "object" ]]
+}


### PR DESCRIPTION
Closes #179
Closes #183
Closes #199

## Summary

- **#179**: Add `--output json` flag to `plan.sh` — emits a machine-readable JSON report with `{timestamp, host, agamemnon_url, summary, planned_changes}` instead of human-readable text. Also fixes `plan_agent` to pass all drift-tracked fields (`owner`, `role`, `model`, `deploymentType`) to `compute_drift` for accurate drift detection.
- **#183**: Add `tests/integration/test_plan_json_output.bats` — 15 integration tests that run `plan.sh --output json` against a mock API and validate the JSON schema, summary counts, `planned_changes` entries, exit codes, and metadata fields.
- **#199**: Add `tests/integration/test_diff.bats` — 19 integration tests for `diff.sh` covering: exit codes (0/1), output markers (`[+]`, `[!]`, `[z]`, `[~]`), field-level drift reporting, tag drift, `--agent` filter, API connection failure, and edge cases.

## Test plan

- [x] All 47 integration tests pass (`pixi run test-integration`)
- [x] All 204 unit tests pass (`pixi run test-unit`)
- [x] Shellcheck passes with no warnings (`pixi run --environment lint lint-shell`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)