### PR TITLE
fix(lint): enable SC2154 in all shellcheck entry points, add regression tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: a23f6b85d0fdd5bb9d564e2579e678033debbdff  # v0.10.0.1
     hooks:
       - id: shellcheck
-        args: [--severity=warning]
+        args: [--severity=warning, --enable=SC2154]
         files: '\.(sh|bats)$|(^|/)pre-commit$'
 
   # GitHub Actions workflow linting

--- a/pixi.toml
+++ b/pixi.toml
@@ -49,5 +49,5 @@ test             = { depends-on = ["test-unit", "test-schema", "test-doc-drift",
 build-hello-world = "just build-hello-world"
 
 [feature.lint.tasks]
-lint-shell = { cmd = "find scripts tests hooks \\( -name '*.sh' -o -name '*.bats' -o -name 'pre-commit' \\) | sort | xargs shellcheck --severity=warning", description = "ShellCheck all shell scripts and bats tests at warning severity" }
+lint-shell = { cmd = "find scripts tests hooks \\( -name '*.sh' -o -name '*.bats' -o -name 'pre-commit' \\) | sort | xargs shellcheck --severity=warning --enable=SC2154", description = "ShellCheck all shell scripts and bats tests at warning severity" }
 lint       = { depends-on = ["lint-shell"] }

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -36,7 +36,7 @@ echo ""
 find "${REPO_ROOT}/scripts" "${REPO_ROOT}/tests" "${REPO_ROOT}/hooks" \
     \( -name '*.sh' -o -name '*.bats' -o -name 'pre-commit' \) \
     | sort \
-    | xargs "$SHELLCHECK_CMD" --severity=warning
+    | xargs "$SHELLCHECK_CMD" --severity=warning --enable=SC2154
 
 echo ""
 echo "Shell script linting complete."

--- a/tests/unit/test_apply_sc2154.bats
+++ b/tests/unit/test_apply_sc2154.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_sc2154.bats — regression guard for issues #370 and #392
+#
+# Issue #370: ${repo_root} (lowercase, undefined) used instead of ${REPO_ROOT}
+# in the effective_snapshot_dir fallback expression inside apply.sh::main().
+# Under set -u this causes an unbound-variable abort; without set -u it writes
+# snapshots to /.myrmidons/snapshots on the root filesystem.
+#
+# Issue #392: Wires shellcheck SC2154 (referenced-but-not-assigned) into the
+# permanent lint entry points so the class of bug from #370 cannot reappear.
+#
+# These tests verify:
+#   - REPO_ROOT is defined (non-empty) in apply.sh's global scope
+#   - The snapshot_dir fallback references REPO_ROOT (correct case), not repo_root
+#   - No lowercase alias repo_root is defined in apply.sh
+#   - SC2154 is enabled in lint-shell.sh
+#   - SC2154 is enabled in .pre-commit-config.yaml's shellcheck hook args
+
+SCRIPT_DIR=""
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+# ---------------------------------------------------------------------------
+# #370 regression: REPO_ROOT casing
+# ---------------------------------------------------------------------------
+
+@test "apply.sh: REPO_ROOT is assigned at global scope" {
+    grep -qE '^REPO_ROOT=' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+@test "apply.sh: no lowercase repo_root reference exists" {
+    # Any occurrence of \${repo_root} (lowercase) is a bug — the variable is REPO_ROOT.
+    ! grep -qE '\$\{?repo_root\}?' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+@test "apply.sh: effective_snapshot_dir fallback uses REPO_ROOT (uppercase)" {
+    # The pattern must contain REPO_ROOT (not repo_root) in the snapshot dir expression.
+    grep -qE 'effective_snapshot_dir=.*REPO_ROOT' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+@test "apply.sh: MYRMIDONS_STATE_DIR uses REPO_ROOT (uppercase)" {
+    grep -qE 'MYRMIDONS_STATE_DIR=.*REPO_ROOT' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+# ---------------------------------------------------------------------------
+# #392: SC2154 is wired into permanent lint entry points
+# ---------------------------------------------------------------------------
+
+@test "lint-shell.sh: SC2154 is enabled in shellcheck invocation" {
+    grep -qF -- '--enable=SC2154' "${SCRIPT_DIR}/scripts/lint-shell.sh"
+}
+
+@test ".pre-commit-config.yaml: SC2154 is enabled in shellcheck hook args" {
+    grep -qF -- '--enable=SC2154' "${SCRIPT_DIR}/.pre-commit-config.yaml"
+}
+
+@test "pixi.toml: SC2154 is enabled in lint env lint-shell task" {
+    grep -qF -- '--enable=SC2154' "${SCRIPT_DIR}/pixi.toml"
+}


### PR DESCRIPTION
## Summary

- Adds `--enable=SC2154` to all three shellcheck lint entry points: `scripts/lint-shell.sh`, `pixi.toml` `[feature.lint.tasks]`, and `.pre-commit-config.yaml`, so undefined-variable references are caught on every lint pass
- Adds `tests/unit/test_apply_sc2154.bats` with 7 tests: 4 regression guards for the `REPO_ROOT`/`repo_root` case-typo from #370, and 3 guards confirming `--enable=SC2154` is wired into each lint entry point
- The SC2154 audit found zero genuine findings in `apply.sh` — the current code is clean

## Test plan

- [x] `pixi run --environment lint bats tests/unit/test_apply_sc2154.bats` — all 7 tests pass
- [x] `pixi run --environment lint lint-shell` — zero findings with `--enable=SC2154`
- [x] `pixi run --environment lint bats tests/unit/` — existing tests unaffected

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)