### PR TITLE
docs(readme): document install-hooks-legacy in quick-start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Container images are built separately in [AchaeanFleet](../AchaeanFleet).
 # Install dependencies (yq, jq, just, pre-commit)
 pixi install   # or: apt install jq && curl -fsSL .../yq_linux_amd64 -o /usr/local/bin/yq
 
-# Install pre-commit hooks (runs automatically on every commit)
-just install-hooks   # uses pre-commit framework
-# Alternatively, for backward compatibility without pre-commit:
-# just install-hooks-legacy
+# Install pre-commit hooks (runs the full pre-commit framework on every commit)
+just install-hooks
+
+# If the pre-commit framework is not installed or not desired (e.g., minimal CI,
+# glibc-incompatible environments), use the legacy hook instead (dangerous-flags check only):
+just install-hooks-legacy
 
 # Bootstrap: export current Agamemnon state to YAML (run once)
 just export hermes


### PR DESCRIPTION
## Summary

- Promotes `just install-hooks-legacy` from a commented-out line to a first-class documented command in the Quick start bash block
- Adds a clear "when to use" note: environments where the `pre-commit` framework is not installed or desired (e.g., minimal CI, glibc-incompatible environments)
- Documents that the legacy hook runs the dangerous-flags check only, without the full `pre-commit` framework

## Test plan

- [ ] Verify the quick-start bash block renders both `just install-hooks` and `just install-hooks-legacy` as runnable commands with clear explanatory comments
- [ ] Confirm the `just install-hooks-legacy` target exists in the justfile and matches the documented behavior

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)