### PR TITLE
docs: document untracked drift fields, fix CONTRIBUTING.md inconsistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,17 @@ The reconciler detects changes to these fields and applies them automatically on
 | `spec.owner` | UPDATE |
 | `spec.role` | UPDATE |
 
-Fields not currently tracked for drift: `spec.model`, `spec.deployment.type`
+Fields not currently tracked for drift — changes to these fields are **silently
+ignored** by the reconciler and will NOT be applied to the running agent:
+
+| Field | Why not tracked |
+|-------|----------------|
+| `spec.model` | Agamemnon manages model selection at runtime; no drift endpoint exists |
+| `spec.deployment.type` | Type changes require agent recreation, not an update — manual step required |
+
+> **AI agent note:** If you modify `spec.model` or `spec.deployment.type` in a YAML
+> file, `apply.sh` will not detect drift for those fields. The running agent will keep
+> its current values until manually recreated.
 
 ## Scripts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,9 +161,9 @@ The reconciler compares these fields between desired YAML state and actual Agame
 | `spec.owner` | ✓ |
 | `spec.role` | ✓ |
 | `spec.desiredState` | ✓ (drives WAKE/HIBERNATE) |
-| `spec.deployment.type` | ✓ |
+| `spec.deployment.type` | — (not tracked; see below) |
 
-Fields NOT currently tracked (no drift detection): `spec.model`, `spec.deployment.docker.*`
+Fields NOT currently tracked (no drift detection): `spec.model`, `spec.deployment.type`, `spec.deployment.docker.*`
 
 ## Pull Request Process
 

--- a/tests/detect-doc-drift.sh
+++ b/tests/detect-doc-drift.sh
@@ -28,6 +28,10 @@ FORBIDDEN_PHRASES=(
     "apply\.sh.*Nomad|implies apply.sh submits Nomad jobs"
     "Nomad integration.*implemented|implies Nomad integration is complete"
     "Nomad.*currently supported|implies Nomad is currently supported"
+    "spec\.model.*reconcil|implies spec.model changes are reconciled by apply.sh"
+    "spec\.deployment\.type.*reconcil|implies spec.deployment.type changes are reconciled"
+    "spec\.model.*tracked|implies spec.model is tracked for drift"
+    "spec\.deployment\.type.*tracked|implies spec.deployment.type is tracked for drift (it is not)"
 )
 
 # Files and directories to scan (relative to repo root).


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: expands the single-line note about untracked drift fields into a table (with "why not tracked" rationale) plus an AI agent callout block — so agents won't silently expect `spec.model` or `spec.deployment.type` changes to be reconciled
- **CONTRIBUTING.md**: corrects `spec.deployment.type` row from `✓` (tracked) to `— (not tracked)` and adds it to the "Fields NOT currently tracked" footnote — it was inconsistently listed as tracked while CLAUDE.md and README.md said otherwise
- **tests/detect-doc-drift.sh**: adds four new `FORBIDDEN_PHRASES` entries to catch future documentation overclaims implying `spec.model` or `spec.deployment.type` are reconciled/tracked

## Test plan

- [x] `bash tests/detect-doc-drift.sh` exits 0 — all doc files pass the new patterns
- [x] `pixi run --environment lint pre-commit run --all-files` — all hooks pass (pre-existing shellcheck warnings in test_apply_yes.bats and test_doctor.bats are unrelated and present on main)
- [x] Visual check: `grep -A 15 "### Drift detection" CLAUDE.md` shows table + callout block
- [x] `grep "deployment.type" CONTRIBUTING.md` shows `— (not tracked)`, not `✓`

Closes #380
Part of #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)