### PR TITLE
ci(changelog): add pygrep hook to enforce compare/vX.Y.Z...HEAD format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - C++ hello-world example wired into build system (#445)
 - CI: markdownlint, pixi, justfile, and symlink lint jobs (#364)
 - CLAUDE.md: `--dangerously-skip-permissions` policy — prohibited by default, suppression annotation with justification required (#147)
+- `pygrep` pre-commit hook `changelog-unreleased-url` catches broken `[Unreleased]` compare links in `CHANGELOG.md`, enforcing `compare/vX.Y.Z...HEAD` format and preventing the regression where both sides resolve to HEAD (#453)
 - CI ↔ pre-commit parity architecture: `.pre-commit-config.yaml` is now the single source of truth for all linting; CI runs `pre-commit run --all-files` to eliminate drift
 - actionlint pre-commit hook added (v1.7.7) so GitHub Actions workflow lint failures are caught locally before push
 - gitleaks pre-commit hook added (v8.24.3, unlicensed binary mode) so secret scanning matches CI


### PR DESCRIPTION
## Summary

- Fixes the broken `[Unreleased]` compare URL in `CHANGELOG.md` (`HEAD...HEAD` → `v0.3.0...HEAD`)
- Adds a `pygrep` pre-commit hook `changelog-unreleased-url` that detects `HEAD...HEAD` in `CHANGELOG.md` and fails, preventing this regression from recurring
- No changes to `validate.yml` — the repo's parity architecture means adding the hook to `.pre-commit-config.yaml` automatically covers CI via `pre-commit run --all-files`

## Test plan

- [x] Verified `grep 'HEAD\.\.\.HEAD' CHANGELOG.md` returns no output after the fix
- [x] Ran `pre-commit run changelog-unreleased-url --all-files` — passes on the clean CHANGELOG
- [x] Canary test: temporarily appended a bad `HEAD...HEAD` URL and confirmed the hook exits non-zero with the correct file+line annotation
- [x] Ran `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `yamllint`, and `changelog-unreleased-url` hooks — all pass

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)