### PR TITLE
test(apply): assert write_failed_agents_file public symbol is absent

### DIFF
--- a/tests/unit/test_apply_error.bats
+++ b/tests/unit/test_apply_error.bats
@@ -500,3 +500,32 @@ APPLY_RETRY_MISSING
     [[ -f "$failed_file" ]]
     [[ $(grep -c "fail:agent" "$failed_file") -eq 2 ]]
 }
+
+# ---------------------------------------------------------------------------
+# Test: Symbol visibility — write_failed_agents_file must not be public
+# ---------------------------------------------------------------------------
+
+@test "write_failed_agents_file: public symbol must not exist after sourcing apply.sh" {
+    local script
+    script="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/../../scripts/apply.sh"
+
+    # Source apply.sh in a subshell, stripping lines that execute at source-time
+    # (library sources, load_config call, and the main "$@" invocation) so we
+    # can inspect only function definitions.
+    run bash -c "
+        stripped=\"\$(grep -v \
+            -e '^#!/' \
+            -e '^set -' \
+            -e 'SCRIPT_DIR=' \
+            -e 'REPO_ROOT=' \
+            -e '# shellcheck' \
+            -e '^source ' \
+            -e '^load_config$' \
+            -e '^main \"\\\$@\"$' \
+            \"$script\")\"
+        eval \"\$stripped\" 2>/dev/null
+        declare -f write_failed_agents_file
+    "
+
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds a bats `@test` to `tests/unit/test_apply_error.bats` that sources `scripts/apply.sh` (stripping exec-at-load lines) and asserts `declare -f write_failed_agents_file` exits non-zero
- Prevents silent re-introduction of the public alias for the private `_write_failed_agents_file` function

## Test plan

- [x] New test passes: `bats tests/unit/test_apply_error.bats --filter "write_failed_agents_file"` → `ok 1`
- [x] Full suite still passes: all 16 tests green in `tests/unit/test_apply_error.bats`
- [x] Verified the inverse: renaming `_write_failed_agents_file` → `write_failed_agents_file` in apply.sh causes this test to fail

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)