### PR TITLE
fix(agents): correct yaml-language-server schema hint in issue69-loop-myrmidons.yaml

### DIFF
--- a/agents/hermes/issue69-loop-myrmidons.yaml
+++ b/agents/hermes/issue69-loop-myrmidons.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: =../../schemas/agent-v1.schema.json
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
 apiVersion: myrmidons/v1
 kind: Agent
 metadata:


### PR DESCRIPTION
## Summary

- Fixes malformed `yaml-language-server` hint on line 1 of `agents/hermes/issue69-loop-myrmidons.yaml`
- The `$schema=` prefix was missing (was `=../../schemas/...`, should be `$schema=../../schemas/...`)
- Without the prefix, IDE schema validation was silently disabled for this manifest

## Test plan

- [ ] Verify the hint now matches the canonical form in `aindrea.yaml` and other manifests
- [ ] Open the file in an IDE with yaml-language-server to confirm schema validation activates

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)