### PR TITLE
fix(export): replace hardcoded owner with MYRMIDONS_DEFAULT_OWNER env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Example: `./scripts/apply.sh hermes --output json | jq .summary`
 | `LOG_LEVEL` | `INFO` | Log verbosity: DEBUG, INFO, WARN, ERROR |
 | `LOG_FORMAT` | `text` | Log output format: text or json |
 | `AIM_LOCK_FILE` | `.myrmidons.lock` | Path to the apply lock file (use workspace-scoped path in parallel CI) |
+| `MYRMIDONS_DEFAULT_OWNER` | `$(whoami)` | Fallback owner written to exported agent YAMLs when the Agamemnon API returns no owner |
 
 ## Authentication
 

--- a/scripts/export.sh
+++ b/scripts/export.sh
@@ -8,6 +8,10 @@
 #   ./scripts/export.sh hermes
 #   ./scripts/export.sh                # defaults to "hermes"
 #
+# Environment:
+#   MYRMIDONS_DEFAULT_OWNER  Fallback owner written to exported agent YAMLs when
+#                            the Agamemnon API returns no owner. Defaults to $(whoami).
+#
 # This is the bootstrap script. Run it once to seed Myrmidons
 # from the current Agamemnon state.
 
@@ -34,6 +38,9 @@ main() {
 
     check_jq
     agamemnon_check_connection
+
+    local effective_owner="${MYRMIDONS_DEFAULT_OWNER:-$(whoami)}"
+    log_debug "Default owner for exported agents: ${effective_owner}"
 
     log_info "Exporting agents from Agamemnon (${AGAMEMNON_URL}) for host: ${HOST}"
     log_info ""
@@ -110,7 +117,7 @@ export_agent() {
     workdir="$(echo "$agent_json" | jq -r '.workingDirectory // ""')"
     args="$(echo "$agent_json" | jq -r '.programArgs // ""')"
     desc="$(echo "$agent_json" | jq -r '.taskDescription // ""')"
-    owner="$(echo "$agent_json" | jq -r '.owner // "mvillmow"')"
+    owner="$(echo "$agent_json" | jq -r --arg default_owner "${MYRMIDONS_DEFAULT_OWNER:-$(whoami)}" '.owner // $default_owner')"
     role="$(echo "$agent_json" | jq -r '.role // "member"')"
     status="$(echo "$agent_json" | jq -r '.status // "offline"')"
     deployment_type="$(echo "$agent_json" | jq -r '.deployment.type // "local"')"

--- a/tests/test-export-default-owner.sh
+++ b/tests/test-export-default-owner.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# tests/test-export-default-owner.sh — Unit tests for MYRMIDONS_DEFAULT_OWNER fallback
+#
+# Verifies that export.sh uses MYRMIDONS_DEFAULT_OWNER when set, falls back to
+# $(whoami) when unset, and never contains the hardcoded literal "mvillmow" in
+# any jq expression.
+#
+# Usage:
+#   ./tests/test-export-default-owner.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXPORT_SH="${REPO_ROOT}/scripts/export.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc}"
+        echo "        expected: ${expected}"
+        echo "        actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_no_match() {
+    local desc="$1" pattern="$2" file="$3"
+    if ! grep -qE "$pattern" "$file"; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc} — pattern '${pattern}' still found in ${file}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: extract the resolved owner from the jq expression in export.sh.
+# Simulates the export_agent owner line by evaluating it in a subshell with
+# the given env, passing a synthetic agent JSON with no owner field.
+# ---------------------------------------------------------------------------
+resolve_owner() {
+    local env_var="${1:-}"
+    local agent_json='{"name":"test","label":"Test","program":"claude-code"}'
+
+    if [[ -n "$env_var" ]]; then
+        MYRMIDONS_DEFAULT_OWNER="$env_var" \
+            bash -c "echo '$agent_json' | jq -r --arg default_owner \"\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}\" '.owner // \$default_owner'"
+    else
+        unset MYRMIDONS_DEFAULT_OWNER 2>/dev/null || true
+        bash -c "echo '$agent_json' | jq -r --arg default_owner \"\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}\" '.owner // \$default_owner'"
+    fi
+}
+
+echo "Testing MYRMIDONS_DEFAULT_OWNER fallback logic..."
+echo ""
+
+echo "=== Env var set ==="
+result="$(resolve_owner "custom-user")"
+assert_eq "MYRMIDONS_DEFAULT_OWNER=custom-user → owner is custom-user" "custom-user" "$result"
+
+echo ""
+echo "=== Env var unset (falls back to whoami) ==="
+expected_whoami="$(whoami)"
+result="$(resolve_owner "")"
+assert_eq "Unset MYRMIDONS_DEFAULT_OWNER → owner matches whoami (${expected_whoami})" "$expected_whoami" "$result"
+
+echo ""
+echo "=== Owner present in API response (env var not used) ==="
+result="$(bash -c "
+    agent_json='{\"name\":\"a\",\"label\":\"A\",\"owner\":\"api-owner\"}'
+    MYRMIDONS_DEFAULT_OWNER=env-user
+    echo \"\$agent_json\" | jq -r --arg default_owner \"\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}\" '.owner // \$default_owner'
+")"
+assert_eq "API-supplied owner takes precedence over env var" "api-owner" "$result"
+
+echo ""
+echo "=== Source code does not contain hardcoded 'mvillmow' in a jq expression ==="
+assert_no_match \
+    "No 'mvillmow' literal in a jq fallback expression in export.sh" \
+    'jq.*mvillmow' \
+    "$EXPORT_SH"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Replaces the hardcoded personal username `mvillmow` at `export.sh:117` with a dynamic fallback using `MYRMIDONS_DEFAULT_OWNER` env var, or `$(whoami)` when unset
- Adds a debug log in `main()` surfacing the effective default owner at startup
- Documents the new env var in the script header comment and the `CLAUDE.md` environment variables table
- Adds `tests/test-export-default-owner.sh` with 4 test cases: env var set, whoami fallback, API-supplied owner takes precedence, and absence of the hardcoded literal in any jq expression

## Test plan

- [x] `bash tests/test-export-default-owner.sh` — 4/4 pass
- [x] `bash tests/test-url-validation.sh` — 20/20 pass (no regressions)
- [x] `bash tests/test-api-retry.sh` — 35/35 pass (no regressions)

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)