### PR TITLE
feat(hello-world): add --help flag and CI smoke-test

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -237,3 +237,28 @@ jobs:
       # Verify pixi.lock matches pixi.toml — exits non-zero if lock is stale
       - name: Install dependencies (locked)
         run: pixi install --locked
+
+  build-hello-world:
+    name: build-hello-world
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            cmake ninja-build g++ git ca-certificates libssl-dev
+
+      - name: Configure (CMake)
+        run: cmake -S hello-world -B build/hello-world -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build hello_myrmidon
+        run: cmake --build build/hello-world
+
+      - name: Smoke-test --help
+        run: |
+          output=$(./build/hello-world/hello_myrmidon --help)
+          echo "$output"
+          echo "$output" | grep -qi "usage:" || { echo "ERROR: --help output missing 'usage:'"; exit 1; }

--- a/hello-world/main.cpp
+++ b/hello-world/main.cpp
@@ -53,7 +53,16 @@ void ensure_stream(jsCtx* js, const char* name, const char** subjects, int subje
     }
 }
 
-int main() {
+int main(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            std::cout << "usage: hello_myrmidon [--help]\n"
+                      << "  Connects to NATS (NATS_URL env) and processes hi.myrmidon.hello.> tasks.\n";
+            return 0;
+        }
+    }
+
     // Disable stdout/stderr buffering for container logging
     std::cout.setf(std::ios::unitbuf);
     std::cerr.setf(std::ios::unitbuf);


### PR DESCRIPTION
## Summary

- Added `argc`/`argv` to `main()` in `hello-world/main.cpp` with a `--help`/`-h` early-exit path that prints a usage line and returns 0 **before** any NATS connection attempt, avoiding the 30-retry hang in CI
- Added a `build-hello-world` job to `.github/workflows/_required.yml` that installs native build deps (cmake, ninja, g++, libssl-dev), compiles via CMake/Ninja, then runs `hello_myrmidon --help` and asserts exit 0 and `"usage:"` in stdout

Closes #448

## Test plan

- [ ] `build-hello-world` CI job appears in Required Checks and passes on this PR
- [ ] `cmake -S hello-world -B build/hello-world -G Ninja && cmake --build build/hello-world && ./build/hello-world/hello_myrmidon --help` exits 0 and prints `usage:`
- [ ] `timeout 2 ./build/hello-world/hello_myrmidon --help` completes in <1s (no NATS hang)
- [ ] All other Required Checks jobs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)