### PR TITLE
docs: cross-link CONTRIBUTING.md from AGENTS.md and CLAUDE.md (#480)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This document defines behavior boundaries, permitted tools, scope limitations, c
 
 **Audience:** AI agent runtimes (Claude Code, loop agents, fleet orchestrators).
 **Developer context:** See [CLAUDE.md](CLAUDE.md) for naming conventions, YAML format, drift detection, and environment variables.
+**Contributor workflow:** See [CONTRIBUTING.md](CONTRIBUTING.md) for branching, commits, PRs, and reviews.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 GitOps agent provisioning for the HomericIntelligence mesh.
 
 > For agent safety boundaries and permitted tool use, see [AGENTS.md](AGENTS.md).
+> For contributor workflow (branching, commits, PRs, reviews), see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## What this repo is
 


### PR DESCRIPTION
## Summary
- AGENTS.md and CLAUDE.md now link CONTRIBUTING.md for discoverability.
- Closes #480

## Test plan
- [x] markdownlint passes
- [x] Both links resolve in GitHub rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)