### PR TITLE
fix(apply): add read -t 30 timeout and MYRMIDONS_YES env bypass to --prune prompts

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -298,7 +298,7 @@ confirm_destructive() {
     local total_changes="$1"
 
     # Non-interactive or --yes: skip prompt
-    if [[ $YES -eq 1 ]] || [[ ! -t 0 ]]; then
+    if [[ $YES -eq 1 ]] || [[ "${MYRMIDONS_YES:-}" == "true" ]] || [[ ! -t 0 ]]; then
         return 0
     fi
 
@@ -310,7 +310,7 @@ confirm_destructive() {
     echo "Pending changes: ${total_changes} total, ${_DESTRUCTIVE_COUNT} destructive (WAKE/HIBERNATE/CREATE/PRUNE)"
     printf "Apply %d change(s) to %s? [y/N] " "${total_changes}" "${AGAMEMNON_URL}"
     local reply
-    read -r reply
+    read -t 30 -r reply || reply="N"
     case "$reply" in
         [Yy]|[Yy][Ee][Ss])
             return 0
@@ -476,12 +476,17 @@ main() {
         log_warn "fleets/ directory not found — reconciling agents only"
     fi
 
-    # Confirmation prompt when --prune is set and stdout is a TTY (unless --yes)
-    if [[ $PRUNE -eq 1 && $YES -eq 0 && -t 0 ]]; then
-        echo "WARNING: --prune will hibernate and delete agents not in YAML."
-        printf 'Continue? [y/N] '
+    # Confirmation prompt when --prune is set (unless --yes or MYRMIDONS_YES=true)
+    if [[ $PRUNE -eq 1 && $YES -eq 0 && "${MYRMIDONS_YES:-}" != "true" ]]; then
         local reply
-        read -r reply
+        if [[ ! -t 0 ]]; then
+            # Non-TTY stdin (CI pipe, /dev/null) — default-deny
+            reply="N"
+        else
+            echo "WARNING: --prune will hibernate and delete agents not in YAML."
+            printf 'Continue? [y/N] '
+            read -t 30 -r reply || reply="N"
+        fi
         if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
             echo "Aborted."
             exit 0

--- a/tests/unit/test_apply_yes.bats
+++ b/tests/unit/test_apply_yes.bats
@@ -350,3 +350,101 @@ MOCK_NOTT
     [[ "${retry_flags[*]}" == *"--retry"* ]]
     [[ "${retry_flags[*]}" != *"--fail-fast"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Test: read timeout — #378 — non-TTY stdin defaults to deny
+# ---------------------------------------------------------------------------
+
+# Helper: create a mock that mirrors the updated --prune prompt logic
+_create_timeout_mock() {
+    local mock="$1"
+    cat > "$mock" << 'MOCK_TIMEOUT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+YES=0
+PRUNE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) YES=1; shift ;;
+            --prune)  PRUNE=1; shift ;;
+            *)        shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $PRUNE -eq 1 && $YES -eq 0 && "${MYRMIDONS_YES:-}" != "true" ]]; then
+    reply=""
+    if [[ ! -t 0 ]]; then
+        reply="N"
+    else
+        echo "WARNING: --prune will hibernate and delete agents not in YAML."
+        printf 'Continue? [y/N] '
+        read -t 30 -r reply || reply="N"
+    fi
+    if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "APPLIED"
+exit 0
+MOCK_TIMEOUT
+    chmod +x "$mock"
+}
+
+@test "timeout-mock: non-TTY stdin with --prune defaults to deny (aborts)" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    # Pipe empty stdin — non-TTY, should default-deny
+    run bash -c "echo '' | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Aborted"* ]]
+    [[ "$output" != *"APPLIED"* ]]
+}
+
+@test "timeout-mock: MYRMIDONS_YES=true bypasses --prune prompt" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    run bash -c "MYRMIDONS_YES=true '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+    [[ "$output" != *"Aborted"* ]]
+}
+
+@test "timeout-mock: MYRMIDONS_YES=false still requires confirmation (piped y applies)" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    run bash -c "echo y | MYRMIDONS_YES=false '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    # Non-TTY stdin → default deny even when piping 'y' (guard fires before read)
+    [[ "$output" == *"Aborted"* ]]
+    [[ "$output" != *"APPLIED"* ]]
+}
+
+@test "timeout-mock: piped 'y' to --prune is rejected by non-TTY default-deny guard" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    # The non-TTY guard fires before read, so piped 'y' has no effect
+    run bash -c "echo y | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Aborted"* ]]
+}
+
+@test "timeout-mock: --yes still bypasses prompt regardless of MYRMIDONS_YES" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    run bash -c "'$mock' --prune --yes"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}


### PR DESCRIPTION
## Summary

- Replaces bare `read -r reply` with `read -t 30 -r reply || reply="N"` in both the `--prune` inline prompt and the `confirm_destructive` function, preventing indefinite hangs when stdin is unexpectedly a TTY in CI/Docker
- Non-TTY stdin (pipe, `/dev/null`) is now detected *before* the `read` call and default-denied immediately (no timeout needed)
- Adds `MYRMIDONS_YES=true` env-var bypass alongside the existing `--yes`/`-y` CLI flag, for CI pipelines that invoke the script without control over its argv

## Test plan

- [ ] 5 new bats tests in `tests/unit/test_apply_yes.bats` covering:
  - Non-TTY stdin with `--prune` defaults to deny
  - `MYRMIDONS_YES=true` bypasses the prompt
  - `MYRMIDONS_YES=false` still enforces the non-TTY guard
  - Piped `y` is rejected by the non-TTY default-deny guard (guard fires before `read`)
  - `--yes` still bypasses regardless of `MYRMIDONS_YES`
- [ ] All 18 tests in `test_apply_yes.bats` pass
- [ ] All 77 tests across `test_apply_yes.bats`, `test_apply_args.bats`, `test_apply_error.bats`, `test_reconcile.bats` pass
- [ ] `shellcheck --severity=warning` clean

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)