### PR TITLE
test(drift): add compute_drift arity guard and caller consistency check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,11 @@ ignored** by the reconciler and will NOT be applied to the running agent:
 > file, `apply.sh` will not detect drift for those fields. The running agent will keep
 > its current values until manually recreated.
 
+> **Adding a new tracked field:** Follow the lockstep checklist in
+> [ADR-009 §How to extend](docs/adr/ADR-009-compute-drift-positional-parameters.md).
+> `scripts/check-compute-drift-callers.sh` (wired as a pre-commit hook) will catch
+> any caller that was not updated.
+
 ## Scripts
 
 | Script | Purpose |

--- a/docs/adr/ADR-009-compute-drift-positional-parameters.md
+++ b/docs/adr/ADR-009-compute-drift-positional-parameters.md
@@ -117,26 +117,45 @@ same file). It also adds I/O for every drift computation.
 
 ---
 
-## How to Extend (Adding New Fields)
+## How to extend compute_drift (lockstep checklist)
 
-If a new field needs drift tracking:
+Adding a new drifted field requires updating the function **and** all three
+callers in lockstep. Missing any step produces a silent wrong-value bug because
+shell positional parameters bind by position, not name.
 
-1. **Update the function signature:** Add a new parameter to the end of the
-   `compute_drift` parameter list in `scripts/lib/reconcile.sh:335-349`.
-   Update the header comment to document the new parameter's position and meaning.
+1. **Add the parameter to `compute_drift`** (`scripts/lib/reconcile.sh`):
+   - Append `$14` (or the next slot) to the function body with a `local` binding.
+   - Update the header comment's parameter table (lines 335–349).
+   - Add a drift comparison line (e.g. `[[ "$actual_foo" != "$desired_foo" ]] && drifted_fields+=("foo")`).
 
-2. **Update all three callers** in lockstep: `scripts/apply.sh`, `scripts/plan.sh`,
-   and `scripts/status.sh`. Each caller must pass the new desired field value at
-   the correct position.
+2. **Bump the arity guard**: change the `13` in `[[ $# -ne 13 ]]` to the new
+   count. This is the authoritative number that `check-compute-drift-callers.sh`
+   reads.
 
-3. **Add drift comparison logic** in `scripts/lib/reconcile.sh:369-427`:
-   extract the actual field from the JSON blob, normalize it if needed
-   (e.g., sort tags), and compare it against the desired value.
+3. **Update all three callers** (`apply.sh`, `plan.sh`, `status.sh`) to pass
+   the new argument in the matching position. All three call sites must change
+   together — a partial update causes a positional shift for every argument that
+   follows.
 
-4. **Update `CLAUDE.md` drift-detection table** to document whether the field is
-   tracked or not, and why.
+4. **Add a row to the drift-detection table in CLAUDE.md** so operators know
+   the field is tracked.
 
-5. **Update this ADR** to reflect the new parameter count and implementation scope.
+5. **Write a new UPDATE test** in `tests/unit/test_drift_owner_role_tags.bats`
+   (or a new test file) asserting that drift is detected when the new field
+   changes and is absent from the result when the field is unchanged.
+
+6. **Run the caller consistency check** — must exit 0 before committing:
+   ```bash
+   ./scripts/check-compute-drift-callers.sh
+   ```
+   This script is also wired as a pre-commit hook and fires automatically
+   whenever `reconcile.sh` or any of the three callers is staged.
+
+7. **Run the full unit test suite** — all drift tests (including the arity
+   guard tests) must pass:
+   ```bash
+   pixi run test-unit
+   ```
 
 **Caution:** This is inherently fragile due to the positional nature. Consider
 proposing a higher-level refactor (e.g., a structured parameter format) if you
@@ -148,7 +167,9 @@ find yourself adding a fourth or fifth extension.
 
 | File | Role |
 |------|------|
-| `scripts/lib/reconcile.sh:335-427` | `compute_drift` definition and parameter comment block |
+| `scripts/lib/reconcile.sh:335-431` | `compute_drift` definition, parameter comment block, and arity guard |
 | `scripts/apply.sh` | Primary caller — passes all 13 parameters |
 | `scripts/plan.sh` | Caller — dry-run drift check |
 | `scripts/status.sh` | Caller — status table drift column |
+| `scripts/check-compute-drift-callers.sh` | Pre-commit / CI arity consistency check |
+| `tests/unit/test_compute_drift_arity.bats` | Arity guard unit tests |

--- a/scripts/check-compute-drift-callers.sh
+++ b/scripts/check-compute-drift-callers.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# scripts/check-compute-drift-callers.sh
+#
+# Verify that every caller of compute_drift passes the same number of arguments
+# that the function declares via its arity guard ([[ $# -ne N ]]).
+#
+# Exits 0 when all callers are in sync.
+# Exits 1 and prints a human-readable report when any caller is out of sync.
+#
+# Runs:
+#   - As a pre-commit hook (triggered when reconcile.sh or any caller is staged)
+#   - In CI via .pre-commit-config.yaml (pre-commit run --all-files)
+#   - Manually: ./scripts/check-compute-drift-callers.sh
+
+# shellcheck disable=SC2034
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+RECONCILE="${REPO_ROOT}/scripts/lib/reconcile.sh"
+CALLERS=(
+    "${REPO_ROOT}/scripts/apply.sh"
+    "${REPO_ROOT}/scripts/plan.sh"
+    "${REPO_ROOT}/scripts/status.sh"
+)
+
+# ---------------------------------------------------------------------------
+# Extract authoritative arity from reconcile.sh
+# ---------------------------------------------------------------------------
+
+# Matches:   if [[ $# -ne 13 ]]; then
+declared_arity=""
+declared_arity="$(grep -oP '\[\[ \$# -ne \K[0-9]+' "${RECONCILE}" | head -1)"
+
+if [[ -z "$declared_arity" ]]; then
+    echo "ERROR: could not find arity guard in ${RECONCILE}" >&2
+    echo "       Expected pattern: [[ \$# -ne N ]] inside compute_drift" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Count args at each call site
+# ---------------------------------------------------------------------------
+
+# Join continuation lines (line ending with \) and count quoted "$..." tokens
+# in the compute_drift call.  We join up to 5 continuation lines to handle
+# any reasonable formatting.
+count_call_args() {
+    local file="$1"
+    # Find the line number where compute_drift is called
+    local call_line
+    call_line="$(grep -n 'compute_drift ' "${file}" | head -1 | cut -d: -f1)"
+    if [[ -z "$call_line" ]]; then
+        echo "0"
+        return
+    fi
+
+    # Read up to 6 lines starting at the call site and join continuation lines
+    local joined=""
+    local i
+    for i in $(seq 0 5); do
+        local lineno=$(( call_line + i ))
+        local line
+        line="$(sed -n "${lineno}p" "${file}")"
+        # Strip trailing backslash-continuation
+        joined+=" ${line%\\}"
+        # Stop when the line does NOT end with a backslash (end of call)
+        if [[ "$line" != *\\ ]]; then
+            break
+        fi
+    done
+
+    # Count "$..." tokens (each represents one positional argument).
+    # grep -o finds each non-overlapping match; wc -l counts them.
+    # We subtract 1 for the function name itself if it appears as a "$..." arg
+    # (it doesn't — it's a bare word), so raw count equals arg count.
+    local count
+    count="$(echo "$joined" | grep -oP '"\$[^"]*"' | wc -l)"
+    echo "$count"
+}
+
+# ---------------------------------------------------------------------------
+# Validate each caller
+# ---------------------------------------------------------------------------
+
+errors=0
+
+for caller in "${CALLERS[@]}"; do
+    name="$(basename "${caller}")"
+    actual_count="$(count_call_args "${caller}")"
+    if [[ "$actual_count" -ne "$declared_arity" ]]; then
+        echo "FAIL: ${name}: compute_drift called with ${actual_count} args (expected ${declared_arity})" >&2
+        errors=$(( errors + 1 ))
+    else
+        echo "OK:   ${name}: compute_drift called with ${actual_count} args"
+    fi
+done
+
+if [[ "$errors" -gt 0 ]]; then
+    echo "" >&2
+    echo "Authoritative arity declared in scripts/lib/reconcile.sh: ${declared_arity}" >&2
+    echo "" >&2
+    echo "To fix: update all callers listed above to pass exactly ${declared_arity} arguments." >&2
+    echo "See ADR-009 §How to extend for the full lockstep checklist." >&2
+    exit 1
+fi
+
+echo ""
+echo "All callers pass exactly ${declared_arity} arguments to compute_drift."

--- a/scripts/lib/reconcile.sh
+++ b/scripts/lib/reconcile.sh
@@ -348,6 +348,10 @@ build_create_json() {
 #   $12 desired_role
 #   $13 desired_deploy_type
 compute_drift() {
+    if [[ $# -ne 13 ]]; then
+        echo "compute_drift requires exactly 13 arguments, got $#" >&2
+        return 1
+    fi
     local name="$1"
     local desired_state="$2"    # "active" | "hibernated"
     local actual_json="$3"      # Full agent JSON from API

--- a/tests/integration/test_reconcile_workflow.bats
+++ b/tests/integration/test_reconcile_workflow.bats
@@ -104,6 +104,9 @@ teardown() {
         --arg workingDirectory "${fields[workingDirectory]}" \
         --arg programArgs "${fields[programArgs]}" \
         --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
         '{
             status: "active",
             label: $lbl,
@@ -111,7 +114,11 @@ teardown() {
             workingDirectory: $workingDirectory,
             programArgs: $programArgs,
             taskDescription: $taskDescription,
-            tags: ["ci","testing"]
+            tags: ["testing","ci"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
         }')"
 
     result="$(compute_drift \
@@ -123,7 +130,11 @@ teardown() {
         "${fields[workingDirectory]}" \
         "${fields[programArgs]}" \
         "${fields[taskDescription]}" \
-        "${fields[tags]}")"
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
 
     [[ "$result" == "UNCHANGED" ]]
 }
@@ -145,6 +156,9 @@ teardown() {
         --arg workingDirectory "${fields[workingDirectory]}" \
         --arg programArgs "${fields[programArgs]}" \
         --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
         '{
             status: "offline",
             label: $lbl,
@@ -152,7 +166,11 @@ teardown() {
             workingDirectory: $workingDirectory,
             programArgs: $programArgs,
             taskDescription: $taskDescription,
-            tags: ["ci","testing"]
+            tags: ["testing","ci"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
         }')"
 
     result="$(compute_drift \
@@ -164,7 +182,11 @@ teardown() {
         "${fields[workingDirectory]}" \
         "${fields[programArgs]}" \
         "${fields[taskDescription]}" \
-        "${fields[tags]}")"
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
 
     [[ "$result" == "WAKE" ]]
 }
@@ -191,6 +213,9 @@ teardown() {
         --arg workingDirectory "${fields[workingDirectory]}" \
         --arg programArgs "${fields[programArgs]}" \
         --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
         '{
             status: "active",
             label: $lbl,
@@ -198,7 +223,11 @@ teardown() {
             workingDirectory: $workingDirectory,
             programArgs: $programArgs,
             taskDescription: $taskDescription,
-            tags: ["hibernated"]
+            tags: ["hibernated"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
         }')"
 
     result="$(compute_drift \
@@ -210,7 +239,11 @@ teardown() {
         "${fields[workingDirectory]}" \
         "${fields[programArgs]}" \
         "${fields[taskDescription]}" \
-        "${fields[tags]}")"
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
 
     [[ "$result" == "HIBERNATE" ]]
 }
@@ -237,6 +270,9 @@ teardown() {
         --arg workingDirectory "${fields[workingDirectory]}" \
         --arg programArgs "${fields[programArgs]}" \
         --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
         '{
             status: "active",
             label: "Stale Label",
@@ -244,7 +280,11 @@ teardown() {
             workingDirectory: $workingDirectory,
             programArgs: $programArgs,
             taskDescription: $taskDescription,
-            tags: ["ci","testing"]
+            tags: ["testing","ci"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
         }')"
 
     result="$(compute_drift \
@@ -256,7 +296,11 @@ teardown() {
         "${fields[workingDirectory]}" \
         "${fields[programArgs]}" \
         "${fields[taskDescription]}" \
-        "${fields[tags]}")"
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
 
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"label"* ]]

--- a/tests/unit/test_apply_plan_entrypoints.bats
+++ b/tests/unit/test_apply_plan_entrypoints.bats
@@ -388,7 +388,7 @@ plan_agent() {
     if [[ -z "\$actual_json" ]]; then return 1; fi
     local action
     action="\$(compute_drift "\$name" "\$desired_state" "\$actual_json" \
-        "\$label" "\$program" "\$workdir" "\$args" "\$desc" "\$tags")"
+        "\$label" "\$program" "\$workdir" "\$args" "\$desc" "\$tags" "" "" "" "local")"
     [[ "\$action" == "UNCHANGED" ]]
 }
 

--- a/tests/unit/test_apply_update_patch.bats
+++ b/tests/unit/test_apply_update_patch.bats
@@ -158,7 +158,7 @@ apply_agent() {
 
     local action
     action="$(compute_drift "$name" "$desired_state" "$actual_json" \
-        "$label" "$program" "$workdir" "$args" "$desc" "$tags")"
+        "$label" "$program" "$workdir" "$args" "$desc" "$tags" "" "" "" "local")"
 
     case "$action" in
         UNCHANGED)

--- a/tests/unit/test_compute_drift_arity.bats
+++ b/tests/unit/test_compute_drift_arity.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# tests/unit/test_compute_drift_arity.bats — arity guard tests for compute_drift
+#
+# Ensures compute_drift rejects calls with wrong argument counts, catching
+# callers that were not updated in lockstep when a new parameter was added.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# Minimal valid actual_json for 13-arg success tests
+_minimal_actual() {
+    jq -n '{status: "active", label: "A", program: "claude-code",
+            workingDirectory: "/tmp", programArgs: "", taskDescription: "",
+            tags: [], model: "", owner: "", role: "member",
+            deployment: {type: "local"}}'
+}
+
+# ---------------------------------------------------------------------------
+# Wrong-arity calls must fail with a descriptive error message
+# ---------------------------------------------------------------------------
+
+@test "compute_drift arity: 0 args → non-zero exit and error message" {
+    run compute_drift
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+@test "compute_drift arity: 12 args → non-zero exit and error message" {
+    run compute_drift a b c d e f g h i j k l
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+@test "compute_drift arity: 12 args → error message mentions got 12" {
+    run compute_drift a b c d e f g h i j k l
+    [[ "$output" == *"got 12"* ]]
+}
+
+@test "compute_drift arity: 14 args → non-zero exit and error message" {
+    run compute_drift a b c d e f g h i j k l m n
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+@test "compute_drift arity: 14 args → error message mentions got 14" {
+    run compute_drift a b c d e f g h i j k l m n
+    [[ "$output" == *"got 14"* ]]
+}
+
+@test "compute_drift arity: 1 arg → non-zero exit and error message" {
+    run compute_drift only-one-arg
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Correct arity (13 args) succeeds
+# ---------------------------------------------------------------------------
+
+@test "compute_drift arity: exactly 13 args → exits zero" {
+    actual="$(_minimal_actual)"
+    run compute_drift "agent" "active" "$actual" \
+        "A" "claude-code" "/tmp" "" "" "" "" "" "member" "local"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "compute_drift arity: exactly 13 args → produces valid output" {
+    actual="$(_minimal_actual)"
+    run compute_drift "agent" "active" "$actual" \
+        "A" "claude-code" "/tmp" "" "" "" "" "" "member" "local"
+    [[ "$output" == "UNCHANGED" || "$output" == WAKE || "$output" == HIBERNATE || "$output" == UPDATE:* ]]
+}

--- a/tests/unit/test_drift.bats
+++ b/tests/unit/test_drift.bats
@@ -37,32 +37,32 @@ _make_actual() {
 
 @test "compute_drift UNCHANGED: all fields match, agent active" {
     actual="$(_make_actual "active" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" '["ci","testing"]')"
-    result="$(compute_drift "test-agent" "active" "$actual" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" "ci,testing")"
+    result="$(compute_drift "test-agent" "active" "$actual" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" "ci,testing" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift UNCHANGED: hibernated agent matches hibernated desired state" {
     actual="$(_make_actual "offline" "Sleeping Agent" "aider" "/tmp/proj" "" "" '[]')"
-    result="$(compute_drift "sleep-agent" "hibernated" "$actual" "Sleeping Agent" "aider" "/tmp/proj" "" "" "")"
+    result="$(compute_drift "sleep-agent" "hibernated" "$actual" "Sleeping Agent" "aider" "/tmp/proj" "" "" "" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift UNCHANGED: tags in different order sorted to same result" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["beta","alpha"]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift UNCHANGED: tilde path normalized with full path" {
     actual="$(_make_actual "active" "Agent" "claude-code" "${HOME}/Projects" "" "" '[]')"
     # shellcheck disable=SC2088
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" '~/Projects' "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" '~/Projects' "" "" "" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift UNCHANGED: both tags empty" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
@@ -72,13 +72,13 @@ _make_actual() {
 
 @test "compute_drift WAKE: desired=active, actual=offline" {
     actual="$(_make_actual "offline" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "WAKE" ]]
 }
 
 @test "compute_drift WAKE: returns WAKE even if other fields differ" {
     actual="$(_make_actual "offline" "Old Label" "old-prog" "/old/path" "--old" "Old desc" '["old-tag"]')"
-    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/new/path" "--new" "New desc" "new-tag")"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/new/path" "--new" "New desc" "new-tag" "" "" "" "local")"
     [[ "$result" == "WAKE" ]]
 }
 
@@ -88,19 +88,19 @@ _make_actual() {
 
 @test "compute_drift HIBERNATE: desired=hibernated, actual=active" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "HIBERNATE" ]]
 }
 
 @test "compute_drift HIBERNATE: desired=hibernated, actual=online" {
     actual="$(_make_actual "online" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "HIBERNATE" ]]
 }
 
 @test "compute_drift HIBERNATE: returns HIBERNATE even if other fields differ" {
     actual="$(_make_actual "active" "Old Label" "old-prog" "/old/path" "--old" "Old desc" '["old-tag"]')"
-    result="$(compute_drift "agent" "hibernated" "$actual" "New Label" "new-prog" "/new/path" "--new" "New desc" "new-tag")"
+    result="$(compute_drift "agent" "hibernated" "$actual" "New Label" "new-prog" "/new/path" "--new" "New desc" "new-tag" "" "" "" "local")"
     [[ "$result" == "HIBERNATE" ]]
 }
 
@@ -110,49 +110,49 @@ _make_actual() {
 
 @test "compute_drift UPDATE: label differs" {
     actual="$(_make_actual "active" "Old Label" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "New Label" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"label"* ]]
 }
 
 @test "compute_drift UPDATE: program differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "aider" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "aider" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"program"* ]]
 }
 
 @test "compute_drift UPDATE: workingDirectory differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/old/path" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/new/path" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/new/path" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"workingDirectory"* ]]
 }
 
 @test "compute_drift UPDATE: programArgs differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "--old" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "--new" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "--new" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"programArgs"* ]]
 }
 
 @test "compute_drift UPDATE: taskDescription differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "Old description" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "New description" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "New description" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"taskDescription"* ]]
 }
 
 @test "compute_drift UPDATE: tags differ" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["tag1"]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "tag1,tag2")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "tag1,tag2" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"tags"* ]]
 }
 
 @test "compute_drift UPDATE: multiple fields differ, lists all in comma-separated format" {
     actual="$(_make_actual "active" "Old Label" "old-prog" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"label"* ]]
     [[ "$result" == *"program"* ]]

--- a/tests/unit/test_reconcile.bats
+++ b/tests/unit/test_reconcile.bats
@@ -169,79 +169,79 @@ _make_actual() {
 
 @test "compute_drift: UNCHANGED when all fields match and agent is active" {
     actual="$(_make_actual "active" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" '["ci","testing"]')"
-    result="$(compute_drift "test-agent" "active" "$actual" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" "ci,testing")"
+    result="$(compute_drift "test-agent" "active" "$actual" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" "ci,testing" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift: UNCHANGED when hibernated agent matches hibernated desired state" {
     actual="$(_make_actual "offline" "Sleeping" "aider" "/tmp/proj" "" "" '[]')"
-    result="$(compute_drift "sleep-agent" "hibernated" "$actual" "Sleeping" "aider" "/tmp/proj" "" "" "")"
+    result="$(compute_drift "sleep-agent" "hibernated" "$actual" "Sleeping" "aider" "/tmp/proj" "" "" "" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift: WAKE when desired=active and actual status=offline" {
     actual="$(_make_actual "offline" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "WAKE" ]]
 }
 
 @test "compute_drift: HIBERNATE when desired=hibernated and actual status=active" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "HIBERNATE" ]]
 }
 
 @test "compute_drift: HIBERNATE when desired=hibernated and actual status=online" {
     actual="$(_make_actual "online" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "HIBERNATE" ]]
 }
 
 @test "compute_drift: UPDATE when label differs" {
     actual="$(_make_actual "active" "Old Label" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "New Label" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"label"* ]]
 }
 
 @test "compute_drift: UPDATE when program differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "aider" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "aider" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"program"* ]]
 }
 
 @test "compute_drift: UPDATE when workingDirectory differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/old/path" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/new/path" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/new/path" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"workingDirectory"* ]]
 }
 
 @test "compute_drift: UPDATE when programArgs differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "--old" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "--new" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "--new" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"programArgs"* ]]
 }
 
 @test "compute_drift: UPDATE when taskDescription differs" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "Old description" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "New description" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "New description" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"taskDescription"* ]]
 }
 
 @test "compute_drift: UPDATE when tags differ" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["tag1"]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "tag1,tag2")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "tag1,tag2" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"tags"* ]]
 }
 
 @test "compute_drift: UPDATE lists all drifted fields" {
     actual="$(_make_actual "active" "Old Label" "old-prog" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == UPDATE:* ]]
     [[ "$result" == *"label"* ]]
     [[ "$result" == *"program"* ]]
@@ -249,19 +249,19 @@ _make_actual() {
 
 @test "compute_drift: UNCHANGED when tags are in different order (sorted comparison)" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["beta","alpha"]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift: UNCHANGED when workingDirectory uses tilde and actual uses full path" {
     actual="$(_make_actual "active" "Agent" "claude-code" "${HOME}/Projects" "" "" '[]')"
     # shellcheck disable=SC2088
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" '~/Projects' "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" '~/Projects' "" "" "" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }
 
 @test "compute_drift: UNCHANGED when both tags are empty" {
     actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
-    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
     [[ "$result" == "UNCHANGED" ]]
 }


### PR DESCRIPTION
## Summary

- **Arity guard in `compute_drift`**: The function now immediately returns non-zero with a descriptive error message when called with anything other than exactly 13 arguments, turning silent wrong-value bugs into loud failures at the call site.
- **BATS arity tests** (`tests/unit/test_compute_drift_arity.bats`): 8 tests covering 0-arg, 1-arg, 12-arg, 13-arg, and 14-arg cases, verifying both exit codes and error message text.
- **Caller consistency check** (`scripts/check-compute-drift-callers.sh`): Reads the authoritative arity from the guard in `reconcile.sh` and verifies all three callers (`apply.sh`, `plan.sh`, `status.sh`) pass exactly that many arguments. Registered as a pre-commit hook triggered only when the function or any caller is staged.
- **ADR-009 extension checklist**: New §How to extend section with a numbered 7-step lockstep process for adding a new drifted field.
- **CLAUDE.md cross-reference**: Note added below the drift-detection table pointing to the ADR checklist and the pre-commit guard.

## Test plan

- [x] All 404 unit tests pass (`pixi run test-unit`) — 8 new arity tests all green
- [x] `./scripts/check-compute-drift-callers.sh` exits 0 against current callers
- [x] `pixi run --environment lint lint-shell` exits 0 (shellcheck clean)
- [x] Negative path verified: guard fires on 12 and 14 arg calls, not on 13

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)