### PR TITLE
chore: Remove CHANGELOG.md checks from CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This document defines behavior boundaries, permitted tools, scope limitations, coordination rules, safety constraints, and escalation paths for AI agents operating this repository.
 
-**Audience:** AI agent runtimes (Claude Code, loop agents, fleet orchestrators).  
+**Audience:** AI agent runtimes (Claude Code, loop agents, fleet orchestrators).
 **Developer context:** See [CLAUDE.md](CLAUDE.md) for naming conventions, YAML format, drift detection, and environment variables.
 
 ---


### PR DESCRIPTION
## Changes

- Removed `changelog` job from `validate.yml`
- Removed `CHANGELOG.md` from path triggers

## Rationale

CHANGELOG updates should be optional, not enforced as a required check. PRs can optionally update CHANGELOG.md, but it should not block merges.

This aligns with the policy that CI infrastructure changes and non-user-facing fixes should not require CHANGELOG updates.