### PR TITLE
feat(ci): add AGENTS.md required-sections validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,3 +118,10 @@ repos:
         entry: python scripts/check-changelog-gaps.py
         pass_filenames: false
         always_run: true
+
+      - id: myrmidons-lint-agents-md
+        name: AGENTS.md required sections
+        language: script
+        entry: scripts/lint-agents-md.sh
+        files: ^AGENTS\.md$
+        pass_filenames: false

--- a/pixi.toml
+++ b/pixi.toml
@@ -47,6 +47,7 @@ export        = "just export"
 lint-names    = "bash scripts/lint-names.sh"
 lint-shell    = "bash scripts/lint-shell.sh"
 check-adr-index = "bash scripts/check-adr-index.sh"
+lint-agents-md = "bash scripts/lint-agents-md.sh"
 
 test-unit        = "bats tests/unit/"
 test-integration = "bats tests/integration/"
@@ -61,5 +62,6 @@ test             = { depends-on = ["test-unit", "test-schema", "test-doc-drift",
 build-hello-world = "just build-hello-world"
 
 [feature.lint.tasks]
-lint-shell = { cmd = "find scripts tests hooks \\( -name '*.sh' -o -name '*.bats' -o -name 'pre-commit' \\) | sort | xargs shellcheck --severity=warning --enable=SC2154", description = "ShellCheck all shell scripts and bats tests at warning severity" }
-lint       = { depends-on = ["lint-shell"] }
+lint-shell     = { cmd = "find scripts tests hooks \\( -name '*.sh' -o -name '*.bats' -o -name 'pre-commit' \\) | sort | xargs shellcheck --severity=warning --enable=SC2154", description = "ShellCheck all shell scripts and bats tests at warning severity" }
+lint-agents-md = "bash scripts/lint-agents-md.sh"
+lint           = { depends-on = ["lint-shell", "check-adr-index", "lint-agents-md"] }

--- a/scripts/lint-agents-md.sh
+++ b/scripts/lint-agents-md.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# scripts/lint-agents-md.sh — validate required sections in AGENTS.md
+#
+# Checks that all six required H2 sections are present in AGENTS.md.
+# Prevents PRs from accidentally deleting or renaming a required section.
+#
+# Usage:
+#   ./scripts/lint-agents-md.sh              # check AGENTS.md at repo root
+#   ./scripts/lint-agents-md.sh path/to/AGENTS.md
+#
+# Exit codes:
+#   0 = all required sections present
+#   1 = one or more sections missing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TARGET="${1:-${REPO_ROOT}/AGENTS.md}"
+
+if [[ ! -f "$TARGET" ]]; then
+    echo "ERROR: lint-agents-md: file not found: ${TARGET}"
+    exit 1
+fi
+
+REQUIRED_SECTIONS=(
+    "## Scope"
+    "## Permitted Actions"
+    "## Prohibited Actions"
+    "## \`--dangerously-skip-permissions\` Policy"
+    "## Fleet Coordination"
+    "## Escalation — Human Review Required"
+)
+
+MISSING=0
+
+for section in "${REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qF "$section" "$TARGET"; then
+        echo "ERROR: lint-agents-md: required section missing from ${TARGET}: ${section}"
+        MISSING=$((MISSING + 1))
+    fi
+done
+
+if [[ $MISSING -gt 0 ]]; then
+    echo ""
+    echo "lint-agents-md: ${MISSING} required section(s) missing from AGENTS.md."
+    echo "Restore the missing sections or update REQUIRED_SECTIONS in scripts/lint-agents-md.sh."
+    exit 1
+fi
+
+exit 0

--- a/tests/unit/test_lint_agents_md.bats
+++ b/tests/unit/test_lint_agents_md.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+# tests/unit/test_lint_agents_md.bats
+#
+# Unit tests for scripts/lint-agents-md.sh
+#
+# Verifies that the script passes when all six required sections are present,
+# fails with a clear error message when any section is missing, and handles
+# edge cases (missing file, partial matches).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+LINT_SCRIPT="${SCRIPT_DIR}/scripts/lint-agents-md.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Write a complete AGENTS.md with all required sections to a temp file.
+_write_complete_agents_md() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+# AGENTS.md — Agent Safety Boundaries
+
+## Scope
+
+In scope content here.
+
+## Permitted Actions
+
+Permitted content here.
+
+## Prohibited Actions
+
+Prohibited content here.
+
+## `--dangerously-skip-permissions` Policy
+
+Policy content here.
+
+## Fleet Coordination
+
+Coordination content here.
+
+## Escalation — Human Review Required
+
+Escalation content here.
+EOF
+}
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: complete AGENTS.md exits 0
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: complete AGENTS.md exits 0" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS.md"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: real AGENTS.md in repo passes
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: real repo AGENTS.md passes" {
+    run bash "$LINT_SCRIPT" "${SCRIPT_DIR}/AGENTS.md"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Tests 3–8: each required section missing → exit 1 with helpful message
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: missing '## Scope' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Scope" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Scope"* ]]
+}
+
+@test "lint-agents-md: missing '## Permitted Actions' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Permitted Actions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Permitted Actions"* ]]
+}
+
+@test "lint-agents-md: missing '## Prohibited Actions' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Prohibited Actions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Prohibited Actions"* ]]
+}
+
+@test "lint-agents-md: missing '--dangerously-skip-permissions Policy' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "dangerously-skip-permissions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"dangerously-skip-permissions"* ]]
+}
+
+@test "lint-agents-md: missing '## Fleet Coordination' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Fleet Coordination" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Fleet Coordination"* ]]
+}
+
+@test "lint-agents-md: missing '## Escalation' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Escalation" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Escalation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: multiple missing sections → reports all of them
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: multiple missing sections reports count" {
+    cat > "${TMP_DIR}/AGENTS-empty.md" <<'EOF'
+# AGENTS.md — Agent Safety Boundaries
+
+Some content but no required sections.
+EOF
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-empty.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: file not found → exit 1 with clear error
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: missing file exits 1 with error" {
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/does-not-exist.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"file not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: partial heading match does not satisfy requirement
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: partial heading 'Scope' without ## prefix does not satisfy requirement" {
+    cat > "${TMP_DIR}/AGENTS-partial.md" <<'EOF'
+# AGENTS.md — Agent Safety Boundaries
+
+Scope is mentioned here in prose but not as a heading.
+
+## Permitted Actions
+
+## Prohibited Actions
+
+## `--dangerously-skip-permissions` Policy
+
+## Fleet Coordination
+
+## Escalation — Human Review Required
+EOF
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-partial.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Scope"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 12: no arguments → defaults to repo AGENTS.md and passes
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: no arguments defaults to repo AGENTS.md" {
+    # Run from repo root so the default path resolves correctly
+    run bash -c "cd '${SCRIPT_DIR}' && bash scripts/lint-agents-md.sh"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-agents-md.sh` — a grep-based linter that enforces all six required H2 sections exist in `AGENTS.md` (Scope, Permitted Actions, Prohibited Actions, `--dangerously-skip-permissions` Policy, Fleet Coordination, Escalation — Human Review Required)
- Adds a `myrmidons-lint-agents-md` local hook in `.pre-commit-config.yaml` that fires only when `AGENTS.md` changes; CI picks it up automatically via the existing `pre-commit run --all-files` step (no `validate.yml` changes needed)
- Adds `lint-agents-md` task to `pixi.toml` and wires it into the `lint` feature's `depends-on` chain

Follows the same pattern as `check-dangerous-flags.sh` and the CI ↔ pre-commit parity rule from `CLAUDE.md`.

## Test plan

- [x] 12 new BATS unit tests in `tests/unit/test_lint_agents_md.bats` — all pass
  - Real repo AGENTS.md passes
  - Each of the 6 required sections triggers exit 1 when missing, with a message naming the missing section
  - Multi-section failure reports total count
  - Missing file exits 1 with "file not found" message
  - Partial heading match (prose mention, no `##`) does not satisfy requirement
  - Default-path behavior (no argument → repo AGENTS.md)
- [x] Full unit test suite: 407/408 pass (test 373 is a pre-existing failure in `test_url_security.bats`, unrelated to this PR)
- [x] `shellcheck --severity=warning scripts/lint-agents-md.sh` — clean

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)