### PR TITLE
refactor(apply): remove dead write_failed_agents_file

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -176,20 +176,6 @@ record_failure() {
     FAILED_AGENT_MESSAGES+=("$error_message")
 }
 
-# Write failed agent names to .myrmidons/failed-agents.txt for use by 'just retry'.
-# This file is self-managing (issue #269):
-# - Truncated before writing (: > ...), so contains only agents that failed THIS run.
-# - On partial retry success: updated with only agents still failing (previously-succeeded agents removed).
-# - On full retry success: cleared by the explicit block at end of main().
-# Operators do not need to manually delete or manage this file.
-write_failed_agents_file() {
-    mkdir -p "${MYRMIDONS_STATE_DIR}"
-    : > "${FAILED_AGENTS_FILE}"
-    for name in "${FAILED_AGENT_NAMES[@]}"; do
-        echo "$name" >> "${FAILED_AGENTS_FILE}"
-    done
-}
-
 # Print a detailed per-agent error summary.
 print_error_summary() {
     echo ""


### PR DESCRIPTION
## Summary

- Removes the dead `write_failed_agents_file()` public function (was at line 185) and its 6-line comment block from `scripts/apply.sh`
- This function iterated `FAILED_AGENT_NAMES[]` but had **zero call sites** across the entire codebase
- The private `_write_failed_agents_file()` (line 677, iterates `FAILED_AGENTS[]`) remains as the sole live implementation, called by retry logic
- `FAILED_AGENT_NAMES` itself is preserved — still populated by `record_failure()` and consumed by `print_error_summary()`

## Test plan

- [x] `grep -rn "write_failed_agents_file" scripts/ tests/` — only the private variant remains (no dead callers)
- [x] `pixi run --environment lint lint-shell` — shellcheck clean, zero new warnings
- [x] `pixi run test` — 20 passed, 0 failed

Closes #371
Part of #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)