### PR TITLE
chore(gitleaks): bundle policy + line-ending + test improvements

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,8 @@
+# Myrmidons gitleaks configuration
+# GITLEAKS_VERSION: pinned via .github/workflows/_required.yml env.GITLEAKS_VERSION
+# This config extends gitleaks' built-in rules and adds allowlist entries for documentation
+# examples and test fixtures that match secret patterns but are not real credentials.
+
 title = "Myrmidons gitleaks configuration"
 
 [extend]
@@ -6,15 +11,15 @@ useDefault = true
 [allowlist]
 description = "Test fixtures and documentation examples"
 regexes = [
-  '''your-token-here''',
-  '''fake-api-key''',
-  '''test-token''',
-  '''AGAMEMNON_API_KEY=.*example''',
+  '''your-token-here''',               # gitleaks-allowlist: placeholder token in CLAUDE.md, not a real credential
+  '''fake-api-key''',                  # gitleaks-allowlist: placeholder token in documentation examples
+  '''test-token''',                    # gitleaks-allowlist: placeholder token in test fixtures and documentation
+  '''AGAMEMNON_API_KEY=.*example''',   # gitleaks-allowlist: environment variable example in CLAUDE.md, not a real API key
 ]
 paths = [
-  '''tests/.*''',
-  '''README\.md''',
-  '''CLAUDE\.md''',
-  '''CHANGELOG\.md''',
-  '''docs/.*''',
+  '''tests/.*''',                      # gitleaks-allowlist: test fixtures contain intentional fake secrets
+  '''README\.md''',                    # gitleaks-allowlist: documentation examples with placeholder tokens
+  '''CLAUDE\.md''',                    # gitleaks-allowlist: policy documentation with example configs and tokens
+  '''CHANGELOG\.md''',                 # gitleaks-allowlist: changelog may reference example tokens in past entries
+  '''docs/.*''',                       # gitleaks-allowlist: documentation files with examples and placeholders
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,14 @@ so allowlist entries are applied automatically. To verify locally before pushing
 gitleaks detect --source . --config .gitleaks.toml --no-git -v
 ```
 
+### Gitleaks version pinning
+
+The gitleaks binary version is pinned in `.github/workflows/_required.yml` via the `GITLEAKS_VERSION` environment variable.
+This pin ensures all CI runs use the same gitleaks ruleset, preventing drift in secret detection between PR checks and merges.
+
+**How rev is chosen:** New versions are adopted after manual testing confirms no new false positives on the current allowlist.
+The pinned version in `_required.yml` is the source of truth; `.gitleaks.toml` comments document this relationship.
+
 ## Known Gotchas
 
 ### jq 1.6: `label` is a reserved keyword

--- a/scripts/check-gitleaks-coe.sh
+++ b/scripts/check-gitleaks-coe.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/check-gitleaks-coe.sh
+#
+# Lint guard: detect prohibited 'continue-on-error: true' on gitleaks CI steps.
+#
+# Policy: Security scanning steps must fail the workflow on detected issues.
+# Setting continue-on-error: true silently suppresses gitleaks results, creating a
+# false sense of security. The correct approach is to use .gitleaks.toml allowlist
+# entries with justification comments for false positives.
+#
+# This script searches all workflow files in .github/workflows/ for the pattern
+# and exits 1 if found on any gitleaks step.
+#
+# Handles Windows line endings (CRLF) by normalizing before grep.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:=$(cd "${SCRIPT_DIR}/.." && pwd)}"
+WORKFLOW_DIR="${REPO_ROOT}/.github/workflows"
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+    echo "ERROR: Workflow directory not found: $WORKFLOW_DIR" >&2
+    exit 1
+fi
+
+FOUND=0
+
+# Search all .yml workflow files
+while IFS= read -r -d '' workflow_file; do
+    # Normalize line endings (remove \r for CRLF files)
+    normalized=$(tr -d '\r' < "$workflow_file")
+
+    # Look for gitleaks step with continue-on-error: true
+    # Pattern: gitleaks in a name or run step, followed by continue-on-error: true
+    if grep -q "gitleaks" <<< "$normalized"; then
+        # Check if this file has continue-on-error: true near a gitleaks reference
+        if grep -E "continue-on-error:\s*true" <<< "$normalized" | grep -q .; then
+            # More precise check: ensure continue-on-error is near gitleaks context
+            if grep -B 5 -A 5 "gitleaks" <<< "$normalized" | grep -q "continue-on-error:\s*true"; then
+                echo "ERROR: $workflow_file contains 'continue-on-error: true' with gitleaks"
+                echo "  → Security scanning must fail the workflow on detected secrets"
+                echo "  → Use .gitleaks.toml allowlist entries with justification comments instead"
+                FOUND=$((FOUND + 1))
+            fi
+        fi
+    fi
+done < <(find "$WORKFLOW_DIR" -maxdepth 1 -name "*.yml" -print0)
+
+if [[ $FOUND -gt 0 ]]; then
+    echo ""
+    echo "check-gitleaks-coe: found $FOUND workflow file(s) with prohibited continue-on-error on gitleaks."
+    exit 1
+fi
+
+exit 0

--- a/tests/unit/test_check_gitleaks_coe.bats
+++ b/tests/unit/test_check_gitleaks_coe.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# tests/unit/test_check_gitleaks_coe.bats
+#
+# Issue #567: test coverage for scripts/check-gitleaks-coe.sh.
+#
+# The script enforces policy: gitleaks security scanning steps must not have
+# 'continue-on-error: true', which would silently suppress results. The correct
+# approach is using .gitleaks.toml allowlist entries with justification comments.
+#
+# The script must handle both Unix (LF) and Windows (CRLF) line endings.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-gitleaks-coe.sh"
+
+TMP_DIR=""
+TMP_WORKFLOWS=""
+
+setup() {
+    TMP_DIR="${SCRIPT_DIR}/_gitleaks_coe_test_$$_${RANDOM}"
+    TMP_WORKFLOWS="${TMP_DIR}/.github/workflows"
+    mkdir -p "$TMP_WORKFLOWS"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: run the checker with REPO_ROOT overridden to TMP_DIR
+_run_checker() {
+    run bash -c "
+        REPO_ROOT='${TMP_DIR}' bash '${CHECKER}'
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Workflow with gitleaks but no continue-on-error → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: workflow with gitleaks, no continue-on-error → exits 0" {
+    cat > "${TMP_WORKFLOWS}/test.yml" <<'EOF'
+name: Security
+on: push
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for secrets (gitleaks)
+        run: gitleaks detect --source . --config .gitleaks.toml
+EOF
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Workflow with gitleaks AND continue-on-error → exit 1 with error
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: workflow with gitleaks and continue-on-error → exits 1" {
+    cat > "${TMP_WORKFLOWS}/test.yml" <<'EOF'
+name: Security
+on: push
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for secrets (gitleaks)
+        run: gitleaks detect --source . --config .gitleaks.toml
+      - continue-on-error: true
+EOF
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"continue-on-error"* ]]
+    [[ "$output" == *"gitleaks"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Multiple workflows; only one has the violation → exit 1, report the bad one
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: multiple workflows, one violates → exits 1, reports violating file" {
+    cat > "${TMP_WORKFLOWS}/good.yml" <<'EOF'
+name: Good
+jobs:
+  lint:
+    steps:
+      - name: Check secrets
+        run: gitleaks detect
+EOF
+
+    cat > "${TMP_WORKFLOWS}/bad.yml" <<'EOF'
+name: Bad
+jobs:
+  secrets:
+    steps:
+      - name: Scan for secrets (gitleaks)
+        run: gitleaks detect
+      - continue-on-error: true
+EOF
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bad.yml"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Workflow without gitleaks, but has continue-on-error → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: workflow without gitleaks, has continue-on-error → exits 0" {
+    cat > "${TMP_WORKFLOWS}/other.yml" <<'EOF'
+name: Other
+jobs:
+  build:
+    steps:
+      - name: Some other step
+        run: echo hello
+      - continue-on-error: true
+EOF
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Handles Windows line endings (CRLF) → still detects violation
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: detects violation with CRLF line endings" {
+    # Create a file with CRLF line endings
+    printf '%s\r\n' \
+        'name: Security' \
+        'jobs:' \
+        '  secrets:' \
+        '    steps:' \
+        '      - name: Scan for secrets (gitleaks)' \
+        '        run: gitleaks detect' \
+        '      - continue-on-error: true' \
+        > "${TMP_WORKFLOWS}/crlf.yml"
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"continue-on-error"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Empty workflows directory → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: empty workflows directory → exits 0" {
+    # TMP_WORKFLOWS is already created but empty
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: Script runs without error on real repo (regression check)
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: real repo workflows pass" {
+    run bash "$CHECKER"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Bundles 5 gitleaks-related issues.

Refs #562 — Add justification comments to .gitleaks.toml allowlist entries
Refs #555 — Document gitleaks-system rev pinning strategy in CLAUDE.md
Refs #563 — Document GITLEAKS_VERSION pin source-of-truth in .gitleaks.toml
Refs #566 — Handle Windows line endings in check-gitleaks-coe.sh
Refs #567 — Add bats test for check-gitleaks-coe.sh

Each issue is partially-fixed; close manually after merge.