### PR TITLE
feat(pre-commit): switch gitleaks to gitleaks-system hook (fixes Go 1.15 build)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,12 @@ repos:
         args: [-d, relaxed]
         files: '\.ya?ml$'
 
-  # Secret scanning (binary mode, no license required)
+  # Secret scanning — uses system-installed gitleaks binary (avoids Go build)
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.3
+    rev: v8.30.1
     hooks:
-      - id: gitleaks
+      - id: gitleaks-system
+        pass_filenames: false
 
   # Myrmidons schema validation
   - repo: local


### PR DESCRIPTION
## Summary

- Switches the gitleaks pre-commit hook from `id: gitleaks` (golang language, builds from source) to `id: gitleaks-system` (uses system-installed binary), because the system Go toolchain is 1.15 which cannot build gitleaks v8.24.3+ (requires Go 1.19+).
- Bumps `rev` from `v8.24.3` to `v8.30.1` to match the installed system binary.
- Adds `pass_filenames: false` override since the upstream `gitleaks-system` hook definition in v8.30.1 is missing it, causing pre-commit to pass all filenames as positional args to `gitleaks git` (which accepts at most one).

Closes #412

## Test plan

- [x] `pre-commit run gitleaks-system --all-files` passes cleanly
- [x] All other hooks (trailing-whitespace, end-of-file-fixer, check-yaml, shellcheck, yamllint, myrmidons-validate) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)