### PR TITLE
docs(hello-world): add README with build prerequisites

### DIFF
--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -1,0 +1,82 @@
+# hello-world
+
+Pull-based myrmidon E2E test worker. Connects to NATS JetStream, pulls tasks
+from `hi.myrmidon.hello.>`, processes them, and publishes completion events back
+to the HomericIntelligence mesh.
+
+## Prerequisites
+
+| Tool | Minimum version | Notes |
+|------|----------------|-------|
+| cmake | ≥ 3.20 | Build system generator |
+| ninja | any | Build backend (`-G Ninja`) |
+| g++ or clang++ | g++ ≥ 10 / clang++ ≥ 12 | C++20 support required |
+| libssl-dev / openssl | any | Required by nats.c (fetched via FetchContent) |
+| git | any | FetchContent clones nats.c and nlohmann/json at configure time |
+
+### Install by platform
+
+**Ubuntu / Debian**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y cmake ninja-build g++ libssl-dev git
+```
+
+**macOS (Homebrew)**
+
+```bash
+brew install cmake ninja openssl git
+```
+
+**Windows (winget)**
+
+```powershell
+winget install Kitware.CMake Ninja-build.Ninja Git.Git
+# OpenSSL: download the Win32/Win64 installer from slproweb.com or use vcpkg
+```
+
+> Windows support is less tested. A Linux build environment (WSL2 or Docker) is
+> the recommended path on Windows.
+
+## Build
+
+**Primary (requires `just`)** — run from the repository root:
+
+```bash
+just build-hello-world
+```
+
+**Fallback (no `just` needed)** — run from the repository root:
+
+```bash
+cmake -S hello-world -B build/hello-world -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build/hello-world
+```
+
+The configure step fetches `nats.c v3.12.0` and `nlohmann/json v3.11.3` from
+GitHub. An internet connection is required on first build; subsequent builds use
+the CMake cache.
+
+## Run
+
+```bash
+# Default: connects to nats://localhost:4222
+./build/hello-world/hello_myrmidon
+
+# Custom NATS URL
+NATS_URL=nats://my-server:4222 ./build/hello-world/hello_myrmidon
+```
+
+You need a running NATS server with JetStream enabled. The binary creates the
+required streams (`homeric-myrmidon`, `homeric-tasks`, `homeric-logs`) on
+startup if they do not exist.
+
+## Docker
+
+A `Dockerfile` is included for containerised builds:
+
+```bash
+docker build -t hello-myrmidon hello-world/
+docker run --rm -e NATS_URL=nats://host.docker.internal:4222 hello-myrmidon
+```


### PR DESCRIPTION
## Summary

- Creates `hello-world/README.md` documenting required prerequisites (cmake ≥ 3.20, ninja, g++/clang++ with C++20, libssl-dev/openssl, git)
- Provides install commands for Ubuntu/Debian, macOS (Homebrew), and Windows (winget)
- Documents both `just build-hello-world` (primary) and the explicit `cmake` invocation (fallback)
- Covers `NATS_URL` env var and Docker build path
- Prerequisites sourced from `Dockerfile` (ground truth) and `CMakeLists.txt` (FetchContent dependencies)

Closes #449

## Test plan

- [x] `pixi run pre-commit run trailing-whitespace --files hello-world/README.md` — Passed
- [x] `pixi run pre-commit run end-of-file-fixer --files hello-world/README.md` — Passed
- [x] cmake flags in README match `justfile` lines 158–159 (`-G Ninja -DCMAKE_BUILD_TYPE=Release`)
- [x] `libssl-dev` / `openssl` present (required by nats.c, confirmed in Dockerfile)
- [x] No `CMakePresets` reference (no `CMakePresets.json` exists in hello-world/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)