### PR TITLE
docs(scripts): document HIBERNATE_SETTLE_SECONDS in apply.sh --help

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -146,9 +146,12 @@ Options:
   -h, --help                 Show this help
 
 Environment variables:
-  AIM_LOCK_FILE        Path to the apply lock file (default: .myrmidons.lock).
-                       Set to a workspace-scoped path in parallel CI environments.
-  AIM_LOCK_TIMEOUT     Lock acquisition timeout in seconds (default: 60).
+  AIM_LOCK_FILE              Path to the apply lock file (default: .myrmidons.lock).
+                             Set to a workspace-scoped path in parallel CI environments.
+  AIM_LOCK_TIMEOUT           Lock acquisition timeout in seconds (default: 60).
+  HIBERNATE_SETTLE_SECONDS   Seconds to wait after hibernating an unmanaged agent before
+                             issuing DELETE (default: 2). Set to 0 to skip the wait in CI:
+                             HIBERNATE_SETTLE_SECONDS=0 ./scripts/apply.sh --prune
 
 Examples:
   $0                              # Reconcile everything

--- a/tests/test-prune-settle.sh
+++ b/tests/test-prune-settle.sh
@@ -37,6 +37,22 @@ _assert_eq() {
     fi
 }
 
+# ── test: --help output documents HIBERNATE_SETTLE_SECONDS ───────────────────
+
+test_help_documents_hibernate_settle_seconds() {
+    echo ""
+    echo "Test: --help output mentions HIBERNATE_SETTLE_SECONDS"
+
+    local found
+    found="$(grep -c 'HIBERNATE_SETTLE_SECONDS' "$APPLY_SH" || true)"
+    _assert_eq "HIBERNATE_SETTLE_SECONDS appears in apply.sh" "1" "$([ "$found" -ge 1 ] && echo 1 || echo 0)"
+
+    # Verify it appears specifically in the usage() function body
+    local in_usage
+    in_usage="$(awk '/^usage\(\)/{found=1} found && /HIBERNATE_SETTLE_SECONDS/{print; exit}' "$APPLY_SH")"
+    _assert_eq "HIBERNATE_SETTLE_SECONDS documented in usage()" "1" "$([ -n "$in_usage" ] && echo 1 || echo 0)"
+}
+
 # ── test: static grep — confirm sleep uses the variable, not a literal ────────
 
 test_no_hardcoded_sleep_2() {
@@ -223,6 +239,7 @@ echo "================================================"
 echo "HIBERNATE_SETTLE_SECONDS tests (issue #373)"
 echo "================================================"
 
+test_help_documents_hibernate_settle_seconds
 test_no_hardcoded_sleep_2
 test_sleep_uses_variable
 test_default_value_is_2

--- a/tests/unit/test_apply_plan_entrypoints.bats
+++ b/tests/unit/test_apply_plan_entrypoints.bats
@@ -94,6 +94,11 @@ YAML
     [[ "$output" == *"Usage"* ]]
 }
 
+@test "apply.sh --help: mentions HIBERNATE_SETTLE_SECONDS" {
+    run "${SCRIPT_DIR}/scripts/apply.sh" --help
+    [[ "$output" == *"HIBERNATE_SETTLE_SECONDS"* ]]
+}
+
 # ── plan.sh --help ────────────────────────────────────────────────────────────
 
 @test "plan.sh --help: exits 0" {


### PR DESCRIPTION
## Summary

- Added `HIBERNATE_SETTLE_SECONDS` to the `Environment variables:` section of `apply.sh`'s `usage()` function, making the CI override (`HIBERNATE_SETTLE_SECONDS=0 ./scripts/apply.sh --prune`) discoverable from `--help` without reading source
- Entry follows the same pattern as `AIM_LOCK_TIMEOUT`: variable name, purpose, default value, and usage example

## Test plan

- [x] `bats tests/unit/test_apply_plan_entrypoints.bats` — new test `apply.sh --help: mentions HIBERNATE_SETTLE_SECONDS` (test 3) passes; all 14 tests pass
- [x] `bash tests/test-prune-settle.sh` — new `test_help_documents_hibernate_settle_seconds` test passes; all 7 tests pass
- [x] `bash -n scripts/apply.sh` — syntax check passes

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)