### PR TITLE
fix(apply): correct REPO_ROOT case typo in default snapshot path

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -495,7 +495,7 @@ main() {
     agents_json="$(agamemnon_list_agents)"
 
     # Capture pre-apply snapshot (#228: includes context fields user/branch/host/timestamp)
-    local effective_snapshot_dir="${SNAPSHOT_DIR:-${repo_root}/.myrmidons/snapshots}"
+    local effective_snapshot_dir="${SNAPSHOT_DIR:-${REPO_ROOT}/.myrmidons/snapshots}"
     local snap_file
     snap_file="$(snapshot_write "$agents_json" "$effective_snapshot_dir" "${HOST:-all}")"
     snapshot_prune "$effective_snapshot_dir" "$SNAPSHOT_KEEP"

--- a/tests/test-rollback.sh
+++ b/tests/test-rollback.sh
@@ -393,6 +393,21 @@ test_apply_snapshot_dir_flag() {
         "Unknown argument" "$output"
 }
 
+# ── Test: default snapshot dir uses REPO_ROOT not root (issue #370) ───────────
+
+test_default_snapshot_dir_uses_repo_root() {
+    echo ""
+    echo "=== default snapshot dir resolves to REPO_ROOT, not / ==="
+
+    # Grep apply.sh directly: the default must reference REPO_ROOT (uppercase),
+    # not repo_root (lowercase undefined variable). Under set -u the lowercase
+    # form fatally aborts; when set -u is absent it silently expands to ""
+    # producing /.myrmidons/snapshots (a root-filesystem write attempt).
+    local occurrences
+    occurrences="$(grep -c '\${repo_root}' "${REPO_ROOT}/scripts/apply.sh" || true)"
+    assert_eq "no lowercase repo_root reference in apply.sh (issue #370)" "0" "$occurrences"
+}
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 run_all_tests() {
@@ -409,6 +424,7 @@ run_all_tests() {
     test_rollback_invalid_json_snapshot
     test_rollback_specific_snapshot_file
     test_apply_snapshot_dir_flag
+    test_default_snapshot_dir_uses_repo_root
 
     echo ""
     echo "================================================"


### PR DESCRIPTION
## Summary

- `apply.sh:35` defines `REPO_ROOT` (uppercase), but `apply.sh:498` referenced `${repo_root}` (lowercase — undefined under `set -u`)
- When `SNAPSHOT_DIR` is unset (the default), the snapshot subsystem either fatally aborts (with `set -u`) or silently writes to `/.myrmidons/snapshots` (root filesystem) making snapshots non-functional out of the box
- Fix: replace `${repo_root}` → `${REPO_ROOT}` on line 498

## Test plan

- [x] Added `test_default_snapshot_dir_uses_repo_root` to `tests/test-rollback.sh` — greps `apply.sh` for any remaining `${repo_root}` occurrences and fails if found
- [x] All 21 rollback/snapshot tests pass (`bash tests/test-rollback.sh`)
- [x] Existing test suite unaffected

Closes #370
Part of #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)