### PR TITLE
fix(justfile): guard install-hooks against missing pixi/pre-commit

### DIFF
--- a/justfile
+++ b/justfile
@@ -164,10 +164,26 @@ build-hello-world:
 
 # Install all git hooks: copies the dangerous-flags hook AND registers the pre-commit framework
 install-hooks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v pixi &>/dev/null; then
+        printf 'ERROR: pixi is not installed.\n'
+        printf '  Install it: curl -fsSL https://pixi.sh/install.sh | bash\n'
+        printf '  Then re-run: just install-hooks\n'
+        printf '  See CONTRIBUTING.md for full setup instructions.\n'
+        exit 1
+    fi
+    if ! pixi run --environment lint pre-commit --version &>/dev/null; then
+        printf 'ERROR: pre-commit is not available in the pixi lint environment.\n'
+        printf '  Run: pixi install --environment lint\n'
+        printf '  Then re-run: just install-hooks\n'
+        printf '  See CONTRIBUTING.md for full setup instructions.\n'
+        exit 1
+    fi
     cp hooks/pre-commit .git/hooks/pre-commit
     chmod +x .git/hooks/pre-commit
-    pixi run pre-commit install
-    @echo "Hooks installed: dangerous-flags hook + pre-commit framework (.pre-commit-config.yaml)."
+    pixi run --environment lint pre-commit install
+    printf 'Hooks installed: dangerous-flags hook + pre-commit framework (.pre-commit-config.yaml).\n'
 
 # Legacy: install only the dangerous-flags hook script (no pre-commit framework)
 install-hooks-legacy:


### PR DESCRIPTION
## Summary

- Rewrites the `install-hooks` justfile recipe as a shebang-headed bash block to support multi-line shell logic
- Adds Guard 1: checks `command -v pixi` and emits a clear error with the install URL if pixi is absent
- Adds Guard 2: checks `pixi run --environment lint pre-commit --version` and emits actionable `pixi install --environment lint` instructions if pre-commit is missing from the lint environment
- Updates the final `pixi run pre-commit install` to correctly target `--environment lint`

## Test plan

- [ ] **pixi missing**: remove pixi from PATH and run `just install-hooks` → prints `ERROR: pixi is not installed.` with install URL; exits 1
- [ ] **pre-commit env missing**: run with a fresh pixi env (no `lint` environment installed) → prints `ERROR: pre-commit is not available in the pixi lint environment.` with `pixi install --environment lint` instruction; exits 1
- [ ] **Happy path**: pixi installed, lint env populated → hooks install normally; `.git/hooks/pre-commit` exists; success message printed
- [ ] `install-hooks-legacy` remains unchanged
- [ ] Existing test suite (`pixi run unit`) still passes

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)