### PR TITLE
fix(reconcile): restore 'not found' in fleet ref error message [skip changelog]

### DIFF
--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -219,7 +219,7 @@ resolve_fleet_files() {
 
             local agent_file="${repo_root}/agents/${ref_host}/${ref_name}.yaml"
             if [[ ! -f "$agent_file" ]]; then
-                echo "ERROR: Fleet '${fleet_file}': ref '${ref}' does not resolve — expected file at ${agent_file}" >&2
+                echo "ERROR: Fleet ref '${ref}' not found — expected file at ${agent_file}" >&2
                 return 1
             fi
             echo "$agent_file"


### PR DESCRIPTION
PR #332 changed the error message in `resolve_fleet_files` from `'not found'` to `'does not resolve'` but `test_fleet.bats` test 175 checks for `'not found'`. This restores consistent wording to fix the CI test failure on main.

## Summary
- Fixes test 175: `resolve_fleet_files: bad ref path exits 1 with error`
- Restores error message to: `ERROR: Fleet ref '${ref}' not found — expected file at ${agent_file}`

## Test plan
- [x] `pixi run test-unit` — all 332 tests pass