### PR TITLE
docs(pr-template): add CLAUDE.md/AGENTS.md update reminder to checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,5 @@
 - [ ] Commit messages follow Conventional Commits format
 - [ ] PR title follows `type(scope): description` format
 - [ ] Documentation updated if behavior changed
+- [ ] `CLAUDE.md` updated if developer workflow or conventions changed
+- [ ] `AGENTS.md` updated if agent permissions or safety boundaries changed


### PR DESCRIPTION
## Summary

Adds two checklist items to `.github/PULL_REQUEST_TEMPLATE.md`:

- `CLAUDE.md` updated if developer workflow or conventions changed
- `AGENTS.md` updated if agent permissions or safety boundaries changed

Makes the guidance from #388 actionable at PR creation time, not just when reading CONTRIBUTING.md.

Closes #479