### PR TITLE
docs: document MYRMIDONS_YES env var in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Example: `./scripts/apply.sh hermes --output json | jq .summary`
 | `LOG_FORMAT` | `text` | Log output format: text or json |
 | `AIM_LOCK_FILE` | `.myrmidons.lock` | Path to the apply lock file (use workspace-scoped path in parallel CI) |
 | `MYRMIDONS_DEFAULT_OWNER` | `$(whoami)` | Fallback owner written to exported agent YAMLs when the Agamemnon API returns no owner |
+| `MYRMIDONS_YES` | _(unset)_ | Set to `true` to skip all interactive confirmation prompts (equivalent to `--yes`); useful in CI pipelines where stdin is not a TTY |
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ hooks/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AGAMEMNON_URL` | `http://localhost:8080` | ProjectAgamemnon base URL |
+| `MYRMIDONS_YES` | _(unset)_ | Set to `true` to skip all interactive confirmation prompts (equivalent to `--yes`); useful in CI pipelines where stdin is not a TTY |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Add `MYRMIDONS_YES` row to the Environment Variables table in `CLAUDE.md` (after `MYRMIDONS_DEFAULT_OWNER`)
- Add `MYRMIDONS_YES` row to the Environment Variables table in `README.md`
- Documents that `MYRMIDONS_YES=true` is equivalent to `--yes`, skipping all interactive confirmation prompts — making this CI escape hatch discoverable without reading source

## Test plan

- [ ] `grep -n MYRMIDONS_YES CLAUDE.md` returns the new table row at line 134
- [ ] `grep -n MYRMIDONS_YES README.md` returns the new table row at line 151
- [ ] `SKIP=mojo-format,actionlint,gitleaks pixi run pre-commit run --all-files` passes (trim whitespace, yaml, shellcheck, schema validation all green)
- [ ] No new markdownlint errors introduced

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)