### PR TITLE
fix(ci): replace gitleaks-action with gitleaks CLI (fix org license requirement)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,10 +58,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz \
+            | tar -xz -C /usr/local/bin gitleaks
+
       - name: Scan for secrets (gitleaks)
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gitleaks detect --source . --log-opts "origin/main..HEAD"
 
   changelog:
     name: CHANGELOG Updated


### PR DESCRIPTION
## Summary

- `gitleaks-action@v2` requires a paid `GITLEAKS_LICENSE` secret for GitHub org repos — without it, the Security Scan job always fails with "missing gitleaks license"
- Switch to downloading the gitleaks CLI binary directly (free for all use cases)
- Scans commits between `origin/main` and `HEAD`

## Root Cause

`gitleaks-action` v2 introduced a license requirement for organization repositories. Since `HomericIntelligence` is an org, every PR's Security Scan was failing.

Supersedes #352 (stale base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)