### PR TITLE
docs(apply): document non-TTY default-deny for --prune piped input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,3 +263,22 @@ Rules:
 The `lint-shell` task in `pixi.toml` / `scripts/lint-shell.sh` covers `*.sh`, `*.bats`,
 and `hooks/pre-commit`. Keep it in sync with the pre-commit shellcheck hook's `files:`
 pattern.
+
+### Piped input to `--prune` is rejected (non-TTY default-deny)
+
+`apply.sh` detects non-TTY stdin and **default-denies** the prune confirmation.
+This means `echo y | ./scripts/apply.sh --prune` will always abort — the piped
+`y` is never read.
+
+**Why:** Introduced in #378 as a CI safety guard. A pipe is indistinguishable
+from an unattended job that should never silently hibernate or delete agents.
+
+**What to do instead:**
+
+```bash
+# Explicit opt-in flag
+./scripts/apply.sh --prune --yes
+
+# Or via environment variable
+MYRMIDONS_YES=true ./scripts/apply.sh --prune
+```

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -484,7 +484,13 @@ main() {
     if [[ $PRUNE -eq 1 && $YES -eq 0 && "${MYRMIDONS_YES:-}" != "true" ]]; then
         local reply
         if [[ ! -t 0 ]]; then
-            # Non-TTY stdin (CI pipe, /dev/null) — default-deny
+            # Non-TTY stdin (CI pipe, /dev/null) → default-deny the prune confirmation.
+            # This is intentional CI safety introduced in #378: piped answers (e.g.
+            # `echo y | ./apply.sh --prune`) are explicitly unsupported because the
+            # pipe is indistinguishable from an unattended CI run that should never
+            # silently delete agents.  For non-interactive automation use:
+            #   ./scripts/apply.sh --prune --yes               (flag)
+            #   MYRMIDONS_YES=true ./scripts/apply.sh --prune  (env var)
             reply="N"
         else
             echo "WARNING: --prune will hibernate and delete agents not in YAML."


### PR DESCRIPTION
## Summary

- Expanded the one-line comment at `scripts/apply.sh:486` to explain why `echo y | ./apply.sh --prune` is intentionally rejected in non-TTY environments (CI safety introduced in #378, not a bug), and documents the correct bypasses (`--yes` flag / `MYRMIDONS_YES=true` env var).
- Added a new **Known Gotchas** entry to `CLAUDE.md` covering the same behavior so operators don't reach for the pipe pattern expecting it to work.

No logic changes — behavior is unchanged from #378.

## Test plan

- [x] `pixi run --environment lint lint-shell` passes (shellcheck clean)
- [x] Manual verify: `echo y | ./scripts/apply.sh --prune` still aborts (non-TTY path sets `reply=N`)
- [x] `--yes` and `MYRMIDONS_YES=true` bypasses remain unaffected (covered by existing guard logic)

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)