### PR TITLE
fix(ci): retry schema validation 3x to handle schemastore.org 503s [skip changelog]

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -203,9 +203,15 @@ jobs:
 
       - name: Validate GitHub workflow schemas
         run: |
-          find .github/workflows -name '*.yml' | sort | \
-            xargs check-jsonschema \
-              --schemafile https://json.schemastore.org/github-workflow
+          mapfile -t workflow_files < <(find .github/workflows -name '*.yml' | sort)
+          # Retry up to 3 times to handle transient schemastore.org 503s
+          for attempt in 1 2 3; do
+            check-jsonschema \
+              --schemafile https://json.schemastore.org/github-workflow \
+              "${workflow_files[@]}" && break
+            echo "::warning::Schema validation attempt $attempt failed; retrying in 15s..."
+            sleep 15
+          done
 
       # Validate pixi.toml is parseable TOML
       - name: Validate pixi.toml
@@ -231,3 +237,4 @@ jobs:
       # Verify pixi.lock matches pixi.toml — exits non-zero if lock is stale
       - name: Install dependencies (locked)
         run: pixi install --locked
+

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -237,4 +237,3 @@ jobs:
       # Verify pixi.lock matches pixi.toml — exits non-zero if lock is stale
       - name: Install dependencies (locked)
         run: pixi install --locked
-


### PR DESCRIPTION
## Summary

The `schema-validation` job fetches the GitHub workflow JSON schema from `https://json.schemastore.org/github-workflow`. This external service returns sporadic `503` errors causing CI to fail with no code issue.

Adds a 3-attempt retry loop with 15s sleep between attempts — consistent with how transient fetch failures should be handled against external schema registries.

## Root cause

`check-jsonschema` has no built-in retry; schemastore.org has been experiencing intermittent 503s. Two consecutive main branch failures confirmed the pattern (job IDs 73589085693 and 73594568134, both showing `FailedDownloadError: got response with status=503`).

## Test plan

- [ ] `schema-validation` job passes on this PR
- [ ] Myrmidons main branch CI all green after merge

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>