### PR TITLE
fix(justfile): run pre-commit install in install-hooks recipe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ cd Myrmidons
 # Activate the Pixi environment
 pixi shell
 
-# Install the pre-commit hook
+# Install all git hooks (dangerous-flags hook + pre-commit framework)
 just install-hooks
 
 # List available recipes

--- a/justfile
+++ b/justfile
@@ -153,8 +153,15 @@ check: lint test
 # Hooks
 # =============================================================================
 
-# Install the pre-commit hook into .git/hooks/
+# Install all git hooks: copies the dangerous-flags hook AND registers the pre-commit framework
 install-hooks:
     cp hooks/pre-commit .git/hooks/pre-commit
     chmod +x .git/hooks/pre-commit
-    @echo "pre-commit hook installed."
+    pixi run pre-commit install
+    @echo "Hooks installed: dangerous-flags hook + pre-commit framework (.pre-commit-config.yaml)."
+
+# Legacy: install only the dangerous-flags hook script (no pre-commit framework)
+install-hooks-legacy:
+    cp hooks/pre-commit .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+    @echo "Legacy hook installed (dangerous-flags only, no pre-commit framework)."


### PR DESCRIPTION
## Summary

- Extends `install-hooks` to call `pixi run pre-commit install` after copying the dangerous-flags hook, so the full `.pre-commit-config.yaml` framework (shellcheck, yamllint, myrmidons-validate) is registered in one command
- Adds `install-hooks-legacy` recipe for the copy-only path (README already referenced it as a fallback)
- Updates the comment in `CONTRIBUTING.md` to accurately describe the single-command setup

## Test plan

- [ ] Run `just install-hooks` — confirm `pixi run pre-commit install` executes and `.git/hooks/pre-commit` becomes the pre-commit framework shim
- [ ] Run `just install-hooks-legacy` — confirm `.git/hooks/pre-commit` is the raw dangerous-flags script
- [ ] Run `pixi run pre-commit run --all-files` — confirm shellcheck, yamllint, myrmidons-validate, trailing-whitespace all fire
- [ ] Verify `just --list` shows both `install-hooks` and `install-hooks-legacy`

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)