### PR TITLE
fix(plan): add (#179) issue reference to --output json flag declaration

### DIFF
--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -33,7 +33,7 @@ load_config
 
 HOST=""
 FLEET_NAME=""
-OUTPUT_FORMAT="text"   # "text" | "json"
+OUTPUT_FORMAT="text"   # "text" | "json" (#179)
 PRUNE=0
 
 # Counters for JSON output


### PR DESCRIPTION
## Summary

In `scripts/plan.sh`, the `OUTPUT_FORMAT` variable declaration now carries an inline `(#179)` issue reference, consistent with the `(#NNN)` annotation pattern used throughout the script (e.g. lines referencing `#273`, `#118`, `#149`, `#96`).

The `--output json` feature was introduced in commit `85a94a7` which closes PR #179. A CHANGELOG.md entry for this feature had incorrectly referenced the commit SHA `(#85a94a7)` rather than the issue/PR number. With CHANGELOG.md since removed (#703), the canonical reference now lives inline in the script.

Closes #461