### PR TITLE
docs: bundle README & ADR-index improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,14 @@ hooks/
 | `AGAMEMNON_URL` | `http://localhost:8080` | ProjectAgamemnon base URL |
 | `AGAMEMNON_API_KEY` | _(unset)_ | Bearer token / API key for authenticating requests |
 | `AGAMEMNON_TIMEOUT` | `10` | HTTP request timeout in seconds for all API calls |
+| `AGAMEMNON_CA_CERT` | _(unset)_ | Path to a PEM CA certificate file for TLS server verification |
+| `AGAMEMNON_CLIENT_CERT` | _(unset)_ | Path to a PEM client certificate file for mTLS authentication |
+| `AGAMEMNON_CLIENT_KEY` | _(unset)_ | Path to a PEM client key file for mTLS authentication |
+| `AGAMEMNON_TLS_VERIFY` | `true` | Set to `false` to skip TLS verification (not recommended for production) |
 | `LOG_LEVEL` | `INFO` | Log verbosity: DEBUG, INFO, WARN, ERROR |
 | `LOG_FORMAT` | `text` | Log output format: text or json |
 | `AIM_LOCK_FILE` | `.myrmidons.lock` | Path to the apply lock file (use workspace-scoped path in parallel CI) |
+| `HIBERNATE_SETTLE_SECONDS` | `2` | Seconds to wait after hibernating an agent before continuing (set to `0` in CI to skip the settle delay) |
 | `MYRMIDONS_DEFAULT_OWNER` | `$(whoami)` | Fallback owner written to exported agent YAMLs when the Agamemnon API returns no owner |
 | `MYRMIDONS_YES` | _(unset)_ | Set to `true` to skip all interactive confirmation prompts (equivalent to `--yes`); useful in CI pipelines where stdin is not a TTY |
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,9 +4,9 @@ This directory contains Architecture Decision Records (ADRs) for Myrmidons.
 Each ADR documents a significant design decision, its context, rationale, and
 alternatives that were considered and rejected.
 
-| ADR | Title | Status | Date |
-|-----|-------|--------|------|
-| [ADR-007](ADR-007-nomad-integration-strategy.md) | Nomad Integration Strategy for Multi-Host Deployments | Accepted | 2026-04-10 |
-| [ADR-008](ADR-008-fleet-ref-filename-stem-resolution.md) | Fleet ref Resolution by Filename Stem | Accepted | 2026-04-28 |
-| [ADR-009](ADR-009-compute-drift-positional-parameters.md) | compute_drift Positional Parameter Interface | Accepted | 2026-04-28 |
-| [ADR-010](ADR-010-schema-versioning-strategy.md) | Schema Versioning Strategy (myrmidons/v1) | Accepted | 2026-04-28 |
+| ADR | Title | Status | Date | Accepted |
+|-----|-------|--------|------|----------|
+| [ADR-007](ADR-007-nomad-integration-strategy.md) | Nomad Integration Strategy for Multi-Host Deployments | Accepted | 2026-04-10 | 2026-05-03 |
+| [ADR-008](ADR-008-fleet-ref-filename-stem-resolution.md) | Fleet ref Resolution by Filename Stem | Accepted | 2026-04-28 | 2026-05-03 |
+| [ADR-009](ADR-009-compute-drift-positional-parameters.md) | compute_drift Positional Parameter Interface | Accepted | 2026-04-28 | 2026-05-03 |
+| [ADR-010](ADR-010-schema-versioning-strategy.md) | Schema Versioning Strategy (myrmidons/v1) | Accepted | 2026-04-28 | 2026-05-03 |

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -29,12 +29,19 @@ sudo apt-get install -y cmake ninja-build g++ libssl-dev git
 brew install cmake ninja openssl git
 ```
 
-**Windows (winget)**
+**Windows (winget + vcpkg)**
 
 ```powershell
 winget install Kitware.CMake Ninja-build.Ninja Git.Git
-# OpenSSL: download the Win32/Win64 installer from slproweb.com or use vcpkg
+
+# Install OpenSSL using vcpkg
+vcpkg install openssl:x64-windows
+# Set CMAKE_TOOLCHAIN_FILE to the vcpkg toolchain when building:
+# cmake -S hello-world -B build/hello-world -G Ninja `
+#   -DCMAKE_TOOLCHAIN_FILE=<path-to-vcpkg>/scripts/buildsystems/vcpkg.cmake
 ```
+
+Alternatively, download the Win32/Win64 OpenSSL installer from [slproweb.com](https://slproweb.com).
 
 > Windows support is less tested. A Linux build environment (WSL2 or Docker) is
 > the recommended path on Windows.
@@ -67,6 +74,12 @@ the CMake cache.
 # Custom NATS URL
 NATS_URL=nats://my-server:4222 ./build/hello-world/hello_myrmidon
 ```
+
+### Runtime environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NATS_URL` | `nats://localhost:4222` | NATS server address. Used at runtime to establish a connection to the JetStream broker. The binary will create required streams (`homeric-myrmidon`, `homeric-tasks`, `homeric-logs`) on connection if they do not exist. |
 
 You need a running NATS server with JetStream enabled. The binary creates the
 required streams (`homeric-myrmidon`, `homeric-tasks`, `homeric-logs`) on


### PR DESCRIPTION
Bundles 5 doc-only issues into a single PR.

Refs #676 — Document NATS_URL in hello-world/README runtime section
Refs #677 — Add Windows build guidance for OpenSSL to hello-world/README
Refs #592 — Expand README env-var table to include all variables
Refs #533 — Sync TLS env vars from CLAUDE.md into README env-var table
Refs #648 — Add Accepted date column to docs/adr/README.md index table

Each issue has been implemented; close the corresponding issue manually after merge.