### PR TITLE
refactor(apply): replace parallel failure arrays with FAILED_AGENTS_INFO

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -76,10 +76,9 @@ ERRORS=0
 FAILED_AGENTS=()   # names of agents that encountered errors
 _PRUNED_NAMES=()   # names of agents pruned during this run (for convergence check)
 
-# Per-agent error tracking: parallel arrays of (agent_name, http_status, error_message)
-FAILED_AGENT_NAMES=()
-FAILED_AGENT_STATUSES=()
-FAILED_AGENT_MESSAGES=()
+# Per-agent error tracking: structured entries "name\x01http_status\x01message"
+# Uses ASCII unit separator (0x01) as delimiter — safe against agent names, HTTP codes, and error messages.
+FAILED_AGENTS_INFO=()
 
 # Directory for state files
 MYRMIDONS_STATE_DIR="${REPO_ROOT}/.myrmidons"
@@ -174,10 +173,9 @@ record_failure() {
     local http_status="$2"
     local error_message="$3"
 
+    local _sep=$'\x01'
     ERRORS=$((ERRORS + 1))
-    FAILED_AGENT_NAMES+=("$agent_name")
-    FAILED_AGENT_STATUSES+=("$http_status")
-    FAILED_AGENT_MESSAGES+=("$error_message")
+    FAILED_AGENTS_INFO+=("${agent_name}${_sep}${http_status}${_sep}${error_message}")
 }
 
 # Print a detailed per-agent error summary.
@@ -186,11 +184,9 @@ print_error_summary() {
     echo "================================================"
     echo "FAILED AGENTS (${ERRORS}):"
     echo ""
-    local i
-    for i in "${!FAILED_AGENT_NAMES[@]}"; do
-        local agent_name="${FAILED_AGENT_NAMES[$i]}"
-        local http_status="${FAILED_AGENT_STATUSES[$i]}"
-        local error_msg="${FAILED_AGENT_MESSAGES[$i]}"
+    local entry agent_name http_status error_msg
+    for entry in "${FAILED_AGENTS_INFO[@]}"; do
+        IFS=$'\x01' read -r agent_name http_status error_msg <<< "$entry"
         echo "  [FAIL] ${agent_name}"
         if [[ -n "$http_status" ]]; then
             echo "         HTTP status: ${http_status}"

--- a/tests/unit/test_record_failure.bats
+++ b/tests/unit/test_record_failure.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# tests/unit/test_record_failure.bats — unit tests for record_failure() and print_error_summary()
+#
+# Tests verify the FAILED_AGENTS_INFO structured-string approach introduced in #394:
+# - record_failure() appends "name\x01http_status\x01message" entries
+# - print_error_summary() parses and formats those entries correctly
+
+# ---------------------------------------------------------------------------
+# Helper: source record_failure and print_error_summary from apply.sh
+# We extract only the two functions plus the required globals to avoid
+# sourcing the entire script (which has side effects).
+# ---------------------------------------------------------------------------
+
+_load_functions() {
+    # Variables that apply.sh expects to exist
+    ERRORS=0
+    FAILED_AGENTS_INFO=()
+    # shellcheck disable=SC2034
+    FAILED_AGENTS_FILE="/tmp/failed-agents.txt"
+
+    # Source only the two functions via eval (extract between markers)
+    # shellcheck disable=SC1090
+    eval "$(sed -n '/^record_failure()/,/^}/p' "${BATS_TEST_DIRNAME}/../../scripts/apply.sh")"
+    # shellcheck disable=SC1090
+    eval "$(sed -n '/^print_error_summary()/,/^}/p' "${BATS_TEST_DIRNAME}/../../scripts/apply.sh")"
+}
+
+setup() {
+    _load_functions
+}
+
+# ---------------------------------------------------------------------------
+# record_failure — array population
+# ---------------------------------------------------------------------------
+
+@test "record_failure: FAILED_AGENTS_INFO starts empty" {
+    [[ "${#FAILED_AGENTS_INFO[@]}" -eq 0 ]]
+}
+
+@test "record_failure: increments ERRORS" {
+    record_failure "agent-a" "404" "not found"
+    [[ "$ERRORS" -eq 1 ]]
+}
+
+@test "record_failure: appends one entry to FAILED_AGENTS_INFO" {
+    record_failure "agent-a" "404" "not found"
+    [[ "${#FAILED_AGENTS_INFO[@]}" -eq 1 ]]
+}
+
+@test "record_failure: entry contains name, status, and message" {
+    record_failure "agent-a" "404" "not found"
+    local entry="${FAILED_AGENTS_INFO[0]}"
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "$entry"
+    [[ "$name"   == "agent-a"   ]]
+    [[ "$status" == "404"       ]]
+    [[ "$msg"    == "not found" ]]
+}
+
+@test "record_failure: multiple calls produce multiple entries in order" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    [[ "${#FAILED_AGENTS_INFO[@]}" -eq 2 ]]
+    local sep=$'\x01'
+    IFS="$sep" read -r n1 s1 m1 <<< "${FAILED_AGENTS_INFO[0]}"
+    IFS="$sep" read -r n2 s2 m2 <<< "${FAILED_AGENTS_INFO[1]}"
+    [[ "$n1" == "agent-a" ]] && [[ "$s1" == "404" ]] && [[ "$m1" == "not found" ]]
+    [[ "$n2" == "agent-b" ]] && [[ "$s2" == "500" ]] && [[ "$m2" == "server error" ]]
+}
+
+@test "record_failure: ERRORS accumulates across multiple calls" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    record_failure "agent-c" "503" "unavailable"
+    [[ "$ERRORS" -eq 3 ]]
+}
+
+@test "record_failure: empty http_status stored and retrievable" {
+    record_failure "agent-b" "" "timeout"
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "${FAILED_AGENTS_INFO[0]}"
+    [[ "$name"   == "agent-b" ]]
+    [[ "$status" == ""        ]]
+    [[ "$msg"    == "timeout" ]]
+}
+
+@test "record_failure: empty error_message stored and retrievable" {
+    record_failure "agent-c" "500" ""
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "${FAILED_AGENTS_INFO[0]}"
+    [[ "$name"   == "agent-c" ]]
+    [[ "$status" == "500"     ]]
+    [[ "$msg"    == ""        ]]
+}
+
+@test "record_failure: message with pipe character is stored safely" {
+    record_failure "agent-d" "500" "Failed to update fields [label|program]"
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "${FAILED_AGENTS_INFO[0]}"
+    [[ "$name"   == "agent-d"                                    ]]
+    [[ "$status" == "500"                                        ]]
+    [[ "$msg"    == "Failed to update fields [label|program]"    ]]
+}
+
+# ---------------------------------------------------------------------------
+# print_error_summary — output formatting
+# ---------------------------------------------------------------------------
+
+@test "print_error_summary: prints FAIL tag for single failure" {
+    record_failure "agent-a" "404" "not found"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"[FAIL] agent-a"* ]]
+}
+
+@test "print_error_summary: includes HTTP status line when present" {
+    record_failure "agent-a" "404" "not found"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"HTTP status: 404"* ]]
+}
+
+@test "print_error_summary: includes error message line when present" {
+    record_failure "agent-a" "404" "not found"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"Error: not found"* ]]
+}
+
+@test "print_error_summary: omits HTTP status line when empty" {
+    record_failure "agent-b" "" "timeout"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" != *"HTTP status:"* ]]
+}
+
+@test "print_error_summary: omits error line when message is empty" {
+    record_failure "agent-c" "500" ""
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" != *"Error:"* ]]
+}
+
+@test "print_error_summary: prints all failures for multiple entries" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    ERRORS=2
+    run print_error_summary
+    [[ "${output}" == *"[FAIL] agent-a"* ]]
+    [[ "${output}" == *"[FAIL] agent-b"* ]]
+}
+
+@test "print_error_summary: prints failures in insertion order" {
+    record_failure "first-agent"  "400" "bad request"
+    record_failure "second-agent" "500" "server error"
+    ERRORS=2
+    run print_error_summary
+    local first_pos second_pos
+    first_pos=$(echo "$output" | grep -n "first-agent"  | head -1 | cut -d: -f1)
+    second_pos=$(echo "$output" | grep -n "second-agent" | head -1 | cut -d: -f1)
+    [[ "$first_pos" -lt "$second_pos" ]]
+}
+
+@test "print_error_summary: FAILED AGENTS count matches ERRORS" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    ERRORS=2
+    run print_error_summary
+    [[ "${output}" == *"FAILED AGENTS (2)"* ]]
+}
+
+@test "print_error_summary: message with pipe character renders correctly" {
+    record_failure "agent-d" "500" "Failed to update fields [label|program]"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"Error: Failed to update fields [label|program]"* ]]
+}


### PR DESCRIPTION
## Summary

- Replaces the `FAILED_AGENT_NAMES[]`, `FAILED_AGENT_STATUSES[]`, `FAILED_AGENT_MESSAGES[]` parallel-array trio in `scripts/apply.sh` with a single `FAILED_AGENTS_INFO=()` array of structured strings
- Each entry uses ASCII unit separator (`$'\x01'`, 0x01) as delimiter — safe against pipe characters in error messages (e.g. `"Failed to update fields [label|program]"`)
- `record_failure()` and `print_error_summary()` are the only consumers; callers are unchanged
- Adds 18 BATS unit tests in `tests/unit/test_record_failure.bats` covering single/multiple failures, empty fields, pipe-in-message safety, and output formatting

## Test plan

- [x] `bats tests/unit/test_record_failure.bats` — 18/18 pass
- [x] `bats tests/unit/` — no regressions (pre-existing test_url_security.bats failure unrelated)
- [x] `pixi run --environment lint lint-shell` — no new shellcheck warnings
- [x] `pre-commit run shellcheck --all-files` — passed

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)