### PR TITLE
fix(hello-world): pin nlohmann_json version across CMakeLists.txt and Dockerfile

### DIFF
--- a/hello-world/CMakeLists.txt
+++ b/hello-world/CMakeLists.txt
@@ -23,10 +23,11 @@ set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 FetchContent_MakeAvailable(nats_c)
 set_directory_properties(PROPERTIES COMPILE_OPTIONS "${_saved_compile_options}")
 
+set(NLOHMANN_JSON_VERSION "v3.11.3" CACHE STRING "nlohmann/json version tag")
 FetchContent_Declare(
   nlohmann_json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.11.3
+  GIT_TAG ${NLOHMANN_JSON_VERSION}
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(nlohmann_json)

--- a/hello-world/Dockerfile
+++ b/hello-world/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY CMakeLists.txt main.cpp ./
+ARG NLOHMANN_JSON_VERSION=3.11.3
 RUN cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    -DNLOHMANN_JSON_VERSION="v${NLOHMANN_JSON_VERSION}" \
     && cmake --build build
 
 FROM ubuntu:24.04

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^hello-world/CMakeLists\\.txt$"],
+      "matchStrings": [
+        "set\\(NLOHMANN_JSON_VERSION\\s+\"v(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "nlohmann/json",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^hello-world/Dockerfile$"],
+      "matchStrings": [
+        "ARG NLOHMANN_JSON_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "nlohmann/json",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Extract nlohmann/json version into `set(NLOHMANN_JSON_VERSION "v3.11.3" CACHE STRING ...)` in `hello-world/CMakeLists.txt` so it's overridable via `-DNLOHMANN_JSON_VERSION` at cmake configure time
- Add `ARG NLOHMANN_JSON_VERSION=3.11.3` to the Dockerfile builder stage and thread it into cmake with `-DNLOHMANN_JSON_VERSION="v${NLOHMANN_JSON_VERSION}"`, making the version explicit and visible via `docker build --build-arg`
- Add `renovate.json` with custom regex managers for both files targeting the `nlohmann/json` GitHub tags datasource, preventing future drift automatically

## Test plan

- [ ] `cmake -S hello-world -B build/hello-world -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build/hello-world` — confirms FetchContent fetches `v3.11.3`
- [ ] `docker build hello-world/` — confirms the Docker build path passes the version through to cmake and builds successfully
- [ ] `docker build --build-arg NLOHMANN_JSON_VERSION=3.11.3 hello-world/` — confirms the ARG override mechanism works
- [ ] Renovate regex patterns match `set(NLOHMANN_JSON_VERSION "v3.11.3" ...)` in CMakeLists.txt and `ARG NLOHMANN_JSON_VERSION=3.11.3` in the Dockerfile

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)