### PR TITLE
fix(apply): print prune-specific header in verify_convergence for prune-only runs

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -330,6 +330,9 @@ verify_convergence() {
     if [[ "$OUTPUT_FORMAT" != "json" ]]; then
         echo ""
         echo "Verifying convergence for ${#_MODIFIED_NAMES[@]} modified agent(s)..."
+        if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+            echo "Verifying ${#_PRUNED_NAMES[@]} pruned agent(s) are absent..."
+        fi
     fi
 
     # Refresh agent list once for all convergence checks

--- a/tests/unit/test_convergence.bats
+++ b/tests/unit/test_convergence.bats
@@ -63,6 +63,15 @@ verify_convergence_impl() {
 
     local failed=0
     local verified=0
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo ""
+        echo "Verifying convergence for ${#_MODIFIED_NAMES[@]} modified agent(s)..."
+        if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+            echo "Verifying ${#_PRUNED_NAMES[@]} pruned agent(s) are absent..."
+        fi
+    fi
+
     local agents_json_fresh
     agents_json_fresh="$(agamemnon_list_agents)"
 
@@ -309,4 +318,22 @@ teardown() {
 
     run verify_convergence_impl
     [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Issue #408: prune-only run prints prune-specific header
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: prune-only run prints 'Verifying N pruned agent(s) are absent' header" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("old-agent" "gone-agent")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Verifying 2 pruned agent(s) are absent"* ]]
 }


### PR DESCRIPTION
## Summary

- When `_MODIFIED_NAMES` is empty but `_PRUNED_NAMES` is non-empty, `verify_convergence` previously produced no output until the final summary line
- Added a conditional `echo "Verifying N pruned agent(s) are absent..."` inside the existing `OUTPUT_FORMAT != "json"` guard, immediately after the modified-agents header
- Updated `verify_convergence_impl` in `tests/unit/test_convergence.bats` to mirror the real implementation (so the inline copy stays in sync)
- Added regression test: `verify_convergence: prune-only run prints 'Verifying N pruned agent(s) are absent' header`

## Test plan

- [x] All 451 existing tests pass (`pixi run bats tests/unit/ tests/integration/`)
- [x] New test `ok 13 verify_convergence: prune-only run prints 'Verifying N pruned agent(s) are absent' header` passes
- [x] Prune-only path (`_MODIFIED_NAMES=()`, `_PRUNED_NAMES=("a" "b")`) now emits the prune header before the summary line
- [x] Mixed path (both arrays non-empty) emits both headers
- [x] Pure-modified path (no pruned agents) unchanged — no extra output

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)