### PR TITLE
docs(contributing): add AGENTS.md checklist item to Code Review section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,7 @@ The `main` branch is protected. All changes must go through pull requests.
 - **Agent types** — Are agent type names consistent with existing conventions?
 - **Privilege levels** — Is the agent requesting minimum necessary privileges?
 - **Resource limits** — Are CPU/memory limits reasonable?
+- **AGENTS.md** — Does this change affect agent permissions or safety boundaries? Update `AGENTS.md` if so.
 
 ### Responding to Review Comments
 


### PR DESCRIPTION
## Summary

Adds a reviewer prompt to the "What Reviewers Look For" checklist in `CONTRIBUTING.md`:

> **AGENTS.md** — Does this change affect agent permissions or safety boundaries? Update `AGENTS.md` if so.

This reinforces the guidance added in #388 at the moment it matters most — during code review — rather than only when reading CONTRIBUTING.md.

Closes #478