### PR TITLE
fix(url): reject empty-string AGAMEMNON_URL (#513)

### DIFF
--- a/scripts/lib/api.sh
+++ b/scripts/lib/api.sh
@@ -17,7 +17,13 @@
 
 set -euo pipefail
 
-AGAMEMNON_URL="${AGAMEMNON_URL:-http://localhost:8080}"
+# Default AGAMEMNON_URL only when truly unset. Issue #513: an explicitly empty
+# exported value must reach _agamemnon_validate_url unchanged so it can be
+# rejected by the empty-string guard, rather than being silently coerced to
+# the localhost default by `:-`.
+if [[ -z "${AGAMEMNON_URL+set}" ]]; then
+    AGAMEMNON_URL="http://localhost:8080"
+fi
 _aim_had_xtrace=0
 if [[ "$-" == *x* ]]; then _aim_had_xtrace=1; fi
 { set +x; } 2>/dev/null


### PR DESCRIPTION
## Summary
- `scripts/lib/api.sh` previously coerced an explicitly empty `AGAMEMNON_URL` to the localhost default via `${VAR:-default}`, so the empty-string guard in `_agamemnon_validate_url` never fired.
- Switched to `${VAR+set}` so the default applies only when the variable is genuinely unset. An explicit empty string now reaches the validator and is rejected as designed.
- Closes #513
- Refs #464 #469 #474 — these are duplicate reports of the same root cause and should be transitively fixed by this change; maintainers may want to close them once CI is green here.

## Test plan
- [x] `bats tests/unit/test_url_security.bats` — all 15 tests pass (was: 1 failure on "empty string is rejected")
- [x] `bats tests/unit/test_api.bats tests/unit/test_api_auth.bats tests/unit/test_config.bats tests/unit/test_curl_cleanup.bats` — 52/52 pass
- [x] Existing URL validation tests unaffected (empty default path still resolves to `http://localhost:8080` when AGAMEMNON_URL is unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)