### PR TITLE
fix(apply): source lib/config.sh + lib/report.sh in test-apply-cache; add _LAST_CREATED_AGENT_JSON

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -89,6 +89,9 @@ FAILED_AGENTS_FILE="${MYRMIDONS_STATE_DIR}/failed-agents.txt"
 _MODIFIED_NAMES=()
 _MODIFIED_DESIRED=()
 
+# Set by apply_agent on successful CREATE; cleared at the top of each apply_agent call.
+_LAST_CREATED_AGENT_JSON=""
+
 # Counts of destructive operations pending — used by confirmation prompt (#48)
 _DESTRUCTIVE_COUNT=0
 
@@ -693,6 +696,8 @@ apply_agent() {
     local yaml_file="$1"
     local agents_json="$2"
 
+    _LAST_CREATED_AGENT_JSON=""
+
     # Parse YAML fields into local variables
     local name label program workdir args desc tags owner role model deploy_type desired_state
     name="$(yq eval '.metadata.name' "$yaml_file")"
@@ -730,6 +735,7 @@ apply_agent() {
                 echo "    Created: id=${new_id}"
             fi
             CREATED=$((CREATED + 1))
+            _LAST_CREATED_AGENT_JSON="$result"
 
             local woke_status="created"
             # Wake if desired

--- a/tests/test-apply-cache.sh
+++ b/tests/test-apply-cache.sh
@@ -127,10 +127,14 @@ _source_apply_functions() {
     local apply_sh="${REPO_ROOT}/scripts/apply.sh"
 
     # Source the lib dependencies directly with their real paths.
+    # shellcheck source=scripts/lib/config.sh
+    source "${REPO_ROOT}/scripts/lib/config.sh"
     # shellcheck source=scripts/lib/api.sh
     source "${REPO_ROOT}/scripts/lib/api.sh"
     # shellcheck source=scripts/lib/reconcile.sh
     source "${REPO_ROOT}/scripts/lib/reconcile.sh"
+    # shellcheck source=scripts/lib/report.sh
+    source "${REPO_ROOT}/scripts/lib/report.sh"
 
     # Eval apply.sh stripping lines that would re-source libs or run main.
     # Also strip SCRIPT_DIR/REPO_ROOT setup (already set) and shebang/set lines.


### PR DESCRIPTION
## Summary

- `test-apply-cache.sh`'s `_source_apply_functions` was missing `source` calls for `lib/config.sh` and `lib/report.sh`, causing `apply.sh`'s `load_config` invocation (line 46) to fail with `load_config: command not found` — crashing the entire test run before any test case executed
- Added the two missing `source` lines, matching the pattern already used in `test-prune-settle.sh`
- Also added `_LAST_CREATED_AGENT_JSON` tracking to `apply_agent` (declared as a global, cleared at function entry, set on successful CREATE) so the O(1) list-agents cache tests pass as designed

## Test plan

- [x] `bash tests/test-apply-cache.sh` → 5 passed, 0 failed (was: immediate crash with `load_config: command not found`)
- [x] `bash tests/test-prune-settle.sh` → 5 passed, 0 failed (no regression)
- [x] `bash tests/test-compute-drift.sh` → 14 passed, 0 failed
- [x] `bash tests/test-report.sh` → 37 passed, 0 failed

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)