### PR TITLE
docs(security): document .gitleaks.toml allowlist and harden CI scan

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -104,8 +104,7 @@ jobs:
             | tar -xz -C /usr/local/bin gitleaks
 
       - name: Scan for secrets (gitleaks)
-        run: gitleaks detect --source . --no-git -v
-        continue-on-error: true
+        run: gitleaks detect --source . --config .gitleaks.toml --no-git -v
 
   build:
     name: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,40 @@ The justification must describe:
 
 To run manually: `./scripts/check-dangerous-flags.sh`
 
+### Gitleaks allowlist
+
+`gitleaks` scans every PR for secrets. False positives (e.g. test fixtures, documentation
+examples, placeholder tokens) must be suppressed via `.gitleaks.toml` — **not** by adding
+`continue-on-error: true` to the CI step.
+
+**Correct approach — add an entry to `.gitleaks.toml`:**
+
+```toml
+[allowlist]
+description = "Test fixtures and documentation examples"
+regexes = [
+  '''your-placeholder-token''',   # gitleaks-allowlist: doc example in CLAUDE.md, not a real credential
+]
+paths = [
+  '''tests/.*''',                 # gitleaks-allowlist: test fixtures contain intentional fake secrets
+]
+```
+
+Every new allowlist entry **must** include an inline comment `# gitleaks-allowlist: <justification>`
+that describes:
+- Why the match is a false positive
+- Where the value appears (file, section, or purpose)
+
+**Wrong approach:** setting `continue-on-error: true` on the scan step silently swallows
+real leaks. Never do this — if you encounter it in the workflow, fix the allowlist instead.
+
+The CI step in `.github/workflows/_required.yml` always passes `--config .gitleaks.toml`
+so allowlist entries are applied automatically. To verify locally before pushing:
+
+```bash
+gitleaks detect --source . --config .gitleaks.toml --no-git -v
+```
+
 ## Known Gotchas
 
 ### jq 1.6: `label` is a reserved keyword


### PR DESCRIPTION
## Summary

- Adds a `### Gitleaks allowlist` subsection to the `## Security` section of `CLAUDE.md`, co-located with the existing `--dangerously-skip-permissions` policy for discoverability
- Documents `.gitleaks.toml` as the **correct** mechanism for suppressing false positives, requiring an inline `# gitleaks-allowlist: <justification>` comment on every new entry
- Explicitly names `continue-on-error: true` as the wrong approach, with the correct local verification command
- Hardens `.github/workflows/_required.yml`: adds `--config .gitleaks.toml` to the gitleaks step and removes `continue-on-error: true`, making the scan blocking

## Test plan

- [x] `gitleaks detect --source . --config .gitleaks.toml --no-git -v` exits 0 — no false positives
- [x] `pre-commit run trailing-whitespace end-of-file-fixer check-yaml` all pass on changed files
- [x] `./scripts/check-dangerous-flags.sh` exits 0
- [x] No `continue-on-error` remains on the gitleaks CI step

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)