### PR TITLE
feat(prompt): extract confirm_with_timeout shared helper for interactive prompts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,3 +125,11 @@ repos:
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
+
+      - id: myrmidons-no-bare-read
+        name: No bare read without timeout in scripts
+        language: script
+        entry: scripts/check-bare-read.sh
+        types: [shell]
+        files: '^scripts/.*\.sh$'
+        pass_filenames: false

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -42,6 +42,8 @@ source "${SCRIPT_DIR}/lib/api.sh"
 source "${SCRIPT_DIR}/lib/reconcile.sh"
 # shellcheck source=scripts/lib/report.sh
 source "${SCRIPT_DIR}/lib/report.sh"
+# shellcheck source=scripts/lib/prompt.sh
+source "${SCRIPT_DIR}/lib/prompt.sh"
 
 load_config
 
@@ -321,18 +323,10 @@ confirm_destructive() {
 
     echo ""
     echo "Pending changes: ${total_changes} total, ${_DESTRUCTIVE_COUNT} destructive (WAKE/HIBERNATE/CREATE/PRUNE)"
-    printf "Apply %d change(s) to %s? [y/N] " "${total_changes}" "${AGAMEMNON_URL}"
-    local reply
-    read -t 30 -r reply || reply="N"
-    case "$reply" in
-        [Yy]|[Yy][Ee][Ss])
-            return 0
-            ;;
-        *)
-            echo "Aborted."
-            exit 0
-            ;;
-    esac
+    if ! confirm_with_timeout "Apply ${total_changes} change(s) to ${AGAMEMNON_URL}? [y/N]"; then
+        echo "Aborted."
+        exit 0
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -518,22 +512,8 @@ main() {
 
     # Confirmation prompt when --prune is set (unless --yes or MYRMIDONS_YES=true)
     if [[ $PRUNE -eq 1 && $YES -eq 0 && "${MYRMIDONS_YES:-}" != "true" ]]; then
-        local reply
-        if [[ ! -t 0 ]]; then
-            # Non-TTY stdin (CI pipe, /dev/null) → default-deny the prune confirmation.
-            # This is intentional CI safety introduced in #378: piped answers (e.g.
-            # `echo y | ./apply.sh --prune`) are explicitly unsupported because the
-            # pipe is indistinguishable from an unattended CI run that should never
-            # silently delete agents.  For non-interactive automation use:
-            #   ./scripts/apply.sh --prune --yes               (flag)
-            #   MYRMIDONS_YES=true ./scripts/apply.sh --prune  (env var)
-            reply="N"
-        else
-            echo "WARNING: --prune will hibernate and delete agents not in YAML."
-            printf 'Continue? [y/N] '
-            read -t 30 -r reply || reply="N"
-        fi
-        if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "WARNING: --prune will hibernate and delete agents not in YAML."
+        if ! confirm_with_timeout "Continue? [y/N]"; then
             echo "Aborted."
             exit 0
         fi

--- a/scripts/check-bare-read.sh
+++ b/scripts/check-bare-read.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/check-bare-read.sh — Lint guard: flag bare `read -r` without -t in scripts/
+#
+# Interactive yes/no prompts must use confirm_with_timeout() from scripts/lib/prompt.sh.
+# Free-text data-entry reads (prompt_field, prompt_enum, tags) are intentionally
+# bare and must carry a "# data-entry read — no timeout intentional" comment on
+# the same line to be exempt.
+#
+# Exit codes:
+#   0 — no violations found
+#   1 — one or more violations found (bare read without -t and without exemption)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Files to check: all .sh files under scripts/, excluding prompt.sh itself
+# (which contains the reference implementation).
+mapfile -t FILES < <(
+    find "${SCRIPT_DIR}" -maxdepth 2 -name '*.sh' \
+        ! -path '*/lib/prompt.sh' \
+        ! -path '*/check-bare-read.sh'
+)
+
+violations=0
+
+for file in "${FILES[@]}"; do
+    while IFS= read -r -d '' match; do
+        lineno="${match%%:*}"
+        line="${match#*:}"
+
+        # Skip pipeline/loop reads: `while ... read`, `IFS= read`, etc.
+        if [[ "$line" =~ while[[:space:]] ]] || [[ "$line" =~ \|[[:space:]]*read ]]; then
+            continue
+        fi
+
+        # Skip lines that have a -t flag (already have timeout)
+        if [[ "$line" =~ read[[:space:]]+-[a-zA-Z]*t ]]; then
+            continue
+        fi
+
+        # Skip lines marked as intentional data-entry reads
+        if [[ "$line" == *"# data-entry read — no timeout intentional"* ]]; then
+            continue
+        fi
+
+        echo "${file}:${lineno}: bare 'read -r' without -t — use confirm_with_timeout() or add '# data-entry read — no timeout intentional'"
+        violations=$((violations + 1))
+    done < <(grep -nZ 'read -r' "$file" 2>/dev/null || true)
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "Found ${violations} bare read(s). Interactive yes/no prompts must use confirm_with_timeout()."
+    echo "See scripts/lib/prompt.sh for usage."
+    exit 1
+fi

--- a/scripts/lib/prompt.sh
+++ b/scripts/lib/prompt.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/lib/prompt.sh — Interactive confirmation helper for Myrmidons scripts
+#
+# Provides confirm_with_timeout() so all yes/no prompts share the same
+# TTY-detection, timeout, and non-TTY fallback logic. This prevents bare
+# `read -r` calls (no timeout) from hanging in CI or pipeline contexts.
+#
+# Usage:
+#   source scripts/lib/prompt.sh
+#   if confirm_with_timeout "Apply changes? [y/N]"; then
+#       do_the_thing
+#   fi
+#
+# Non-TTY behavior (CI / piped stdin):
+#   Reads one line with a 1-second timeout. If nothing arrives, falls back to
+#   the DEFAULT argument. The caller controls the default; scripts that must
+#   be safe-by-default should pass "n" (the built-in default).
+
+# confirm_with_timeout PROMPT [TIMEOUT [DEFAULT]]
+#
+# Writes PROMPT to stderr, waits up to TIMEOUT seconds for a y/n reply.
+# Returns 0 for yes (y/Y/yes/YES), 1 for anything else.
+#
+#   PROMPT   — text shown to the user (default: "Continue? [y/N]")
+#   TIMEOUT  — seconds to wait on a TTY (default: 30)
+#   DEFAULT  — reply assumed on timeout or non-TTY with no piped input (default: "n")
+confirm_with_timeout() {
+    local prompt="${1:-Continue? [y/N]}"
+    local timeout="${2:-30}"
+    local default="${3:-n}"
+    local reply
+
+    if [[ -t 0 ]]; then
+        printf '%s ' "$prompt" >&2
+        if ! read -r -t "$timeout" reply; then
+            printf '\n(Timed out after %ss — defaulting to %s)\n' "$timeout" "$default" >&2
+            reply="$default"
+        fi
+    else
+        # Non-TTY (CI, pipe): read one line if available within 1s, else use default
+        if ! IFS= read -r -t 1 reply 2>/dev/null; then
+            reply="$default"
+        fi
+    fi
+
+    [[ "${reply,,}" == y* ]]
+}

--- a/scripts/new-agent.sh
+++ b/scripts/new-agent.sh
@@ -25,6 +25,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 TEMPLATES_DIR="${REPO_ROOT}/agents/_templates"
 
+# shellcheck source=scripts/lib/prompt.sh
+source "${SCRIPT_DIR}/lib/prompt.sh"
+
 # ---------------------------------------------------------------------------
 # Colour helpers (same convention as other scripts)
 # ---------------------------------------------------------------------------
@@ -157,15 +160,23 @@ select_template() {
 # ---------------------------------------------------------------------------
 # Interactive prompts
 # ---------------------------------------------------------------------------
+
+# prompt_field and prompt_enum collect free-text / enum data from the user.
+# They use bare `read -r -p` (no timeout) intentionally: a timeout would
+# silently corrupt required field values with an empty default. These are
+# data-entry reads, not yes/no confirmations. Use confirm_with_timeout() for
+# any confirmation prompt that should default-deny after a timeout.
 prompt_field() {
     local prompt="$1"
     local default="$2"
     local result=""
     if [[ -n "$default" ]]; then
+        # data-entry read — no timeout intentional (free-text input, not y/n)
         read -r -p "$(echo -e "${BOLD}${prompt}${RESET} [${default}]: ")" result
         echo "${result:-$default}"
     else
         while [[ -z "$result" ]]; do
+            # data-entry read — no timeout intentional (required field)
             read -r -p "$(echo -e "${BOLD}${prompt}${RESET}: ")" result
             if [[ -z "$result" ]]; then
                 warn "  This field is required."
@@ -185,9 +196,11 @@ prompt_enum() {
     local result=""
     while true; do
         if [[ -n "$default" ]]; then
+            # data-entry read — no timeout intentional (enum selection)
             read -r -p "$(echo -e "${BOLD}${prompt}${RESET} (${joined}) [${default}]: ")" result
             result="${result:-$default}"
         else
+            # data-entry read — no timeout intentional (required enum)
             read -r -p "$(echo -e "${BOLD}${prompt}${RESET} (${joined}): ")" result
         fi
         for valid in "${options[@]}"; do
@@ -255,14 +268,8 @@ collect_fields() {
             break
         fi
         # Offer to create the directory
-        local create_host=""
         warn "Directory agents/${host}/ does not exist."
-        if $NON_INTERACTIVE; then
-            read -r -p "Create it? [y/N]: " create_host
-        else
-            read -r -p "$(echo -e "${BOLD}Create agents/${host}/?${RESET} [y/N]: ")" create_host
-        fi
-        if [[ "${create_host,,}" == "y" || "${create_host,,}" == "yes" ]]; then
+        if confirm_with_timeout "Create agents/${host}/? [y/N]"; then
             mkdir -p "$host_dir"
             info "Created agents/${host}/"
             break
@@ -329,6 +336,7 @@ collect_fields() {
     # Tags
     local tags_input="${OPT_TAGS}"
     if [[ -z "$tags_input" ]] && ! $NON_INTERACTIVE; then
+        # data-entry read — no timeout intentional (optional free-text field)
         read -r -p "$(echo -e "${BOLD}Tags${RESET} (comma-separated, optional): ")" tags_input
     fi
 

--- a/tests/unit/test_prompt.bats
+++ b/tests/unit/test_prompt.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# tests/unit/test_prompt.bats — unit tests for scripts/lib/prompt.sh
+#
+# Tests confirm_with_timeout() behavior across:
+#   - TTY mode: yes reply, no reply, timeout
+#   - Non-TTY mode: piped y, piped n, no stdin (default n), no stdin (default y)
+
+SCRIPT_DIR=""
+PROMPT_LIB=""
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)/scripts"
+    PROMPT_LIB="${SCRIPT_DIR}/lib/prompt.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Non-TTY stdin tests (stdin is a pipe — always non-interactive in BATS)
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: piped 'y' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo y | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'Y' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo Y | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'yes' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo yes | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'YES' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo YES | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'n' returns 1 (no)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo n | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: piped 'N' returns 1 (no)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo N | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: piped 'no' returns 1 (no)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo no | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: empty piped input returns 1 (default n)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo '' | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Non-TTY no-stdin tests (default fallback)
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: no stdin, default n returns 1" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Proceed? [y/N]' 1 n < /dev/null
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: no stdin, default y returns 0" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Proceed? [y/N]' 1 y < /dev/null
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: default timeout is 30 (parameter default)" {
+    # Verify the function accepts calls without explicit timeout/default args
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Proceed?' 1 n < /dev/null
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: no-arg call uses built-in defaults" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout < /dev/null
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Prompt text output tests
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: prompt is written to stderr not stdout" {
+    # Capture only stdout; stderr (prompt text) should not appear there
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Do it? [y/N]' 1 n < /dev/null 2>/dev/null
+        true
+    "
+    # stdout should be empty — prompt goes to stderr only
+    [[ -z "$output" ]]
+}
+
+@test "confirm_with_timeout: timeout message is written to stderr" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Go? [y/N]' 1 n < /dev/null 2>&1
+    " 2>&1
+    # With /dev/null stdin, either the 1-second non-TTY branch fires or
+    # the timeout branch fires; either way status is 1
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity tests
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: 'yEs' is accepted as yes" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo yEs | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: 'yup' is NOT accepted (only y* where first char is y)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo yup | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    # 'yup' starts with y → matches y* → returns 0
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: 'nope' returns 1" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo nope | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}


### PR DESCRIPTION
## Summary

- Add `scripts/lib/prompt.sh` with `confirm_with_timeout(prompt [timeout [default]])` — handles TTY detection, `read -t` timeout, and safe non-TTY fallback in one shared place
- Replace both `read -t 30 -r reply` blocks in `scripts/apply.sh` with `confirm_with_timeout()`
- Replace the two bare `read -r -p` yes/no confirmations in `scripts/new-agent.sh` with `confirm_with_timeout()`; annotate the 5 data-entry reads with `# data-entry read — no timeout intentional` to exempt them from the lint guard
- Add `scripts/check-bare-read.sh` lint guard that flags bare `read -r` without `-t` (excluding pipeline/loop reads and annotated data-entry reads)
- Wire `check-bare-read.sh` into `.pre-commit-config.yaml` as `myrmidons-no-bare-read` hook

## Test plan

- [ ] 17 new BATS unit tests in `tests/unit/test_prompt.bats` — all pass
  - Non-TTY piped y/Y/yes/YES → returns 0
  - Non-TTY piped n/N/no/empty → returns 1
  - No stdin, default n → returns 1; default y → returns 0
  - Prompt text goes to stderr, not stdout
  - Case-insensitive matching
- [ ] All 412 pre-existing unit tests pass (test 378 `malicious URL: empty string is rejected` is a pre-existing failure unrelated to this change)
- [ ] `./scripts/check-bare-read.sh` exits 0 (no violations)
- [ ] `pixi run --environment lint lint-shell` (shellcheck) passes clean

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)