### PR TITLE
fix(api): guard AGAMEMNON_API_KEY source-time init against xtrace leak

### DIFF
--- a/scripts/lib/api.sh
+++ b/scripts/lib/api.sh
@@ -18,7 +18,12 @@
 set -euo pipefail
 
 AGAMEMNON_URL="${AGAMEMNON_URL:-http://localhost:8080}"
+_aim_had_xtrace=0
+if [[ "$-" == *x* ]]; then _aim_had_xtrace=1; fi
+{ set +x; } 2>/dev/null
 AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
+if [[ $_aim_had_xtrace -eq 1 ]]; then set -x; fi
+unset _aim_had_xtrace
 
 # Validate that AGAMEMNON_URL is a safe http/https URL.
 #

--- a/tests/test-api-xtrace-init.sh
+++ b/tests/test-api-xtrace-init.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tests/test-api-xtrace-init.sh — Verify AGAMEMNON_API_KEY init in api.sh does not leak under xtrace
+#
+# Issue #429: the source-time assignment `AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"` at the top
+# of scripts/lib/api.sh was a secondary xtrace leak path. A set +x guard was added around it.
+# These tests verify that guard works correctly.
+#
+# Tests:
+#   1. Token value does not appear in xtrace when api.sh is sourced under bash -x
+#   2. AGAMEMNON_API_KEY is correctly set after the guard (functional check)
+#   3. Xtrace is restored after sourcing (a statement after source still traces)
+#   4. Guard does not enable xtrace when it was off before sourcing
+#
+# Usage:
+#   ./tests/test-api-xtrace-init.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — found '${needle}' in output (should be hidden)"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected '${needle}' not found in output"
+    fi
+}
+
+echo "Running api source-time xtrace init tests..."
+echo ""
+
+# ── Test 1: Token value does not appear in xtrace when api.sh is sourced ─────
+# The key is passed via the environment so the caller's own assignment does not
+# appear in the xtrace — we only want to verify that api.sh's internal re-init
+# `AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"` does not re-echo the token.
+_XTRACE_OUT="$(AGAMEMNON_API_KEY=init-secret-token-1 bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+" 2>&1 >/dev/null)"
+assert_not_contains "source-time init: token not in xtrace" \
+    "init-secret-token-1" "$_XTRACE_OUT"
+
+# ── Test 2: AGAMEMNON_API_KEY is correctly set after source ───────────────────
+_VALUE_CHECK="$(bash -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=init-secret-token-2
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    echo \"\${AGAMEMNON_API_KEY}\"
+" 2>/dev/null)"
+assert_contains "source-time init: AGAMEMNON_API_KEY correctly set" \
+    "init-secret-token-2" "$_VALUE_CHECK"
+
+# ── Test 3: Xtrace is restored after sourcing api.sh ─────────────────────────
+_RESTORE_CHECK="$(bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=init-canary-restore
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    echo XTRACE_STILL_ON
+" 2>&1)"
+assert_contains "xtrace restored after source: echo command traced" \
+    "+ echo XTRACE_STILL_ON" "$_RESTORE_CHECK"
+
+# ── Test 4: Guard does not enable xtrace when it was off ─────────────────────
+_NO_XTRACE_CHECK="$(bash +x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=init-secret-token-4
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    echo AFTER_SOURCE
+" 2>&1)"
+assert_contains "xtrace-off path: echo still works after source" \
+    "AFTER_SOURCE" "$_NO_XTRACE_CHECK"
+assert_not_contains "xtrace-off path: no xtrace lines introduced by source" \
+    "+ source" "$_NO_XTRACE_CHECK"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-api-xtrace.sh
+++ b/tests/test-api-xtrace.sh
@@ -11,7 +11,8 @@
 #
 # What is NOT tested (and is intentionally out of scope):
 #   - "export AGAMEMNON_API_KEY=..." in caller scripts — that is caller responsibility.
-#   - The variable init line in api.sh itself — it carries no header value.
+#
+# Source-time variable init (issue #429) is covered by tests/test-api-xtrace-init.sh.
 #
 # Usage:
 #   ./tests/test-api-xtrace.sh


### PR DESCRIPTION
## Summary

- Wraps `AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"` at api.sh line 21 with a `set +x` guard using the same `_aim_had_xtrace` pattern already used in `_agamemnon_auth_headers()` and `agamemnon_check_connection()`
- Adds `tests/test-api-xtrace-init.sh` with 5 tests covering the source-time init xtrace guard
- Updates the "What is NOT tested" comment in `test-api-xtrace.sh` to point to the new test file

Closes #429

## Test plan

- [x] `bash tests/test-api-xtrace-init.sh` — 5 passed, 0 failed
- [x] `bash tests/test-api-xtrace.sh` — 11 passed, 0 failed
- [x] `pixi run --environment lint lint-shell` — no shellcheck warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)