### PR TITLE
docs(setup): add pre-commit hook install step to README and justfile (#145) [skip changelog]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ Myrmidons is the source of truth for *desired* agent state. Agent definitions li
 ## Quick start
 
 ```bash
+# Install pre-commit hooks (runs the dangerous-flags policy check on every commit)
+just install-hooks
+
 # Export current Agamemnon agents to YAML (run once)
 ./scripts/export.sh
 


### PR DESCRIPTION
Closes #145

## Summary

Add `just install-hooks` as the first step in CLAUDE.md's Quick Start section to ensure new contributors install the pre-commit hook that enforces the dangerous-flags policy before making changes.

The README.md already documents this step, but CLAUDE.md did not. New contributors reading only CLAUDE.md would miss the hook setup until a CI failure surfaced the policy violation.

## Validation

All tests pass:
- `bash scripts/check-dangerous-flags.sh` — PASS
- `pixi run test-schema` — Checked: 19 files, Errors: 0
- `pixi run test-doc-drift` — Checked: 99 files, Errors: 0
- `just --list | grep -i hook` — install-hooks recipe exists

Generated with Claude Code