### PR TITLE
docs: add HIBERNATE_SETTLE_SECONDS to env var table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ Example: `./scripts/apply.sh hermes --output json | jq .summary`
 | `LOG_LEVEL` | `INFO` | Log verbosity: DEBUG, INFO, WARN, ERROR |
 | `LOG_FORMAT` | `text` | Log output format: text or json |
 | `AIM_LOCK_FILE` | `.myrmidons.lock` | Path to the apply lock file (use workspace-scoped path in parallel CI) |
+| `HIBERNATE_SETTLE_SECONDS` | `2` | Seconds to wait after hibernating an agent before continuing (set to `0` in CI to skip the settle delay) |
 | `MYRMIDONS_DEFAULT_OWNER` | `$(whoami)` | Fallback owner written to exported agent YAMLs when the Agamemnon API returns no owner |
 
 ## Authentication


### PR DESCRIPTION
## Summary

- Adds `HIBERNATE_SETTLE_SECONDS` (default `2`) to the environment variables table in `CLAUDE.md`
- Placed alongside `AIM_LOCK_FILE` and other `apply.sh` tuning knobs so operators know they can override it in CI
- Documents the `0` value as the fast CI path to skip the settle delay

Closes #418

## Test plan

- [ ] Verify the new row appears correctly in the rendered CLAUDE.md table
- [ ] Confirm default value (`2`) matches `scripts/apply.sh` line 63: `HIBERNATE_SETTLE_SECONDS="${HIBERNATE_SETTLE_SECONDS:-2}"`
- [ ] Confirm description matches actual usage in `apply.sh` and `tests/test-prune-settle.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)