### PR TITLE
docs(adr): add ADR-008/009/010 for fleet-ref, compute_drift, and schema versioning

### DIFF
--- a/docs/adr/ADR-008-fleet-ref-filename-stem-resolution.md
+++ b/docs/adr/ADR-008-fleet-ref-filename-stem-resolution.md
@@ -1,0 +1,101 @@
+# ADR-008: Fleet ref Resolution by Filename Stem
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Author:** mvillmow
+
+---
+
+## Context
+
+Fleet YAML documents list agents via `spec.agents[].ref` entries such as
+`ref: hermes/aindrea`. The reconciler must resolve this reference to an agent
+YAML file on disk. Each agent YAML has two candidate identifiers that could
+serve as the resolution key:
+
+- **`spec.label`** — the human-readable display name (e.g. `Aindrea`). The
+  export script derives the filename from this field via `label_to_stem()`
+  (`scripts/export.sh:80-83`): lowercase, spaces replaced with hyphens.
+- **`metadata.name`** — the ProjectAgamemnon API identifier / tmux session name
+  (e.g. `odyssey-mainline-analysis`). This is used by the REST API and scripts
+  to identify and operate on agents at runtime.
+
+The reconciler (`scripts/lib/reconcile.sh:210-224`) resolves `ref: hermes/foo`
+to `agents/hermes/foo.yaml`. The question is: what does `foo` represent —
+the label stem or `metadata.name`?
+
+---
+
+## Decision
+
+Fleet `ref:` entries resolve by **filename stem**, where the filename is derived
+from `spec.label` (lowercased, spaces→hyphens) via `label_to_stem()`.
+
+- `ref: hermes/aindrea` → `agents/hermes/aindrea.yaml` (label `Aindrea` → stem
+  `aindrea`) ✓
+- `ref: hermes/odyssey-mainline-analysis` → `agents/hermes/odyssey-mainline-analysis.yaml`
+  would only work if a file with that exact name exists; it is **not** resolved
+  by `metadata.name` ✗
+
+This means the filename is the canonical lookup key, and filenames are always
+label-derived.
+
+---
+
+## Consequences
+
+### Positive
+
+- Fleet refs are short, human-readable, and stable. Labels like `Aindrea` yield
+  stems like `aindrea` — compact and easy to type in fleet YAML.
+- Filesystem layout reflects how users think about agents (by label/role), not
+  how Agamemnon identifies them internally.
+- Renaming an agent in Agamemnon (changing `metadata.name`) does not break
+  existing fleet refs as long as the label is unchanged.
+
+### Negative / Trade-offs
+
+- A reader who knows only `metadata.name` cannot construct the correct `ref:`
+  without also knowing the label. The mapping is documented in `CLAUDE.md` but
+  not enforced by tooling.
+- If `spec.label` changes, the filename must be renamed and all fleet `ref:`
+  entries updated. The tooling does not auto-detect this rename.
+
+### Neutral
+
+- The `label_to_stem()` function in `scripts/export.sh` is the single source of
+  truth for the label→stem conversion. Any future change to that function
+  requires auditing all existing filenames.
+
+---
+
+## Alternatives Considered
+
+### A. Resolve by `metadata.name`
+
+**Rejected.** `metadata.name` values are Agamemnon API identifiers optimized
+for backend uniqueness, not human readability. They are often long compound
+strings (e.g. `odyssey-mainline-analysis`) that reflect Agamemnon's internal
+naming conventions, not the agent's purpose. Coupling filesystem paths to API
+identifiers makes renaming agents in Agamemnon a breaking change in the
+repository layout. It also contradicts the export convention, which already
+derives filenames from labels.
+
+### B. Introduce an explicit `ref` field in each agent YAML
+
+**Rejected.** Adding a third identifier (beyond `metadata.name` and
+`spec.label`) would create a new sync-drift risk: three values must be kept
+consistent. The label-derived filename is deterministic and requires no
+additional field. A dedicated `ref` field would also make the schema more
+complex with no corresponding benefit.
+
+---
+
+## Implementation Scope (this ADR)
+
+| File | Role |
+|------|------|
+| `scripts/lib/reconcile.sh:210-224` | Ref resolution: `ref: host/name` → `agents/<host>/<name>.yaml` |
+| `scripts/export.sh:80-83` | `label_to_stem()` — defines the label→filename mapping |
+| `tests/validate-fleet-refs.sh` | CI test that all fleet `ref:` entries resolve to existing files |
+| `CLAUDE.md` | Documents the naming convention and the ref resolution rule |

--- a/docs/adr/ADR-009-compute-drift-positional-parameters.md
+++ b/docs/adr/ADR-009-compute-drift-positional-parameters.md
@@ -1,0 +1,126 @@
+# ADR-009: compute_drift Positional Parameter Interface
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Author:** mvillmow
+
+---
+
+## Context
+
+The `compute_drift` function (`scripts/lib/reconcile.sh:350-427`) compares the
+desired state of an agent (from its YAML file) against its live state (from the
+ProjectAgamemnon REST API JSON). To perform the comparison it needs:
+
+- The agent name (for context / error messages)
+- The desired `desiredState` (`active` or `hibernated`)
+- The full actual agent JSON blob from the API
+- Ten desired field values: `label`, `program`, `workingDirectory`,
+  `programArgs`, `taskDescription`, `tags`, `model`, `owner`, `role`,
+  `deployment.type`
+
+That is 13 inputs in total. Shell functions have no named-parameter mechanism;
+the available options are positional parameters, associative arrays, or a
+serialized intermediate format.
+
+The function is called from three callers: `apply.sh`, `plan.sh`, and
+`status.sh`. Each caller already reads the YAML fields into local shell
+variables before calling `compute_drift`.
+
+---
+
+## Decision
+
+Use **13 discrete positional parameters** in a fixed documented order:
+
+```
+$1  name               — agent name (for context)
+$2  desired_state      — "active" | "hibernated"
+$3  actual_json        — full agent JSON from the API
+$4  desired_label
+$5  desired_program
+$6  desired_workdir
+$7  desired_args
+$8  desired_desc
+$9  desired_tags_csv
+$10 desired_model
+$11 desired_owner
+$12 desired_role
+$13 desired_deploy_type
+```
+
+The function outputs one of:
+
+- `UNCHANGED` — no drift detected
+- `WAKE` — agent is offline but desired state is `active`
+- `HIBERNATE` — agent is active/online but desired state is `hibernated`
+- `UPDATE:<field1>,<field2>,...` — one or more fields differ
+
+---
+
+## Consequences
+
+### Positive
+
+- No runtime dependencies beyond POSIX shell. No `bash 4+` associativity, no
+  `declare -A`, no `nameref`.
+- Callers are already reading YAML fields into local variables; passing them
+  positionally requires no additional serialization step.
+- The fixed order is fully documented in the function header comment, making
+  the interface self-describing without requiring callers to look up key names.
+
+### Negative / Trade-offs
+
+- The call sites are positionally sensitive. Adding a new field requires
+  incrementing the parameter count and updating all three callers in lockstep.
+  A missing or reordered argument produces a silent wrong-value bug rather than
+  a named-parameter error.
+- 13 parameters is at the upper end of what is readable at a call site.
+  Callers pass values in a column-aligned block to compensate, but the
+  interface is inherently fragile to future extension.
+
+### Neutral
+
+- The function header comment (`scripts/lib/reconcile.sh:335-349`) enumerates
+  all 13 parameters. Any future change must update both the comment and every
+  caller.
+
+---
+
+## Alternatives Considered
+
+### A. Pass desired state as a JSON blob
+
+**Rejected.** Callers (`apply.sh`, `plan.sh`, `status.sh`) read YAML fields
+into local shell variables via `yq`. Serializing those variables back into a
+JSON blob on every call adds unnecessary `jq` round-trips and makes the call
+site opaque — the reader cannot see which fields are being passed without
+inspecting the serialization logic. The positional interface is verbose but
+transparent.
+
+### B. Use bash associative arrays
+
+**Rejected.** Associative arrays require `bash 4+` and `declare -A` at both
+definition and call sites. Passing an associative array to a function requires
+either a `nameref` (`declare -n`, bash 4.3+) or serialization to a string.
+`nameref` behaves unexpectedly across subshells (the array is not visible in a
+subprocess), which is a real risk since callers may invoke `compute_drift` in a
+pipeline. The positional interface works identically in all execution contexts.
+
+### C. Source a shared environment file
+
+**Rejected.** Writing desired-state variables to a temp file and sourcing it
+inside `compute_drift` would defeat function isolation and make parallel
+invocations unsafe (multiple agents reconciled concurrently would race on the
+same file). It also adds I/O for every drift computation.
+
+---
+
+## Implementation Scope (this ADR)
+
+| File | Role |
+|------|------|
+| `scripts/lib/reconcile.sh:335-427` | `compute_drift` definition and parameter comment block |
+| `scripts/apply.sh` | Primary caller — passes all 13 parameters |
+| `scripts/plan.sh` | Caller — dry-run drift check |
+| `scripts/status.sh` | Caller — status table drift column |

--- a/docs/adr/ADR-010-schema-versioning-strategy.md
+++ b/docs/adr/ADR-010-schema-versioning-strategy.md
@@ -1,0 +1,120 @@
+# ADR-010: Schema Versioning Strategy (myrmidons/v1)
+
+**Status:** Proposed
+**Date:** 2026-04-28
+**Author:** mvillmow
+
+---
+
+## Context
+
+Myrmidons defines two YAML document kinds:
+
+- **Agent** — a single agent definition (`agents/<host>/<stem>.yaml`)
+- **Fleet** — a group of agents with a shared lifecycle (`fleets/<name>.yaml`)
+
+Both kinds are validated by JSON Schema files in `schemas/`. As the project
+evolves, schema changes (new required fields, changed semantics, removed fields)
+could silently break existing YAML documents if the tooling cannot distinguish
+documents written for different schema generations.
+
+Two design choices must be made:
+
+1. **What versioning field to use** — a freeform string, an integer, or a
+   structured `apiVersion` field?
+2. **How to scope versions** — one shared version across all kinds, or
+   independent versions per kind?
+
+---
+
+## Decision
+
+Both `Agent` and `Fleet` documents share a single `apiVersion: myrmidons/v1`
+string, enforced as a JSON Schema `const` in:
+
+- `schemas/agent-v1.schema.json` — `"apiVersion": { "const": "myrmidons/v1" }`
+- `schemas/fleet-v1.schema.json` — `"apiVersion": { "const": "myrmidons/v1" }`
+
+Runtime enforcement is applied in `scripts/doctor.sh:215-221`: any YAML document
+whose `apiVersion` field is absent or does not equal `myrmidons/v1` is rejected
+with an explicit error. No version negotiation or migration logic is performed;
+a version mismatch is a hard failure.
+
+When a future breaking schema change requires a new version, the schema files
+will be renamed (e.g. `agent-v2.schema.json`) and the `const` updated. Existing
+`v1` documents must be migrated explicitly; the tooling will reject them with a
+clear message referencing the expected version.
+
+---
+
+## Consequences
+
+### Positive
+
+- Version mismatches are caught immediately at validation time, not silently
+  at apply time when a missing or renamed field would produce an incorrect API
+  call.
+- The `apiVersion`/`kind` pattern follows Kubernetes conventions, which most
+  infrastructure engineers recognize. The learning curve for new contributors
+  is reduced.
+- A single shared version is unambiguous: there is no question of whether
+  `agent/v2` and `fleet/v1` are compatible.
+
+### Negative / Trade-offs
+
+- If `Agent` and `Fleet` schemas evolve at different rates, a breaking change to
+  one kind forces a version bump for both (under the shared-version model), or
+  requires moving to per-kind versioning. This is a future migration decision,
+  not a current problem.
+- The `const` constraint in JSON Schema is strict: any document with
+  `apiVersion: myrmidons/v2` will fail validation against the v1 schema even if
+  no fields have changed. Migration tooling will be required for any version
+  increment.
+
+### Neutral
+
+- Schema filenames (`agent-v1.schema.json`, `fleet-v1.schema.json`) embed the
+  version, so adding a v2 schema does not require renaming or removing the v1
+  file. Both can coexist during a migration window.
+
+---
+
+## Alternatives Considered
+
+### A. Per-kind versioning (`agent/v1`, `fleet/v1`)
+
+**Rejected.** There is no current need for `Agent` and `Fleet` schemas to
+version independently. Maintaining two version constants (and two validation
+code paths) adds complexity with no current benefit. If independent versioning
+becomes necessary in the future, it can be introduced at that point with a
+concrete motivation.
+
+### B. Integer version field (`version: 1`)
+
+**Rejected.** An integer field is less portable and less recognizable. The
+`apiVersion`/`kind` pattern is a well-established convention in the Kubernetes
+ecosystem and in tools like Argo, Flux, and Helm. Using a recognized pattern
+reduces the documentation burden for contributors who have worked with those
+tools. An integer `version` field also lacks the namespace component
+(`myrmidons/`) that disambiguates this schema from other YAML formats that might
+be present in the same repository.
+
+### C. No versioning field
+
+**Rejected.** Without a version field, the tooling cannot distinguish a v1
+document from a hypothetical v2 document. Any future schema change that adds
+required fields or changes semantics would either silently accept malformed v1
+documents (if the new field has a default) or produce confusing errors (if it
+does not). Explicit versioning makes schema evolution possible without breaking
+backward compatibility silently.
+
+---
+
+## Implementation Scope (this ADR)
+
+| File | Role |
+|------|------|
+| `schemas/agent-v1.schema.json` | JSON Schema for Agent kind; enforces `apiVersion: myrmidons/v1` via `const` |
+| `schemas/fleet-v1.schema.json` | JSON Schema for Fleet kind; enforces `apiVersion: myrmidons/v1` via `const` |
+| `scripts/doctor.sh:215-221` | Runtime enforcement: rejects documents with wrong or missing `apiVersion` |
+| `scripts/lib/reconcile.sh` | Reads YAML fields after schema validation passes |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for Myrmidons.
+Each ADR documents a significant design decision, its context, rationale, and
+alternatives that were considered and rejected.
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-007](ADR-007-nomad-integration-strategy.md) | Nomad Integration Strategy for Multi-Host Deployments | Proposed | 2026-04-10 |
+| [ADR-008](ADR-008-fleet-ref-filename-stem-resolution.md) | Fleet ref Resolution by Filename Stem | Proposed | 2026-04-28 |
+| [ADR-009](ADR-009-compute-drift-positional-parameters.md) | compute_drift Positional Parameter Interface | Proposed | 2026-04-28 |
+| [ADR-010](ADR-010-schema-versioning-strategy.md) | Schema Versioning Strategy (myrmidons/v1) | Proposed | 2026-04-28 |


### PR DESCRIPTION
## Summary

- **ADR-008**: Documents the decision to resolve fleet `ref:` entries by filename stem (label-derived via `label_to_stem()`) rather than `metadata.name`, with rationale and two rejected alternatives
- **ADR-009**: Documents the `compute_drift` 13-positional-parameter interface design, explaining why positional params were chosen over bash associative arrays, JSON blobs, or shared env files
- **ADR-010**: Documents the shared `apiVersion: myrmidons/v1` schema versioning strategy (enforced via JSON Schema `const` + `doctor.sh` runtime check), with three rejected alternatives
- **`docs/adr/README.md`**: New ADR index table covering all four ADRs (007–010)

All ADRs follow the ADR-007 template: Context → Decision → Consequences → Alternatives Considered → Implementation Scope. Each includes a minimum of 2 rejected alternatives with explicit **Rejected.** rationale.

## Test plan

- [x] All four files pass `pre-commit run --files docs/adr/*.md` (trim whitespace, fix end of files)
- [x] Each ADR has `Alternatives Considered` section with ≥2 rejected alternatives
- [x] Each ADR has `**Status:** Proposed`
- [x] `docs/adr/README.md` index covers all four ADRs (ADR-007 through ADR-010)
- [x] No existing files modified (purely additive documentation)

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)