### PR TITLE
test(hooks): add bats coverage for install-hooks-legacy recipe

### DIFF
--- a/tests/unit/test_install_hooks_legacy.bats
+++ b/tests/unit/test_install_hooks_legacy.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# tests/unit/test_install_hooks_legacy.bats
+#
+# Issue #421: test coverage for the install-hooks-legacy justfile recipe.
+#
+# Verifies that install-hooks-legacy copies hooks/pre-commit to .git/hooks/pre-commit
+# without invoking `pixi run pre-commit install`.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+TMP_REPO=""
+PIXI_STUB=""
+
+setup() {
+    TMP_REPO="${SCRIPT_DIR}/_install_hooks_legacy_test_$$_${RANDOM}"
+    mkdir -p "$TMP_REPO"
+
+    git -C "$TMP_REPO" init -q
+    git -C "$TMP_REPO" config user.email "test@example.com"
+    git -C "$TMP_REPO" config user.name "Test"
+    git -C "$TMP_REPO" config commit.gpgsign false
+
+    mkdir -p "${TMP_REPO}/hooks"
+    mkdir -p "${TMP_REPO}/.git/hooks"
+    cp "${SCRIPT_DIR}/hooks/pre-commit" "${TMP_REPO}/hooks/pre-commit"
+
+    touch "${TMP_REPO}/.gitkeep"
+    git -C "$TMP_REPO" add .gitkeep
+    git -C "$TMP_REPO" commit -q --no-verify -m "init"
+
+    # Stub that records any invocation of pixi
+    PIXI_STUB="$(mktemp -d)"
+    cat > "${PIXI_STUB}/pixi" <<'SH'
+#!/usr/bin/env bash
+echo "called" >> "${0%/*}/pixi.log"
+exit 0
+SH
+    chmod +x "${PIXI_STUB}/pixi"
+}
+
+teardown() {
+    [[ -n "$TMP_REPO" && -d "$TMP_REPO" ]] && rm -rf "$TMP_REPO"
+    [[ -n "$PIXI_STUB" && -d "$PIXI_STUB" ]] && rm -rf "$PIXI_STUB"
+}
+
+@test "install-hooks-legacy: copies pre-commit hook to .git/hooks/pre-commit" {
+    run just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    [ -f "${TMP_REPO}/.git/hooks/pre-commit" ]
+}
+
+@test "install-hooks-legacy: installed hook is executable" {
+    run just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    [ -x "${TMP_REPO}/.git/hooks/pre-commit" ]
+}
+
+@test "install-hooks-legacy: installed hook content matches hooks/pre-commit" {
+    run just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    run diff "${TMP_REPO}/hooks/pre-commit" "${TMP_REPO}/.git/hooks/pre-commit"
+    [ "$status" -eq 0 ]
+}
+
+@test "install-hooks-legacy: does not invoke pixi run pre-commit install" {
+    run env PATH="${PIXI_STUB}:${PATH}" \
+        just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    [ ! -f "${PIXI_STUB}/pixi.log" ]
+}


### PR DESCRIPTION
## Summary

- Adds `tests/unit/test_install_hooks_legacy.bats` with 4 bats tests covering the `install-hooks-legacy` justfile recipe
- Tests verify: hook file is created, is executable, content matches `hooks/pre-commit`, and `pixi` is never invoked
- No changes to production code; the new file is automatically picked up by `pixi run test-unit`

## Test plan

- [x] All 4 new tests pass: `pixi run bats tests/unit/test_install_hooks_legacy.bats`
- [x] Full unit suite passes (400 tests, 1 pre-existing failure in `test_url_security.bats` unrelated to this change): `pixi run test-unit`

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)