### PR TITLE
ci(apply): switch to self-hosted runner to reach local Agamemnon endpoint

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -16,12 +16,16 @@ permissions:
 jobs:
   apply:
     name: Reconcile Desired State
-    runs-on: ubuntu-latest
+    # Self-hosted runner required: Agamemnon is on the local network and is not
+    # reachable from GitHub-hosted runners. Register a runner on the same host
+    # (or LAN segment) as Agamemnon. See docs/self-hosted-runner.md for setup.
+    runs-on: [self-hosted, linux]
     # Gate on vars.AGAMEMNON_URL (repository variable, not secret) — the URL
     # is not sensitive and secrets context is unavailable in job-level if:.
     # Set AGAMEMNON_URL as a repository *variable* (Settings > Variables) and
     # AGAMEMNON_API_KEY as a repository *secret* to enable reconciliation.
     if: ${{ vars.AGAMEMNON_URL != '' }}
+    timeout-minutes: 15
     env:
       AGAMEMNON_URL: ${{ vars.AGAMEMNON_URL }}
       AGAMEMNON_API_KEY: ${{ secrets.AGAMEMNON_API_KEY }}
@@ -33,6 +37,18 @@ jobs:
           fi
 
       - uses: actions/checkout@v4
+
+      - name: Configure TLS
+        if: ${{ secrets.AGAMEMNON_CA_CERT_B64 != '' }}
+        run: |
+          echo "${{ secrets.AGAMEMNON_CA_CERT_B64 }}" | base64 -d > /tmp/agamemnon-ca.pem
+          echo "AGAMEMNON_CA_CERT=/tmp/agamemnon-ca.pem" >> "$GITHUB_ENV"
+          if [[ -n "${{ secrets.AGAMEMNON_CLIENT_CERT_B64 }}" ]]; then
+            echo "${{ secrets.AGAMEMNON_CLIENT_CERT_B64 }}" | base64 -d > /tmp/agamemnon-client.pem
+            echo "${{ secrets.AGAMEMNON_CLIENT_KEY_B64 }}" | base64 -d > /tmp/agamemnon-client.key
+            echo "AGAMEMNON_CLIENT_CERT=/tmp/agamemnon-client.pem" >> "$GITHUB_ENV"
+            echo "AGAMEMNON_CLIENT_KEY=/tmp/agamemnon-client.key" >> "$GITHUB_ENV"
+          fi
 
       - name: Set up pixi
         # jq and yq (go-yq) versions are pinned in pixi.lock:

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -1,0 +1,37 @@
+name: Runner and Agamemnon Health Check
+
+on:
+  schedule:
+    # Run every 6 hours so failures surface well before a real apply is needed.
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    name: Health Check
+    runs-on: [self-hosted, linux]
+    # Skip if AGAMEMNON_URL is not configured — same gate as apply.yml.
+    if: ${{ vars.AGAMEMNON_URL != '' }}
+    timeout-minutes: 5
+    env:
+      AGAMEMNON_URL: ${{ vars.AGAMEMNON_URL }}
+      AGAMEMNON_API_KEY: ${{ secrets.AGAMEMNON_API_KEY }}
+    steps:
+      - name: Mask secrets
+        run: |
+          if [[ -n "$AGAMEMNON_API_KEY" ]]; then
+            echo "::add-mask::$AGAMEMNON_API_KEY"
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Doctor — verify runner can reach Agamemnon
+        run: |
+          chmod +x scripts/doctor.sh
+          pixi run bash scripts/doctor.sh --skip-hooks

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,0 +1,141 @@
+# Self-Hosted Runner Setup
+
+The `Apply Agent Definitions` workflow requires a self-hosted GitHub Actions runner
+on the same network as the ProjectAgamemnon instance. GitHub-hosted runners cannot
+reach Agamemnon because it listens only on the local network.
+
+## Prerequisites
+
+The runner host must have:
+
+- `bash` ≥ 4.4
+- `curl`
+- `jq`
+- `yq` (go-yq v4, mikefarah/yq) — or use `pixi run` which installs pinned versions
+- `git`
+- `pixi` — install from [prefix.dev](https://prefix.dev/docs/pixi/installation)
+
+If `pixi` is present, the workflow's `setup-pixi` step installs `jq` and `yq` at
+pinned versions from the lock file, so only `bash`, `curl`, `git`, and `pixi` are
+strictly required on the host.
+
+## Register the runner
+
+1. Go to **GitHub → Settings → Actions → Runners → New self-hosted runner**.
+2. Select **Linux / x64** (or arm64 if applicable).
+3. Follow the download and configuration commands shown on that page.
+
+   Suggested labels during `./config.sh`:
+
+   ```
+   self-hosted, linux
+   ```
+
+   These match the `runs-on: [self-hosted, linux]` selector in `apply.yml`.
+
+4. Install as a systemd service so it survives reboots:
+
+   ```bash
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   sudo ./svc.sh status
+   ```
+
+5. Confirm the runner appears as **Idle** in GitHub → Settings → Actions → Runners
+   before pushing to `main`.
+
+## Runner user
+
+Run the runner as a dedicated non-root OS user:
+
+```bash
+sudo useradd -m -s /bin/bash actions-runner
+sudo su - actions-runner
+# then run ./config.sh and ./svc.sh install from within this session
+```
+
+Grant the user read access to any directories needed by the workflow (workspace
+checkout, pixi cache). No broader system privileges are required.
+
+## GitHub repository settings
+
+### Repository variable (not a secret — URL is not sensitive)
+
+| Setting | Value |
+|---------|-------|
+| Name | `AGAMEMNON_URL` |
+| Value | `http://<agamemnon-host>:8080` |
+
+Set via: **Settings → Secrets and variables → Actions → Variables → New repository variable**
+
+### Repository secrets
+
+| Secret | Description |
+|--------|-------------|
+| `AGAMEMNON_API_KEY` | Bearer token / API key for Agamemnon authentication |
+
+Set via: **Settings → Secrets and variables → Actions → Secrets → New repository secret**
+
+Or via CLI:
+
+```bash
+gh secret set AGAMEMNON_API_KEY
+```
+
+### Optional: TLS secrets (if Agamemnon uses HTTPS with a private CA)
+
+| Secret | How to generate |
+|--------|----------------|
+| `AGAMEMNON_CA_CERT_B64` | `base64 -w0 ca.pem` |
+| `AGAMEMNON_CLIENT_CERT_B64` | `base64 -w0 client.pem` (mTLS only) |
+| `AGAMEMNON_CLIENT_KEY_B64` | `base64 -w0 client.key` (mTLS only) |
+
+The `Configure TLS` step in `apply.yml` decodes these to temp files and sets
+`AGAMEMNON_CA_CERT`, `AGAMEMNON_CLIENT_CERT`, and `AGAMEMNON_CLIENT_KEY` for the
+remaining steps. The step is skipped entirely if `AGAMEMNON_CA_CERT_B64` is unset.
+
+## Verification
+
+After registering the runner and setting the repository variable/secrets:
+
+1. Push a no-op change to any file under `agents/` (e.g., add and remove a trailing
+   newline) to trigger the workflow.
+2. In **GitHub → Actions → Apply Agent Definitions**, confirm:
+   - The job is picked up by the self-hosted runner (shown in the run header).
+   - `Plan` shows expected diff or "no changes".
+   - `Apply` exits 0.
+   - `Convergence` reports "no drift detected".
+   - `Status` shows all agents at desired state.
+   - The snapshots artifact is uploaded.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Job stays "Queued" indefinitely | Runner offline or no runner registered | Start the runner service; workflow times out after 15 minutes |
+| `AGAMEMNON_URL` gate skips the job | Repository variable not set | Add `AGAMEMNON_URL` as a repository variable (not a secret) |
+| `curl: Could not resolve host` | Runner cannot reach Agamemnon | Check runner host is on the same network as Agamemnon |
+| TLS handshake errors | CA cert not trusted | Set `AGAMEMNON_CA_CERT_B64` secret or set `AGAMEMNON_TLS_VERIFY=false` (dev only) |
+
+## Secret rotation
+
+To rotate `AGAMEMNON_API_KEY`:
+
+```bash
+gh secret set AGAMEMNON_API_KEY
+```
+
+No code changes required — the workflow reads the secret at runtime.
+
+## Concurrency
+
+The workflow inherits the apply lock (`AIM_LOCK_FILE`, default `.myrmidons.lock`)
+relative to the checkout directory. Each workflow run gets a fresh checkout, so
+lock files do not persist between runs. If you need to prevent concurrent applies
+from multiple pushes, add a `concurrency:` block to `apply.yml`:
+
+```yaml
+concurrency:
+  group: apply-${{ github.ref }}
+  cancel-in-progress: false  # queue rather than cancel, to avoid skipping applies
+```


### PR DESCRIPTION
## Summary

- Switches `apply.yml` from `runs-on: ubuntu-latest` to `runs-on: [self-hosted, linux]` — the only viable approach for a LAN-only Agamemnon instance
- Adds `timeout-minutes: 15` so the job fails fast when the runner is offline rather than hanging indefinitely
- Adds an optional `Configure TLS` step that decodes `AGAMEMNON_CA_CERT_B64` / `AGAMEMNON_CLIENT_CERT_B64` / `AGAMEMNON_CLIENT_KEY_B64` secrets into temp files for HTTPS/mTLS connections
- Adds `.github/workflows/runner-health.yml` — a periodic (every 6 hours) health check that runs `doctor.sh` against the real Agamemnon endpoint, giving early warning before a real apply fails
- Adds `docs/self-hosted-runner.md` — full setup guide covering runner installation, systemd service, GitHub secrets/variables configuration, TLS secrets, verification steps, and failure modes

## Required one-time setup (not automated)

1. Register a self-hosted runner on the Agamemnon host (see `docs/self-hosted-runner.md`)
2. Set repository **variable** `AGAMEMNON_URL` (Settings → Variables → Actions)
3. Set repository **secret** `AGAMEMNON_API_KEY` (Settings → Secrets → Actions)
4. Optionally set TLS secrets if Agamemnon uses HTTPS with a private CA

## Test plan

- [ ] Register the self-hosted runner on the Agamemnon host and confirm it shows "Idle" in GitHub → Settings → Actions → Runners
- [ ] Set `AGAMEMNON_URL` as a repository variable and `AGAMEMNON_API_KEY` as a secret
- [ ] Push a no-op change to `agents/` to trigger the workflow
- [ ] Confirm the job is picked up by the self-hosted runner (not a GitHub-hosted runner)
- [ ] Confirm `Plan`, `Apply`, `Convergence`, and `Status` steps all pass
- [ ] Confirm snapshots artifact is uploaded
- [ ] Verify runner-health.yml can be dispatched manually via `workflow_dispatch`

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)