### PR TITLE
docs(contributing): consolidate dangerous-flags hook reference to CLAUDE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ cd Myrmidons
 # Activate the Pixi environment
 pixi shell
 
-# Install all git hooks (dangerous-flags hook + pre-commit framework)
+# Install all git hooks (pre-commit framework including dangerous-flags lint guard;
+# see CLAUDE.md § Security for the single canonical policy description)
 just install-hooks
 
 # List available recipes


### PR DESCRIPTION
## Summary

CONTRIBUTING.md's Quick Start section had an incomplete one-liner comment about the dangerous-flags hook. Updated to reference CLAUDE.md's Security section as the single canonical description — covering both the policy (CLAUDE.md entry from #147) and the pre-commit/CI integration (hook added in prior commit). Prevents the split-documentation pattern that caused the duplicate CHANGELOG entries.

Closes #462