### PR TITLE
test(apply): add prune-convergence integration test for verify_convergence

### DIFF
--- a/tests/fixtures/convergence-routes-prune.json
+++ b/tests/fixtures/convergence-routes-prune.json
@@ -1,0 +1,45 @@
+{
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": { "id": "uid1", "name": "unmanaged-prune-agent", "status": "offline" }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {}
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "Convergence Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    },
+    {
+      "id": "uid1",
+      "name": "unmanaged-prune-agent",
+      "status": "active",
+      "label": "Unmanaged Prune Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/unmanaged",
+      "programArgs": "",
+      "taskDescription": "unmanaged agent that should be pruned",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tests/integration/test_verify_convergence.bats
+++ b/tests/integration/test_verify_convergence.bats
@@ -147,3 +147,29 @@ teardown() {
 
     [[ "$output" == *"NOT converged"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Test 4: prune-convergence path — pruned agent still present in API
+#
+# Routes design (convergence-routes-prune.json):
+#   All GET /api/v1/agents  → two agents: convergence-agent (managed, active)
+#                             and unmanaged-prune-agent (unmanaged, active)
+#   PATCH /api/v1/agents/*  → 200 offline  (hibernate succeeds)
+#   DELETE /api/v1/agents/* → 200          (delete appears to succeed)
+#   default_body            → still returns both agents (delete had no effect)
+#
+# With --prune, apply.sh calls handle_unmanaged for unmanaged-prune-agent,
+# which hibernates then deletes it. The mock DELETE returns 200 but the
+# subsequent GET still returns the agent. verify_convergence checks
+# _PRUNED_NAMES and finds unmanaged-prune-agent still present, reporting
+# "pruned but still present in API (convergence failed)".
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: detects pruned agent still present in API — reports convergence failed" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-prune.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --prune --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$output" == *"pruned but still present in API (convergence failed)"* ]]
+}


### PR DESCRIPTION
## Summary

- Adds `tests/fixtures/convergence-routes-prune.json`: a mock routes config where `DELETE /api/v1/agents/*` returns 200 but the subsequent GET still includes the unmanaged agent (`unmanaged-prune-agent`), simulating a failed deletion.
- Adds a fourth `@test` block to `tests/integration/test_verify_convergence.bats`: runs `apply.sh --prune` against the new fixture and asserts that `verify_convergence` reports `"pruned but still present in API (convergence failed)"`.

## Test plan

- [x] All 4 integration tests in `test_verify_convergence.bats` pass (`bats tests/integration/test_verify_convergence.bats`)
- [x] New test targets the `_PRUNED_NAMES` loop in `verify_convergence` (lines 388–399 of `apply.sh`), which previously had zero integration test coverage
- [x] No existing tests broken

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)