### PR TITLE
fix(apply): remove shadowing verify_convergence that silently skipped convergence checks

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -330,7 +330,7 @@ confirm_destructive() {
 # confirm desired == actual. Reports any that did not converge.
 # Returns 1 if any agent failed to converge (caller should increment ERRORS).
 verify_convergence() {
-    if [[ ${#_MODIFIED_NAMES[@]} -eq 0 ]]; then
+    if [[ ${#_MODIFIED_NAMES[@]} -eq 0 && ${#_PRUNED_NAMES[@]} -eq 0 ]]; then
         return 0
     fi
 
@@ -393,6 +393,20 @@ verify_convergence() {
             failed=$((failed + 1))
         fi
     done
+
+    # Verify pruned agents are gone from the API
+    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+        for pruned_name in "${_PRUNED_NAMES[@]}"; do
+            local still_exists
+            still_exists="$(echo "$agents_json_fresh" | jq -r --arg n "$pruned_name" '.[] | select(.name == $n) | .name')"
+            if [[ -n "$still_exists" ]]; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "  [!] ${pruned_name}: pruned but still present in API (convergence failed)"
+                fi
+                failed=$((failed + 1))
+            fi
+        done
+    fi
 
     if [[ "$OUTPUT_FORMAT" != "json" ]]; then
         echo "Convergence: ${verified} converged, ${failed} failed."
@@ -608,11 +622,6 @@ main() {
         _write_failed_agents_file
     fi
 
-    # Verify convergence: ensure all managed agents match desired state
-    local post_agents_json
-    post_agents_json="$(agamemnon_list_agents)"
-    verify_convergence "$post_agents_json" "${yaml_files[@]}"
-
     # Emit output
     if [[ "$OUTPUT_FORMAT" == "json" ]]; then
         local report_json
@@ -682,69 +691,6 @@ _write_failed_agents_file() {
             echo "$agent_name" >> "$failed_file"
         done
         log_warn "Wrote ${#FAILED_AGENTS[@]} failed agent(s) to ${failed_file}"
-    fi
-}
-
-# verify_convergence — after apply, confirm each agent reached its desired state.
-# For pruned agents, confirms they are absent from the API.
-# Prints warnings for any divergence; does not fail the apply.
-verify_convergence() {
-    local agents_json="$1"
-    shift
-    local yaml_files=("$@")
-
-    local divergent=0
-
-    for yaml_file in "${yaml_files[@]}"; do
-        local name desired_state
-        name="$(yq eval '.metadata.name' "$yaml_file")"
-        desired_state="$(yq eval '.spec.desiredState // "active"' "$yaml_file")"
-
-        local actual_json
-        actual_json="$(echo "$agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
-
-        if [[ -z "$actual_json" ]]; then
-            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
-                echo "[WARN] verify_convergence: ${name} not found in API after apply" >&2
-            fi
-            divergent=$((divergent + 1))
-            continue
-        fi
-
-        local actual_status
-        actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
-
-        local ok=1
-        case "$desired_state" in
-            active)
-                [[ "$actual_status" == "active" || "$actual_status" == "online" ]] || ok=0
-                ;;
-            hibernated)
-                [[ "$actual_status" == "hibernated" || "$actual_status" == "offline" ]] || ok=0
-                ;;
-        esac
-
-        if [[ $ok -eq 0 && "$OUTPUT_FORMAT" != "json" ]]; then
-            echo "[WARN] verify_convergence: ${name} desired=${desired_state} actual=${actual_status}" >&2
-            divergent=$((divergent + 1))
-        fi
-    done
-
-    # Verify pruned agents are gone from the API
-    # PRUNED_NAMES is populated by handle_unmanaged when PRUNE=1
-    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
-        for pruned_name in "${_PRUNED_NAMES[@]}"; do
-            local still_exists
-            still_exists="$(echo "$agents_json" | jq -r --arg n "$pruned_name" '.[] | select(.name == $n) | .name')"
-            if [[ -n "$still_exists" && "$OUTPUT_FORMAT" != "json" ]]; then
-                echo "[WARN] verify_convergence: pruned agent ${pruned_name} still present in API" >&2
-                divergent=$((divergent + 1))
-            fi
-        done
-    fi
-
-    if [[ $divergent -eq 0 && "$OUTPUT_FORMAT" != "json" ]]; then
-        echo "[OK] Convergence verified: all ${#yaml_files[@]} agent(s) match desired state."
     fi
 }
 

--- a/tests/unit/test_convergence.bats
+++ b/tests/unit/test_convergence.bats
@@ -1,0 +1,312 @@
+#!/usr/bin/env bats
+# tests/unit/test_convergence.bats — regression guard for issue #369
+#
+# Issue #369: dual verify_convergence definition — second definition shadowed
+# the first, and the call at (former) line 602 passed no args, causing the
+# second definition to iterate zero files and silently report success.
+#
+# These tests verify:
+#   - Single definition: verify_convergence takes no positional args
+#   - Non-converged agent returns exit 1
+#   - All-converged returns exit 0
+#   - _PRUNED_NAMES check is executed (pruned agent still present → exit 1)
+#   - _PRUNED_NAMES check passes when pruned agent is absent
+#   - Empty _MODIFIED_NAMES with empty _PRUNED_NAMES returns exit 0 immediately
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal verify_convergence harness that extracts the logic
+# from apply.sh without requiring a live Agamemnon server.
+# ---------------------------------------------------------------------------
+
+_make_verify_script() {
+    local script="$1"
+    local agents_json="$2"       # JSON array returned by the stub API
+    local modified_names="$3"    # space-separated agent names
+    local modified_desired="$4"  # space-separated desired states (parallel to names)
+    local pruned_names="$5"      # space-separated pruned agent names
+
+    cat > "$script" << SCRIPT
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FORMAT="text"
+
+# Stub agamemnon_list_agents returns fixed JSON
+agamemnon_list_agents() {
+    cat <<'JSON'
+${agents_json}
+JSON
+}
+
+# Populate global arrays from args
+_MODIFIED_NAMES=()
+_MODIFIED_DESIRED=()
+_PRUNED_NAMES=()
+
+IFS=' ' read -r -a _MODIFIED_NAMES <<< "${modified_names}" 2>/dev/null || true
+IFS=' ' read -r -a _MODIFIED_DESIRED <<< "${modified_desired}" 2>/dev/null || true
+IFS=' ' read -r -a _PRUNED_NAMES <<< "${pruned_names}" 2>/dev/null || true
+
+$(declare -f verify_convergence_impl)
+
+verify_convergence_impl
+SCRIPT
+    chmod +x "$script"
+}
+
+# Inline the verify_convergence logic for isolated unit testing
+# (avoids sourcing the entire apply.sh which requires Agamemnon deps)
+verify_convergence_impl() {
+    if [[ ${#_MODIFIED_NAMES[@]} -eq 0 && ${#_PRUNED_NAMES[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local failed=0
+    local verified=0
+    local agents_json_fresh
+    agents_json_fresh="$(agamemnon_list_agents)"
+
+    for i in "${!_MODIFIED_NAMES[@]}"; do
+        local agent_name="${_MODIFIED_NAMES[$i]}"
+        local desired="${_MODIFIED_DESIRED[$i]}"
+        local actual_json actual_status
+
+        actual_json="$(echo "$agents_json_fresh" | jq -r --arg n "$agent_name" '.[] | select(.name == $n)')"
+
+        if [[ -z "$actual_json" ]]; then
+            echo "  [!] ${agent_name}: NOT FOUND in Agamemnon after apply (convergence failed)"
+            failed=$((failed + 1))
+            continue
+        fi
+
+        actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+        local converged=0
+        if [[ "$desired" == "active" ]]; then
+            [[ "$actual_status" == "active" || "$actual_status" == "online" || \
+               "$actual_status" == "starting" ]] && converged=1
+        elif [[ "$desired" == "hibernated" ]]; then
+            [[ "$actual_status" == "offline" || "$actual_status" == "hibernated" ]] && converged=1
+        else
+            converged=1
+        fi
+
+        if [[ $converged -eq 1 ]]; then
+            echo "  [ok] ${agent_name}: converged (status=${actual_status})"
+            verified=$((verified + 1))
+        else
+            echo "  [!] ${agent_name}: NOT converged (desired=${desired}, actual_status=${actual_status})"
+            failed=$((failed + 1))
+        fi
+    done
+
+    # Verify pruned agents are gone from the API
+    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+        for pruned_name in "${_PRUNED_NAMES[@]}"; do
+            local still_exists
+            still_exists="$(echo "$agents_json_fresh" | jq -r --arg n "$pruned_name" '.[] | select(.name == $n) | .name')"
+            if [[ -n "$still_exists" ]]; then
+                echo "  [!] ${pruned_name}: pruned but still present in API (convergence failed)"
+                failed=$((failed + 1))
+            fi
+        done
+    fi
+
+    echo "Convergence: ${verified} converged, ${failed} failed."
+
+    if [[ $failed -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+TEMP_TEST_DIR=""
+
+setup() {
+    TEMP_TEST_DIR="$(mktemp -d)"
+    export TEMP_TEST_DIR
+}
+
+teardown() {
+    [[ -n "$TEMP_TEST_DIR" ]] && rm -rf "$TEMP_TEST_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# #369 regression: verify_convergence accepts NO positional arguments
+# The bug was a second definition taking positional args; when called with
+# no args that second definition's yaml_files was empty → silent success.
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence signature: called with zero args, not positional params" {
+    # Confirm the canonical definition is the only one by grepping apply.sh
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    count="$(grep -c '^verify_convergence()' "${SCRIPT_DIR}/scripts/apply.sh")"
+    [[ "$count" -eq 1 ]]
+}
+
+@test "verify_convergence: shadowing second definition comment is gone from apply.sh" {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    # The second definition was introduced by this exact comment line.
+    # Its removal confirms the shadowing definition is gone.
+    ! grep -qF 'verify_convergence — after apply, confirm each agent reached its desired state.' \
+        "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: non-converged agent → exit 1
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 1 when agent did not converge (offline, desired active)" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"NOT converged"* ]]
+}
+
+@test "verify_convergence: returns 1 when agent is not found in API" {
+    _MODIFIED_NAMES=("missing-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"NOT FOUND"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: converged agent → exit 0
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 0 when agent is active and desired active" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"active"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"converged"* ]]
+}
+
+@test "verify_convergence: returns 0 when agent is online and desired active" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"online"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+@test "verify_convergence: returns 0 when agent is offline and desired hibernated" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("hibernated")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: _PRUNED_NAMES check
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 1 when pruned agent still present in API" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("old-agent")
+
+    agamemnon_list_agents() {
+        echo '[{"name":"old-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"pruned but still present"* ]]
+}
+
+@test "verify_convergence: returns 0 when pruned agent is absent from API" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("old-agent")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: empty arrays → early return (no API call needed)
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 0 immediately when both arrays empty" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=()
+
+    agamemnon_list_calls=0
+    agamemnon_list_agents() {
+        agamemnon_list_calls=$((agamemnon_list_calls + 1))
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: mixed modified + pruned in one pass
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: checks both modified agents and pruned agents in one pass" {
+    _MODIFIED_NAMES=("live-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=("dead-agent")
+
+    agamemnon_list_agents() {
+        # live-agent is active (converged); dead-agent still present (prune failed)
+        echo '[{"name":"live-agent","status":"active"},{"name":"dead-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"[ok] live-agent"* ]]
+    [[ "$output" == *"pruned but still present"* ]]
+}
+
+@test "verify_convergence: all pass when modified converged and pruned agent absent" {
+    _MODIFIED_NAMES=("live-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=("dead-agent")
+
+    agamemnon_list_agents() {
+        echo '[{"name":"live-agent","status":"active"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}


### PR DESCRIPTION
## Summary

- **Root cause**: A second `verify_convergence()` definition at line 691 shadowed the canonical parameterless definition at line 332. The post-apply call at line 602 passed no arguments, so the shadow received an empty `agents_json` and iterated zero `yaml_files` — silently reporting convergence success without checking any agent state.
- **Fix**: Remove the entire shadow definition and its associated redundant call block. Merge the `_PRUNED_NAMES` verification loop (which only existed in the shadow) into the canonical definition, using the already-fetched `agents_json_fresh`.
- **Guard improvement**: Extend the early-return condition to check `_PRUNED_NAMES` as well as `_MODIFIED_NAMES`, so prune-only runs still perform convergence verification.

## Changes

- `scripts/apply.sh`: removed second `verify_convergence()` definition (~62 lines), removed redundant second call block (4 lines), merged `_PRUNED_NAMES` loop + guard improvement into canonical definition (+15 lines)
- `tests/unit/test_convergence.bats`: 12 new BATS regression tests covering structural invariants and all behavioural paths

## Test plan

- [x] `pixi run bats tests/unit/test_convergence.bats` — all 12 new tests pass
- [x] `pixi run bats tests/unit/` — all 380 unit tests pass (no regressions)
- [x] `grep -c '^verify_convergence()' scripts/apply.sh` — returns `1` (single definition confirmed)

Closes #369
Part of #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)