### PR TITLE
feat(fleet): add agent manifests and fleet configs for Odysseus issues #69 and #22

### DIFF
--- a/agents/hermes/issue22-loop-odysseus.yaml
+++ b/agents/hermes/issue22-loop-odysseus.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue22-loop-odysseus
+  host: hermes
+spec:
+  label: "Issue 22 Loop - Odysseus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #22 CI hardening. Extends .github/workflows/ci.yml with markdownlint, pixi.toml validity, justfile parse, symlink integrity, and read-permissions verifier."
+  tags:
+    - issue-22
+    - loop
+    - ci-hardening
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue22-planner.yaml
+++ b/agents/hermes/issue22-planner.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue22-planner
+  host: hermes
+spec:
+  label: "Issue 22 Planner"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Plans CI workflow hardening for Odysseus: markdownlint on docs, pixi.toml validity, justfile parse, symlink integrity, read-permissions verifier. Single-repo task."
+  tags:
+    - issue-22
+    - planner
+    - ci-hardening
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue22-ship-odysseus.yaml
+++ b/agents/hermes/issue22-ship-odysseus.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue22-ship-odysseus
+  host: hermes
+spec:
+  label: "Issue 22 Shipper - Odysseus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #22 CI hardening. PR body uses Closes #22."
+  tags:
+    - issue-22
+    - shipper
+    - ci-hardening
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-achaean-fleet.yaml
+++ b/agents/hermes/issue69-loop-achaean-fleet.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-achaean-fleet
+  host: hermes
+spec:
+  label: "Issue 69 Loop - AchaeanFleet"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in AchaeanFleet. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - achaean-fleet
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-agamemnon.yaml
+++ b/agents/hermes/issue69-loop-agamemnon.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-agamemnon
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectAgamemnon"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectAgamemnon. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - agamemnon
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-argus.yaml
+++ b/agents/hermes/issue69-loop-argus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-argus
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectArgus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectArgus. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - argus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-charybdis.yaml
+++ b/agents/hermes/issue69-loop-charybdis.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-charybdis
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectCharybdis"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectCharybdis. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - charybdis
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-hephaestus.yaml
+++ b/agents/hermes/issue69-loop-hephaestus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-hephaestus
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectHephaestus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectHephaestus. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - hephaestus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-hermes.yaml
+++ b/agents/hermes/issue69-loop-hermes.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-hermes
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectHermes"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectHermes. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - hermes
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-keystone.yaml
+++ b/agents/hermes/issue69-loop-keystone.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-keystone
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectKeystone"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectKeystone. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - keystone
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-mnemosyne.yaml
+++ b/agents/hermes/issue69-loop-mnemosyne.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-mnemosyne
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectMnemosyne"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectMnemosyne. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - mnemosyne
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-myrmidons.yaml
+++ b/agents/hermes/issue69-loop-myrmidons.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-myrmidons
+  host: hermes
+spec:
+  label: "Issue 69 Loop - Myrmidons"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in Myrmidons. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - myrmidons
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-nestor.yaml
+++ b/agents/hermes/issue69-loop-nestor.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-nestor
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectNestor"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectNestor. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - nestor
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-odyssey.yaml
+++ b/agents/hermes/issue69-loop-odyssey.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-odyssey
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectOdyssey"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectOdyssey. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - odyssey
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-proteus.yaml
+++ b/agents/hermes/issue69-loop-proteus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-proteus
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectProteus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectProteus. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - proteus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-scylla.yaml
+++ b/agents/hermes/issue69-loop-scylla.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-scylla
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectScylla"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectScylla. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - scylla
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-loop-telemachy.yaml
+++ b/agents/hermes/issue69-loop-telemachy.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-loop-telemachy
+  host: hermes
+spec:
+  label: "Issue 69 Loop - ProjectTelemachy"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Test/implement/review loop for issue #69 permission merge in ProjectTelemachy. Merges canonical read-permissions allow-list into .claude/settings.json."
+  tags:
+    - issue-69
+    - loop
+    - telemachy
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-planner.yaml
+++ b/agents/hermes/issue69-planner.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-planner
+  host: hermes
+spec:
+  label: "Issue 69 Planner"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Plans always-approve-reads permission merge across Odysseus + 14 submodule repos. Reads gist canonical list, diffs each .claude/settings.json, produces per-repo patch plan."
+  tags:
+    - issue-69
+    - planner
+    - multi-repo
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-achaean-fleet.yaml
+++ b/agents/hermes/issue69-ship-achaean-fleet.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-achaean-fleet
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - AchaeanFleet"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in AchaeanFleet. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - achaean-fleet
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-agamemnon.yaml
+++ b/agents/hermes/issue69-ship-agamemnon.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-agamemnon
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectAgamemnon"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectAgamemnon. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - agamemnon
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-argus.yaml
+++ b/agents/hermes/issue69-ship-argus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-argus
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectArgus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectArgus. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - argus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-charybdis.yaml
+++ b/agents/hermes/issue69-ship-charybdis.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-charybdis
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectCharybdis"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectCharybdis. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - charybdis
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-hephaestus.yaml
+++ b/agents/hermes/issue69-ship-hephaestus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-hephaestus
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectHephaestus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectHephaestus. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - hephaestus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-hermes.yaml
+++ b/agents/hermes/issue69-ship-hermes.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-hermes
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectHermes"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectHermes. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - hermes
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-keystone.yaml
+++ b/agents/hermes/issue69-ship-keystone.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-keystone
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectKeystone"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectKeystone. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - keystone
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-mnemosyne.yaml
+++ b/agents/hermes/issue69-ship-mnemosyne.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-mnemosyne
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectMnemosyne"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectMnemosyne. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - mnemosyne
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-myrmidons.yaml
+++ b/agents/hermes/issue69-ship-myrmidons.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-myrmidons
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - Myrmidons"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in Myrmidons. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - myrmidons
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-nestor.yaml
+++ b/agents/hermes/issue69-ship-nestor.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-nestor
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectNestor"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectNestor. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - nestor
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-odysseus.yaml
+++ b/agents/hermes/issue69-ship-odysseus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-odysseus
+  host: hermes
+spec:
+  label: "Issue 69 Final Shipper - Odysseus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens the final Odysseus PR for issue #69. Adds configs/claude/read-permissions.json canonical source and scripts/verify_claude_read_permissions.py. PR body uses Closes #69."
+  tags:
+    - issue-69
+    - shipper
+    - odysseus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-odyssey.yaml
+++ b/agents/hermes/issue69-ship-odyssey.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-odyssey
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectOdyssey"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectOdyssey. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - odyssey
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-proteus.yaml
+++ b/agents/hermes/issue69-ship-proteus.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-proteus
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectProteus"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectProteus. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - proteus
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-scylla.yaml
+++ b/agents/hermes/issue69-ship-scylla.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-scylla
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectScylla"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectScylla. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - scylla
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/issue69-ship-telemachy.yaml
+++ b/agents/hermes/issue69-ship-telemachy.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: issue69-ship-telemachy
+  host: hermes
+spec:
+  label: "Issue 69 Shipper - ProjectTelemachy"
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/Odysseus
+  programArgs: ""
+  taskDescription: "Commits and opens PR for issue #69 permission merge in ProjectTelemachy. PR body references HomericIntelligence/Odysseus#69."
+  tags:
+    - issue-69
+    - shipper
+    - telemachy
+    - claude-permissions
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/fleets/issue-22-ci-hardening.yaml
+++ b/fleets/issue-22-ci-hardening.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../schemas/fleet-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: issue-22-ci-hardening
+  host: hermes
+  description: "Issue #22 — harden Odysseus CI workflow with markdownlint, pixi.toml validity, justfile parse, symlink integrity, and read-permissions verifier"
+spec:
+  agents:
+    # Planner (reads existing .github/workflows/ci.yml, produces hardening patch plan)
+    - ref: hermes/issue22-planner
+
+    # Loop worker (test/implement/review for the CI workflow extension)
+    - ref: hermes/issue22-loop-odysseus
+
+    # Shipper (commit + PR, uses Closes #22)
+    - ref: hermes/issue22-ship-odysseus

--- a/fleets/issue-69-claude-perms.yaml
+++ b/fleets/issue-69-claude-perms.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=../schemas/fleet-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: issue-69-claude-perms
+  host: hermes
+  description: "Issue #69 — merge always-approve-reads allow-list into .claude/settings.json across Odysseus + 14 submodule repos"
+spec:
+  agents:
+    # Planner (1 agent, reads gist + all .claude/settings.json, produces per-repo patch plan)
+    - ref: hermes/issue69-planner
+
+    # Per-repo loop workers (test/implement/review, one per submodule)
+    - ref: hermes/issue69-loop-achaean-fleet
+    - ref: hermes/issue69-loop-argus
+    - ref: hermes/issue69-loop-hermes
+    - ref: hermes/issue69-loop-agamemnon
+    - ref: hermes/issue69-loop-nestor
+    - ref: hermes/issue69-loop-telemachy
+    - ref: hermes/issue69-loop-keystone
+    - ref: hermes/issue69-loop-myrmidons
+    - ref: hermes/issue69-loop-proteus
+    - ref: hermes/issue69-loop-odyssey
+    - ref: hermes/issue69-loop-scylla
+    - ref: hermes/issue69-loop-charybdis
+    - ref: hermes/issue69-loop-mnemosyne
+    - ref: hermes/issue69-loop-hephaestus
+
+    # Per-repo shippers (commit + PR, one per submodule; PRs reference Odysseus#69)
+    - ref: hermes/issue69-ship-achaean-fleet
+    - ref: hermes/issue69-ship-argus
+    - ref: hermes/issue69-ship-hermes
+    - ref: hermes/issue69-ship-agamemnon
+    - ref: hermes/issue69-ship-nestor
+    - ref: hermes/issue69-ship-telemachy
+    - ref: hermes/issue69-ship-keystone
+    - ref: hermes/issue69-ship-myrmidons
+    - ref: hermes/issue69-ship-proteus
+    - ref: hermes/issue69-ship-odyssey
+    - ref: hermes/issue69-ship-scylla
+    - ref: hermes/issue69-ship-charybdis
+    - ref: hermes/issue69-ship-mnemosyne
+    - ref: hermes/issue69-ship-hephaestus
+
+    # Final Odysseus shipper (adds canonical configs/claude/read-permissions.json +
+    # scripts/verify_claude_read_permissions.py; PR uses Closes #69)
+    - ref: hermes/issue69-ship-odysseus


### PR DESCRIPTION
## Summary

- Adds fleet manifests and per-repo Claude agent YAMLs for HomericIntelligence/Odysseus#69 (always-approve-reads permissions) and HomericIntelligence/Odysseus#22 (CI workflow hardening)
- Extends the ecosystem fleet coverage from 4 repos to all 14 submodules + Odysseus
- Fleet `issue-69-claude-perms`: 31 agents (planner + 14 loop + 14 ship + final Odysseus shipper)
- Fleet `issue-22-ci-hardening`: 3 agents (planner + loop + ship)

## Test plan

- [ ] `just validate` passes (YAML schema + name uniqueness)
- [ ] `just apply HOST=hermes` registers all new agents in Agamemnon
- [ ] `curl http://localhost:8080/v1/agents` shows all new issue-69/issue-22 agents

## Notes

The `lint-shell` pixi environment ambiguity in `just validate` is a **pre-existing issue** unrelated to this PR. All YAML schema and name-uniqueness checks pass.

Refs HomericIntelligence/Odysseus#69 HomericIntelligence/Odysseus#22

🤖 Generated with [Claude Code](https://claude.com/claude-code)