### PR TITLE
chore(tests): add bats_require_minimum_version to new test file (#482)

### DIFF
--- a/tests/unit/test_snapshot_dir_resolution.bats
+++ b/tests/unit/test_snapshot_dir_resolution.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
 # tests/unit/test_snapshot_dir_resolution.bats
 #
 # Runtime regression test for issue #390: effective_snapshot_dir resolves to


### PR DESCRIPTION
## Summary
- Adds `bats_require_minimum_version 1.5.0` to `tests/unit/test_snapshot_dir_resolution.bats` to prevent the BW02 warning and keep the suite consistent.
- Version 1.5.0 matches the value requested in the issue and is compatible with the `bats-core >=1.11,<2` pin in `pixi.toml`.
- Closes #482

## Test plan
- [x] bats suite still passes
- [x] No other bats files modified (scope kept to the file named in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)