### PR TITLE
docs(adr): advance ADR-007 through ADR-010 status to Accepted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,25 @@ Agent manifests are YAML files that describe desired agent state. Reference exis
 as examples for the expected schema. Key fields typically include agent type, resource limits,
 NATS subject subscriptions, and container image references.
 
+### ADR Lifecycle
+
+ADRs in `docs/adr/` follow this lifecycle:
+
+- **Proposed** — The decision is under active discussion. The ADR file has been
+  written but the team has not yet reached consensus.
+- **Accepted** — The team has reviewed and agreed to the decision. Update
+  `**Status:**` from `Proposed` to `Accepted` and add an `**Accepted:**` date
+  line immediately after the existing `**Date:**` line. Also update the status
+  column in `docs/adr/README.md`.
+- **Deprecated** — The decision is no longer in effect but was not replaced by
+  another ADR. Update status to `Deprecated`.
+- **Superseded** — The decision has been replaced. Update status to `Superseded`
+  and add a `**Superseded by:**` line referencing the new ADR.
+
+To accept an ADR: open a PR that changes the status field, adds the accepted
+date, and updates the index table. No special approval process is required
+beyond the normal PR review.
+
 ## Development Workflow
 
 ### 1. Find or Create an Issue

--- a/docs/adr/ADR-007-nomad-integration-strategy.md
+++ b/docs/adr/ADR-007-nomad-integration-strategy.md
@@ -1,7 +1,8 @@
 # ADR-007: Nomad Integration Strategy for Multi-Host Deployments
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-10
+**Accepted:** 2026-05-03
 **Author:** mvillmow
 
 ---

--- a/docs/adr/ADR-008-fleet-ref-filename-stem-resolution.md
+++ b/docs/adr/ADR-008-fleet-ref-filename-stem-resolution.md
@@ -1,7 +1,8 @@
 # ADR-008: Fleet ref Resolution by Filename Stem
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-28
+**Accepted:** 2026-05-03
 **Author:** mvillmow
 
 ---

--- a/docs/adr/ADR-009-compute-drift-positional-parameters.md
+++ b/docs/adr/ADR-009-compute-drift-positional-parameters.md
@@ -1,7 +1,8 @@
 # ADR-009: compute_drift Positional Parameter Interface
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-28
+**Accepted:** 2026-05-03
 **Author:** mvillmow
 
 ---

--- a/docs/adr/ADR-010-schema-versioning-strategy.md
+++ b/docs/adr/ADR-010-schema-versioning-strategy.md
@@ -1,7 +1,8 @@
 # ADR-010: Schema Versioning Strategy (myrmidons/v1)
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-28
+**Accepted:** 2026-05-03
 **Author:** mvillmow
 
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,7 +6,7 @@ alternatives that were considered and rejected.
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [ADR-007](ADR-007-nomad-integration-strategy.md) | Nomad Integration Strategy for Multi-Host Deployments | Proposed | 2026-04-10 |
-| [ADR-008](ADR-008-fleet-ref-filename-stem-resolution.md) | Fleet ref Resolution by Filename Stem | Proposed | 2026-04-28 |
-| [ADR-009](ADR-009-compute-drift-positional-parameters.md) | compute_drift Positional Parameter Interface | Proposed | 2026-04-28 |
-| [ADR-010](ADR-010-schema-versioning-strategy.md) | Schema Versioning Strategy (myrmidons/v1) | Proposed | 2026-04-28 |
+| [ADR-007](ADR-007-nomad-integration-strategy.md) | Nomad Integration Strategy for Multi-Host Deployments | Accepted | 2026-04-10 |
+| [ADR-008](ADR-008-fleet-ref-filename-stem-resolution.md) | Fleet ref Resolution by Filename Stem | Accepted | 2026-04-28 |
+| [ADR-009](ADR-009-compute-drift-positional-parameters.md) | compute_drift Positional Parameter Interface | Accepted | 2026-04-28 |
+| [ADR-010](ADR-010-schema-versioning-strategy.md) | Schema Versioning Strategy (myrmidons/v1) | Accepted | 2026-04-28 |


### PR DESCRIPTION
## Summary

- Changed `**Status:** Proposed` → `**Status:** Accepted` in ADR-007, ADR-008, ADR-009, and ADR-010
- Added `**Accepted:** 2026-05-03` date line to each ADR (immediately after the existing `**Date:**` line)
- Updated all four rows in `docs/adr/README.md` index table from Proposed → Accepted
- Added `### ADR Lifecycle` subsection to `CONTRIBUTING.md` documenting the Proposed → Accepted → Deprecated → Superseded lifecycle and how to accept an ADR

## Test plan

- [x] `grep "Proposed" docs/adr/ADR-00{7,8,9,10}*.md` returns nothing
- [x] `grep "Accepted" docs/adr/ADR-00{7,8,9,10}*.md` shows one line per file with date 2026-05-03
- [x] `grep "Proposed" docs/adr/README.md` returns nothing
- [x] `grep "ADR Lifecycle" CONTRIBUTING.md` confirms section is present
- [x] `pre-commit run trailing-whitespace end-of-file-fixer` passes on all six changed files
- [x] `git diff --stat` shows exactly 6 files changed, no unintended changes

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)