### PR TITLE
feat(lint): add xtrace leak detection for AGAMEMNON_API_KEY to CI pipeline

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -53,8 +53,9 @@ test-schema      = "./tests/validate-schemas.sh"
 test-doc-drift   = "./tests/detect-doc-drift.sh"
 test-api-retry   = "./tests/test-api-retry.sh"
 test-rollback    = "./tests/test-rollback.sh"
+test-xtrace      = "bash tests/test-check-xtrace-guards.sh"
 test-standalone  = { depends-on = ["test-api-retry", "test-rollback"] }
-test             = { depends-on = ["test-unit", "test-schema", "test-doc-drift", "test-standalone"] }
+test             = { depends-on = ["test-unit", "test-schema", "test-doc-drift", "test-standalone", "test-xtrace"] }
 build-hello-world = "just build-hello-world"
 
 [feature.lint.tasks]

--- a/scripts/check-xtrace-guards.sh
+++ b/scripts/check-xtrace-guards.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# scripts/check-xtrace-guards.sh — lint guard for AGAMEMNON_API_KEY xtrace leaks
+#
+# Scans shell scripts for lines that expand ${AGAMEMNON_API_KEY} or $AGAMEMNON_API_KEY
+# outside of a set +x / set -x guard block. Unguarded expansions cause the API key
+# value to appear in bash -x trace output.
+#
+# Guard patterns recognised:
+#   { set +x; } 2>/dev/null          — start of guard
+#   if [[ $_had_xtrace -eq 1 ]]; then set -x; fi   — end of guard
+#   set +x                            — bare start of guard
+#   set -x                            — bare end of guard
+#
+# Suppression annotation (same line):
+#   ${AGAMEMNON_API_KEY}  # xtrace-lint: ok
+#
+# Usage:
+#   ./scripts/check-xtrace-guards.sh                  # scan all *.sh in repo
+#   ./scripts/check-xtrace-guards.sh file1.sh ...     # scan specific files
+#
+# Exit codes:
+#   0 = no violations
+#   1 = violations found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+VIOLATIONS=0
+FILES_CHECKED=0
+
+# Collect files to scan
+if [[ $# -gt 0 ]]; then
+    FILES=("$@")
+else
+    # Default: scan all .sh files tracked in git
+    mapfile -t FILES < <(find "${REPO_ROOT}" \
+        -name "*.sh" \
+        -not -path "*/.pixi/*" \
+        -not -path "*/_precommit_test_*" \
+        2>/dev/null | sort)
+fi
+
+for file in "${FILES[@]}"; do
+    [[ ! -f "$file" ]] && continue
+    [[ "$file" != *.sh ]] && continue
+
+    FILES_CHECKED=$((FILES_CHECKED + 1))
+
+    # For each line that expands AGAMEMNON_API_KEY, check if it is within a
+    # set +x guard block. We track guard state by scanning the file line by line.
+    # Single-quoted heredocs (<<'WORD') are skipped — they are not executed.
+    inside_guard=0
+    heredoc_delim=""
+    lineno=0
+    while IFS= read -r line; do
+        lineno=$((lineno + 1))
+
+        # Track single-quoted heredoc blocks: variables inside are not expanded.
+        if [[ -n "$heredoc_delim" ]]; then
+            if [[ "$line" == "$heredoc_delim" ]]; then
+                heredoc_delim=""
+            fi
+            continue
+        fi
+        # Detect start of a single-quoted heredoc: <<'WORD' or <<"WORD" (double-quoted also suppresses expansion)
+        if echo "$line" | grep -qE "<<['\"][A-Za-z_][A-Za-z_0-9]*['\"]"; then
+            heredoc_delim="$(echo "$line" | grep -oE "['\"][A-Za-z_][A-Za-z_0-9]*['\"]" | tr -d "'\"")"
+            continue
+        fi
+
+        # Detect start of xtrace guard: { set +x; } or bare set +x
+        if echo "$line" | grep -qE '^\s*\{\s*set \+x\s*;\s*\}\s*(2>/dev/null)?$|^\s*set \+x\s*$'; then
+            inside_guard=1
+            continue
+        fi
+
+        # Detect end of xtrace guard: set -x (bare or inside if block)
+        if echo "$line" | grep -qE '^\s*(if \[\[.*_had_xtrace.*\]\];\s*then\s*)?set -x\s*(;\s*fi\s*)?$'; then
+            inside_guard=0
+            continue
+        fi
+
+        # Check if this line expands AGAMEMNON_API_KEY (not escaped \$ references)
+        if echo "$line" | grep -qE '[^\\]\$\{?AGAMEMNON_API_KEY\}?|^\$\{?AGAMEMNON_API_KEY\}?'; then
+            # Skip pure comment lines
+            if echo "$line" | grep -qE '^\s*#'; then
+                continue
+            fi
+            # Skip suppressed lines (inline annotation)
+            if echo "$line" | grep -q '# xtrace-lint: ok'; then
+                continue
+            fi
+            # Skip variable assignment lines: AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
+            # These normalise the variable and do not embed the value in HTTP headers.
+            if echo "$line" | grep -qE '^\s*AGAMEMNON_API_KEY='; then
+                continue
+            fi
+
+            if [[ $inside_guard -eq 0 ]]; then
+                echo "ERROR: ${file}:${lineno}: AGAMEMNON_API_KEY expanded without xtrace guard."
+                echo "       Wrap with: { set +x; } 2>/dev/null ... if [[ \$_had_xtrace -eq 1 ]]; then set -x; fi"
+                echo "       To suppress: append  # xtrace-lint: ok  on the same line."
+                VIOLATIONS=$((VIOLATIONS + 1))
+            fi
+        fi
+    done < "$file"
+done
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+    echo ""
+    echo "check-xtrace-guards: ${VIOLATIONS} violation(s) found in ${FILES_CHECKED} file(s)."
+    echo "AGAMEMNON_API_KEY must only be expanded inside a set +x / set -x guard block."
+    exit 1
+fi
+
+exit 0

--- a/tests/test-check-xtrace-guards.sh
+++ b/tests/test-check-xtrace-guards.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# tests/test-check-xtrace-guards.sh — unit tests for scripts/check-xtrace-guards.sh
+#
+# Creates temporary shell script fixtures and verifies detector behavior.
+#
+# Usage:
+#   ./tests/test-check-xtrace-guards.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DETECTOR="${REPO_ROOT}/scripts/check-xtrace-guards.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_LOCAL="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMPDIR_LOCAL"
+}
+trap cleanup EXIT
+
+assert_exit() {
+    local description="$1"
+    local expected_exit="$2"
+    local file="$3"
+
+    actual_exit=0
+    "$DETECTOR" "$file" >/dev/null 2>&1 || actual_exit=$?
+
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        echo "  PASS: ${description}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${description}"
+        echo "        expected exit ${expected_exit}, got ${actual_exit}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "Testing scripts/check-xtrace-guards.sh..."
+echo ""
+
+# --- Test 1: bare ${AGAMEMNON_API_KEY} in curl invocation → exit 1
+cat > "${TMPDIR_LOCAL}/violation.sh" <<'EOF'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+EOF
+assert_exit "bare \${AGAMEMNON_API_KEY} in curl without guard → exit 1" 1 "${TMPDIR_LOCAL}/violation.sh"
+
+# --- Test 2: bare $AGAMEMNON_API_KEY (no braces) in curl → exit 1
+cat > "${TMPDIR_LOCAL}/violation-no-braces.sh" <<'EOF'
+#!/usr/bin/env bash
+curl -H "X-API-Key: $AGAMEMNON_API_KEY" http://example.com
+EOF
+assert_exit "bare \$AGAMEMNON_API_KEY (no braces) without guard → exit 1" 1 "${TMPDIR_LOCAL}/violation-no-braces.sh"
+
+# --- Test 3: expansion inside { set +x; } / set -x guard → exit 0
+cat > "${TMPDIR_LOCAL}/guarded.sh" <<'EOF'
+#!/usr/bin/env bash
+local _had_xtrace=0
+if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+{ set +x; } 2>/dev/null
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+EOF
+assert_exit "expansion inside { set +x; } ... set -x guard → exit 0" 0 "${TMPDIR_LOCAL}/guarded.sh"
+
+# --- Test 4: expansion inside bare set +x / set -x guard → exit 0
+cat > "${TMPDIR_LOCAL}/guarded-bare.sh" <<'EOF'
+#!/usr/bin/env bash
+set +x
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+set -x
+EOF
+assert_exit "expansion inside bare set +x / set -x guard → exit 0" 0 "${TMPDIR_LOCAL}/guarded-bare.sh"
+
+# --- Test 5: suppression annotation on expansion line → exit 0
+cat > "${TMPDIR_LOCAL}/suppressed.sh" <<'EOF'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com # xtrace-lint: ok
+EOF
+assert_exit "suppressed with # xtrace-lint: ok annotation → exit 0" 0 "${TMPDIR_LOCAL}/suppressed.sh"
+
+# --- Test 6: variable assignment (normalisation) → exit 0
+cat > "${TMPDIR_LOCAL}/assignment.sh" <<'EOF'
+#!/usr/bin/env bash
+AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
+echo "setup done"
+EOF
+assert_exit "variable assignment line AGAMEMNON_API_KEY= → exit 0" 0 "${TMPDIR_LOCAL}/assignment.sh"
+
+# --- Test 7: comment-only reference → exit 0
+cat > "${TMPDIR_LOCAL}/comment.sh" <<'EOF'
+#!/usr/bin/env bash
+# Authenticate with ${AGAMEMNON_API_KEY} before calling the API.
+echo "hello"
+EOF
+assert_exit "comment-only reference → exit 0" 0 "${TMPDIR_LOCAL}/comment.sh"
+
+# --- Test 8: no AGAMEMNON_API_KEY reference at all → exit 0
+cat > "${TMPDIR_LOCAL}/no-key.sh" <<'EOF'
+#!/usr/bin/env bash
+curl http://example.com
+EOF
+assert_exit "no AGAMEMNON_API_KEY reference → exit 0" 0 "${TMPDIR_LOCAL}/no-key.sh"
+
+# --- Test 9: multiple files, one violation one clean → exit 1
+cat > "${TMPDIR_LOCAL}/multi-clean.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "nothing here"
+EOF
+cat > "${TMPDIR_LOCAL}/multi-dirty.sh" <<'EOF'
+#!/usr/bin/env bash
+curl -H "X-API-Key: ${AGAMEMNON_API_KEY}" http://example.com
+EOF
+actual_exit=0
+"$DETECTOR" "${TMPDIR_LOCAL}/multi-clean.sh" "${TMPDIR_LOCAL}/multi-dirty.sh" >/dev/null 2>&1 || actual_exit=$?
+if [[ "$actual_exit" -eq 1 ]]; then
+    echo "  PASS: multiple files, one dirty → exit 1"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: multiple files, one dirty → expected exit 1, got ${actual_exit}"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- Test 10: violation after a guard block ends → exit 1
+cat > "${TMPDIR_LOCAL}/post-guard.sh" <<'EOF'
+#!/usr/bin/env bash
+{ set +x; } 2>/dev/null
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com/guarded
+if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com/unguarded
+EOF
+assert_exit "expansion after guard block ends → exit 1" 1 "${TMPDIR_LOCAL}/post-guard.sh"
+
+# --- Test 11: default scan of repo — should exit 0 (all expansions guarded)
+echo -n "  Testing default scan of repo *.sh files: "
+default_exit=0
+(cd "${REPO_ROOT}" && ./scripts/check-xtrace-guards.sh) >/dev/null 2>&1 || default_exit=$?
+if [[ "$default_exit" -eq 0 ]]; then
+    echo "PASS (exit 0)"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL (exit ${default_exit} — violations remain in repo)"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tests/unit/test_xtrace_guards.bats
+++ b/tests/unit/test_xtrace_guards.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# tests/unit/test_xtrace_guards.bats
+#
+# Issue #431: test coverage for check-xtrace-guards.sh.
+#
+# The linter statically flags shell scripts that expand ${AGAMEMNON_API_KEY}
+# outside of a set +x / set -x guard block, preventing API key leakage in
+# bash -x trace output.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+DETECTOR="${SCRIPT_DIR}/scripts/check-xtrace-guards.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="${SCRIPT_DIR}/_xtrace_test_$$_${RANDOM}"
+    mkdir -p "$TMP_DIR"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: bare ${AGAMEMNON_API_KEY} in curl without guard → violation
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: bare expansion in curl exits 1" {
+    local f="${TMP_DIR}/bare.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGAMEMNON_API_KEY expanded without xtrace guard"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: bare $AGAMEMNON_API_KEY (no braces) without guard → violation
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: bare expansion without braces exits 1" {
+    local f="${TMP_DIR}/bare-no-braces.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+curl -H "X-API-Key: $AGAMEMNON_API_KEY" http://example.com
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGAMEMNON_API_KEY expanded without xtrace guard"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: expansion inside { set +x; } / set -x guard → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: expansion inside brace guard exits 0" {
+    local f="${TMP_DIR}/guarded.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+local _had_xtrace=0
+if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+{ set +x; } 2>/dev/null
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: expansion inside bare set +x / set -x guard → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: expansion inside bare set +x guard exits 0" {
+    local f="${TMP_DIR}/bare-guard.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+set +x
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+set -x
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: suppression annotation → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: suppressed with xtrace-lint: ok exits 0" {
+    local f="${TMP_DIR}/suppressed.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com # xtrace-lint: ok
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: variable assignment (normalisation) → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: AGAMEMNON_API_KEY= assignment exits 0" {
+    local f="${TMP_DIR}/assign.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
+echo "ready"
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: comment-only reference → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: comment-only reference exits 0" {
+    local f="${TMP_DIR}/comment.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+# Use ${AGAMEMNON_API_KEY} for authentication
+echo "hello"
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: violation after guard block ends → violation
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: expansion after guard block ends exits 1" {
+    local f="${TMP_DIR}/post-guard.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+{ set +x; } 2>/dev/null
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com/guarded
+if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com/unguarded
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: scripts/lib/api.sh in repo passes the linter
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: repo api.sh exits 0" {
+    run bash "$DETECTOR" "${SCRIPT_DIR}/scripts/lib/api.sh"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: default full-repo scan exits 0 (all expansions are guarded)
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: full-repo default scan exits 0" {
+    run bash "$DETECTOR"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Add `scripts/check-xtrace-guards.sh`: static linter that flags `${AGAMEMNON_API_KEY}` expansions outside of `set +x` / `set -x` guard blocks, preventing API key leakage in `bash -x` trace output
- Register as a `myrmidons-xtrace-guard` pre-commit hook (`.sh` files only); CI already runs `pre-commit run --all-files` so no workflow changes are needed
- Add `test-xtrace` pixi task and include it in the `test` dependency chain

## What the linter catches

```
ERROR: scripts/example.sh:5: AGAMEMNON_API_KEY expanded without xtrace guard.
       Wrap with: { set +x; } 2>/dev/null ... if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
       To suppress: append  # xtrace-lint: ok  on the same line.
```

## Guard patterns recognised (clean)

- `{ set +x; } 2>/dev/null` / `if [[ $_had_xtrace -eq 1 ]]; then set -x; fi`
- bare `set +x` / `set -x`

## Exclusions (not flagged)

- `AGAMEMNON_API_KEY=` assignment lines (variable normalisation, no header value)
- Comment-only lines (`#`)
- Escaped `\${AGAMEMNON_API_KEY}` (not expanded at runtime)
- Single-quoted heredoc bodies `<<'EOF'` (not expanded at runtime)
- Lines with `# xtrace-lint: ok` suppression annotation

## Test plan

- [x] 11 shell test cases in `tests/test-check-xtrace-guards.sh` — all pass
- [x] 10 BATS unit tests in `tests/unit/test_xtrace_guards.bats` — all pass
- [x] Full-repo default scan exits 0 (all existing expansions are guarded)
- [x] ShellCheck clean on all new scripts (`pixi run --environment lint lint-shell`)
- [x] `pixi run test-xtrace` passes

Closes #431
Follow-up to #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)