### PR TITLE
docs(contributing): add spec.model as explicit untracked row; extend drift guard to cover CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,7 @@ The reconciler compares these fields between desired YAML state and actual Agame
 | `spec.owner` | ✓ |
 | `spec.role` | ✓ |
 | `spec.desiredState` | ✓ (drives WAKE/HIBERNATE) |
+| `spec.model` | — (not tracked; Agamemnon manages model selection at runtime) |
 | `spec.deployment.type` | — (not tracked; see below) |
 
 Fields NOT currently tracked (no drift detection): `spec.model`, `spec.deployment.type`, `spec.deployment.docker.*`

--- a/tests/detect-doc-drift.sh
+++ b/tests/detect-doc-drift.sh
@@ -30,8 +30,8 @@ FORBIDDEN_PHRASES=(
     "Nomad.*currently supported|implies Nomad is currently supported"
     "spec\.model.*reconcil|implies spec.model changes are reconciled by apply.sh"
     "spec\.deployment\.type.*reconcil|implies spec.deployment.type changes are reconciled"
-    "spec\.model.*tracked|implies spec.model is tracked for drift"
-    "spec\.deployment\.type.*tracked|implies spec.deployment.type is tracked for drift (it is not)"
+    "spec\.model.*✓|implies spec.model is tracked for drift (table row with checkmark)"
+    "spec\.deployment\.type.*✓|implies spec.deployment.type is tracked for drift (table row with checkmark)"
 )
 
 # Files and directories to scan (relative to repo root).
@@ -41,7 +41,7 @@ DOC_FILES=()
 while IFS= read -r -d '' f; do
     DOC_FILES+=("$f")
 done < <(find "${REPO_ROOT}" \
-    \( -name "Architecture.md" -o -name "README.md" -o -name "CLAUDE.md" \) \
+    \( -name "Architecture.md" -o -name "README.md" -o -name "CLAUDE.md" -o -name "CONTRIBUTING.md" \) \
     -print0 2>/dev/null)
 
 while IFS= read -r -d '' f; do


### PR DESCRIPTION
## Summary

- Added `spec.model` as an explicit "not tracked" row in CONTRIBUTING.md's drift detection table, making its untracked status self-documenting alongside `spec.deployment.type`
- Extended `tests/detect-doc-drift.sh` to scan `CONTRIBUTING.md` in addition to `README.md`, `CLAUDE.md`, and `Architecture.md`
- Fixed the `spec.model` and `spec.deployment.type` forbidden-phrase patterns to use the checkmark character (`✓`) — the previous `.*tracked` patterns were too broad and would match "not tracked" prose, causing false positives

## Test plan

- [x] `bash tests/detect-doc-drift.sh` passes clean (0 errors across 5 files including CONTRIBUTING.md)
- [x] Adversarial test: temporarily changing the new row to `| spec.model | ✓ |` causes the lint guard to exit 1 and report a violation
- [x] Full test suite passes: `pixi run test` — 396 tests, 0 failures
- [x] `pixi run test-doc-drift` passes

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)