### PR TITLE
ci(lint): add `run ... || true` BATS antipattern guard (#507)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,6 +154,22 @@ repos:
         types: [text]
         pass_filenames: true
 
+      - id: forbid-bats-run-or-true
+        name: "forbid `run ... || true` antipattern in BATS files"
+        description: >
+          In BATS, `run COMMAND` already captures COMMAND's exit code into
+          `$status`. Appending `|| true` to the `run` line wraps it in an
+          always-zero subshell, making `$status` meaningless and silently
+          neutralising any later `[ "$status" -eq N ]` assertion. The global
+          `forbid-or-true` rule excludes `.bats` files because legitimate
+          cleanup hooks (`kill ... || true`) and command substitutions
+          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
+          rule targets only the dangerous form. See issue #507.
+        language: script
+        entry: scripts/check-bats-run-or-true.sh
+        files: '\.bats$'
+        pass_filenames: true
+
       - id: forbid-continue-on-error
         name: "forbid continue-on-error workflow opt-out"
         description: >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,33 @@ subscription on hi.research.> and MaxAckPending=1.
 Closes #20"
 ```
 
+### Test Antipatterns to Avoid
+
+#### `run ... || true` in BATS files
+
+Never append `|| true` to a BATS `run` line:
+
+```bash
+# BAD — $status is meaningless, any subsequent assertion is silently neutered
+run some-command --foo bar || true
+[ "$status" -eq 0 ]
+
+# GOOD — `run` already captures the exit code into $status
+run some-command --foo bar
+[ "$status" -eq 0 ]
+```
+
+BATS's `run` builtin already captures the command's exit code into `$status`,
+so the command can never fail the test. Wrapping it in `|| true` puts it in an
+always-zero subshell, so `$status` is permanently 0 and any
+`[ "$status" -eq N ]` check silently passes. This antipattern shipped
+undetected in Tests 1, 2, and 3 before #398. The `forbid-bats-run-or-true`
+pre-commit hook (see `scripts/check-bats-run-or-true.sh`) blocks it.
+
+Legitimate `|| true` uses in `.bats` files remain allowed for cleanup hooks
+(`kill ... || true`) and command substitutions (`x=$(grep -c ... || true)`)
+because those do not interact with `run`'s `$status` capture.
+
 ## Validation and Testing
 
 ```bash

--- a/scripts/check-bats-run-or-true.sh
+++ b/scripts/check-bats-run-or-true.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/check-bats-run-or-true.sh — Lint guard: flag `run ... || true` in BATS files
+#
+# In BATS, `run COMMAND` captures the exit code of COMMAND into `$status`.
+# Appending `|| true` to the run line wraps COMMAND in an `OR` expression whose
+# subshell always exits 0, so `$status` is never meaningful and any subsequent
+# `[ "$status" -eq N ]` assertion is silently meaningless. This antipattern
+# shipped in Tests 1, 2, and 3 before #398 and was difficult to spot in review.
+#
+# Use BATS's intended idiom instead:
+#
+#     run COMMAND ...
+#     [ "$status" -eq 0 ]   # or whatever exit code is expected
+#
+# If you genuinely need the command to never abort the test regardless of exit
+# code, do NOT use `|| true` on the `run` line — just rely on `run`'s own
+# capture and assert on `$status` (or assert nothing). See issue #507.
+#
+# Exit codes:
+#   0 — no violations
+#   1 — one or more violations found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Collect .bats files: either args from pre-commit, or scan tests/ tree.
+if [[ $# -gt 0 ]]; then
+    FILES=("$@")
+else
+    mapfile -t FILES < <(find "${REPO_ROOT}/tests" -name '*.bats' -type f)
+fi
+
+violations=0
+
+for file in "${FILES[@]}"; do
+    # Only inspect .bats files even if other paths slip through.
+    [[ "$file" == *.bats ]] || continue
+    [[ -f "$file" ]] || continue
+
+    # Match lines that start with optional whitespace, then `run ` (BATS's
+    # exit-code-capturing builtin), with `|| true` somewhere on the same line.
+    # We deliberately key on `^[[:space:]]*run[[:space:]]` to avoid false
+    # positives from arbitrary commands that happen to contain `|| true`
+    # (which BATS-internal `run` already neutralizes by capturing $status).
+    while IFS= read -r match; do
+        [[ -n "$match" ]] || continue
+        lineno="${match%%:*}"
+        line="${match#*:}"
+        printf '%s:%s: BATS antipattern: `run ... || true` discards $status — drop `|| true` and assert on $status instead (see issue #507)\n    %s\n' \
+            "$file" "$lineno" "$line" >&2
+        violations=$((violations + 1))
+    done < <(grep -nE '^[[:space:]]*run[[:space:]].*\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "$file" || true)
+done
+
+if (( violations > 0 )); then
+    printf '\n%d BATS `run ... || true` antipattern violation(s) found.\n' "$violations" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds `scripts/check-bats-run-or-true.sh` + matching `forbid-bats-run-or-true` pre-commit hook to block the BATS `run ... || true` antipattern (always-zero subshell silently neuters `$status` assertions).
- Documents the antipattern in CONTRIBUTING.md with GOOD/BAD examples, per the issue request.
- Narrower than the global `forbid-or-true` rule (which excludes `.bats`); legitimate cleanup hooks (`kill ... || true`) and command substitutions remain allowed.
- Closes #507

## Test plan
- [x] `pre-commit run forbid-bats-run-or-true --all-files` passes against the current tree (no existing violations).
- [x] Script flags a deliberately-violating fixture (`run some-command || true` → exit 1 with location and message).
- [x] Full `pre-commit run --all-files` green (modulo missing `actionlint` binary in local env, unrelated).
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)