### PR TITLE
fix(gitleaks): add CHANGELOG.md to paths allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,5 +15,6 @@ paths = [
   '''tests/.*''',
   '''README\.md''',
   '''CLAUDE\.md''',
+  '''CHANGELOG\.md''',
   '''docs/.*''',
 ]


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` to the gitleaks `paths` allowlist in `.gitleaks.toml`
- The existing allowlist covered `tests/`, `README.md`, `CLAUDE.md`, and `docs/` but omitted `CHANGELOG.md`
- Without this, any future changelog entry that includes a redacted token example (e.g. describing a security fix) would fail the gitleaks scan and block the PR

## Test plan

- [ ] Confirm `.gitleaks.toml` allowlist now includes `CHANGELOG\.md`
- [ ] Verify that adding a token-like string to `CHANGELOG.md` no longer triggers gitleaks in CI
- [ ] Confirm existing files outside the allowlist still trigger gitleaks as expected

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)