### PR TITLE
docs(readme): add repo grade badge (B+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Lint and Test](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lint.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lint.yml)
 [![Validate YAML](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/validate.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/validate.yml)
+[![Repo Grade: B+](https://img.shields.io/badge/repo%20grade-B%2B-brightgreen)](https://github.com/HomericIntelligence/Myrmidons/issues/35)
 
 GitOps agent provisioning for the HomericIntelligence mesh.
 Agent YAML files are the source of truth for **desired** state.


### PR DESCRIPTION
## Summary

Adds a repo-grade badge to README reflecting the post-swarm audit re-grade.

- Audit ran 2026-03-22 at **D- (62%)** — NO-GO
- Post-swarm re-grade 2026-04-24: **B+ (85%)** — 34 of 35 original issues resolved
- 332 unit tests pass on `main`; CI green

## Closes

Closes #35

## Badge

```
[![Repo Grade: B+](https://img.shields.io/badge/repo%20grade-B%2B-brightgreen)](https://github.com/HomericIntelligence/Myrmidons/issues/35)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)