### PR TITLE
ci: promote gitleaks version to workflow-level env var

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  GITLEAKS_VERSION: "8.24.3"
+
 jobs:
   lint:
     name: lint
@@ -95,12 +98,10 @@ jobs:
 
       # Use the unlicensed gitleaks binary — no GITLEAKS_LICENSE required.
       - name: Install gitleaks
-        env:
-          GL_VERSION: "8.24.3"
         run: |
           url="https://github.com/gitleaks/gitleaks/releases/download"
           curl -sSfL \
-            "${url}/v${GL_VERSION}/gitleaks_${GL_VERSION}_linux_x64.tar.gz" \
+            "${url}/v${{ env.GITLEAKS_VERSION }}/gitleaks_${{ env.GITLEAKS_VERSION }}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks
 
       - name: Scan for secrets (gitleaks)


### PR DESCRIPTION
## Summary

- Moves `GL_VERSION: "8.24.3"` from the step-level `env:` block in the `Install gitleaks` step to a workflow-level `env:` block as `GITLEAKS_VERSION: "8.24.3"`
- Updates the `curl` invocation in that step to reference `${{ env.GITLEAKS_VERSION }}` instead of `${GL_VERSION}`
- Matches the `ACTIONLINT_VERSION` naming convention established elsewhere in the repo

## Test plan

- [x] YAML is well-formed (`yq eval '.' _required.yml`)
- [x] No `GL_VERSION` references remain in the file
- [x] `GITLEAKS_VERSION` appears in the workflow-level `env:` block
- [x] `${{ env.GITLEAKS_VERSION }}` used twice in the `curl` line
- [x] `yamllint` and `check-yaml` pre-commit hooks pass
- [x] `scripts/check-dangerous-flags.sh` passes

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)