### PR TITLE
fix(security): make gitleaks scan blocking in validate.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - gitleaks secret scanning: migrated from `gitleaks-action@v2` (paid license) to free CLI install (#263)
 - pixi bumped to 0.67.2; bats-core made platform-specific to fix linux-aarch64 solve failure
 
+### Security
+- gitleaks secret scan is now blocking: removed `continue-on-error: true` from validate.yml security job so secret detection failures fail the PR; dropped `--no-git` so git history is also scanned; added `--config .gitleaks.toml` to use the existing allowlist for known false positives (#375)
+
 ### Fixed
 - pre-commit hook: `REPO_ROOT` now uses `git rev-parse --show-toplevel` so the hook resolves the correct repo root when installed as `.git/hooks/pre-commit` (#330)
 - pre-commit hook: `NAME_LIST` pipeline guarded with `|| true` to prevent `set -o pipefail` from aborting the hook when `yq` returns non-zero on an unstaged file (#330)


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the gitleaks secret scan step in `validate.yml` — secret detection failures now **fail the PR** instead of passing silently
- Drops `--no-git` so gitleaks scans the full git history of the PR's commits, not just the working-tree snapshot
- Adds `--config .gitleaks.toml` to leverage the existing allowlist for known false positives (test fixtures, doc examples)

## Why

A committer could push an `AGAMEMNON_API_KEY` or other bearer token and the PR would pass all required checks. The `.gitleaks.toml` allowlist already exists, so there's no risk of CI being blocked by known FPs.

## Test plan

- [ ] CI `security` job now fails (exit 1) when a secret is introduced in a PR
- [ ] `grep -n 'continue-on-error' .github/workflows/validate.yml` returns no output
- [ ] Existing clean PRs still pass the `security` job (`.gitleaks.toml` allowlist handles known FPs)
- [ ] CHANGELOG.md updated with `### Security` entry

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)