### PR TITLE
fix(guard): handle REPO_ROOT with trailing slash (#487)

### DIFF
--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -189,7 +189,14 @@ _guard_snapshot_dir() {
     fi
 
     # Block derived out-of-repo paths (only when SNAPSHOT_DIR was not explicitly set).
-    if [[ -z "$explicitly_set" && "$dir" != "${REPO_ROOT}"/* ]]; then
+    # Strip any trailing slash from REPO_ROOT (#487) so the glob below does not silently
+    # fail when REPO_ROOT is set to something like "/home/user/repo/" — the resulting
+    # pattern "/home/user/repo//*" would not match the legitimate default
+    # "/home/user/repo/.myrmidons/snapshots".
+    # NOTE: variable name avoids the lowercase "repo_root" substring (issue #370 invariant
+    # enforced by tests/unit/test_apply_sc2154.bats).
+    local REPO_ROOT_NOSLASH="${REPO_ROOT%/}"
+    if [[ -z "$explicitly_set" && "$dir" != "${REPO_ROOT_NOSLASH}"/* ]]; then
         echo "ERROR: snapshot dir '${dir}' is outside the repo tree '${REPO_ROOT}'." >&2
         echo "  REPO_ROOT may be empty or unset. Set SNAPSHOT_DIR explicitly to override." >&2
         exit 1

--- a/tests/unit/test_snapshot_dir_guard.bats
+++ b/tests/unit/test_snapshot_dir_guard.bats
@@ -40,7 +40,8 @@ _run_guard() {
                 exit 1
             fi
 
-            if [[ -z \"\$explicitly_set\" && \"\$dir\" != \"\${REPO_ROOT}\"/* ]]; then
+            local repo_root_stripped=\"\${REPO_ROOT%/}\"
+            if [[ -z \"\$explicitly_set\" && \"\$dir\" != \"\${repo_root_stripped}\"/* ]]; then
                 echo \"ERROR: snapshot dir '\${dir}' is outside the repo tree '\${REPO_ROOT}'.\" >&2
                 echo \"  REPO_ROOT may be empty or unset. Set SNAPSHOT_DIR explicitly to override.\" >&2
                 exit 1
@@ -127,4 +128,23 @@ _run_guard() {
     run _run_guard "/tmp/my-snapshots" "set" "/home/user/myrepo"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 5 (#487): REPO_ROOT with trailing slash must still match in-repo paths
+# ---------------------------------------------------------------------------
+
+@test "_guard_snapshot_dir: REPO_ROOT with trailing slash accepts in-repo path" {
+    # Without the ${REPO_ROOT%/} strip, the glob "/home/user/myrepo//*" would not
+    # match "/home/user/myrepo/.myrmidons/snapshots" and the guard would falsely
+    # report an out-of-repo path.
+    run _run_guard "/home/user/myrepo/.myrmidons/snapshots" "" "/home/user/myrepo/"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "_guard_snapshot_dir: REPO_ROOT with trailing slash still rejects out-of-repo path" {
+    run _run_guard "/tmp/snapshots" "" "/home/user/myrepo/"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"outside the repo tree"* ]]
 }


### PR DESCRIPTION
## Summary
- `_guard_snapshot_dir` in `scripts/apply.sh` compared against `"${REPO_ROOT}"/*`. If `REPO_ROOT` ever carried a trailing slash, the glob became `…//*` and failed to match legitimate in-repo paths like `…/.myrmidons/snapshots`, producing a spurious abort.
- Strip a trailing slash via `${REPO_ROOT%/}` before the comparison (defensive future-proofing, per the issue).
- Added bats coverage in `tests/unit/test_snapshot_dir_guard.bats` for both the accept-in-repo and reject-out-of-repo trailing-slash cases.
- Closes #487 (follow-up from #391).

## Test plan
- [x] `bats tests/unit/test_snapshot_dir_guard.bats` — all 12 tests pass (10 existing + 2 new)
- [x] `shellcheck scripts/apply.sh` — clean
- [x] New tests cover trailing-slash `REPO_ROOT` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)