### PR TITLE
chore(security): resolve CVE-2026-44431 in urllib3

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -203,7 +203,8 @@ jobs:
             --ignore-vuln CVE-2025-66418 \
             --ignore-vuln CVE-2025-66471 \
             --ignore-vuln CVE-2026-21441 \
-            --ignore-vuln CVE-2026-24049
+            --ignore-vuln CVE-2026-24049 \
+            --ignore-vuln CVE-2026-44431
 
       # Trivy filesystem scan — informational. `--exit-code 0` already makes
       # vulnerability findings non-fatal; install/extraction failures should


### PR DESCRIPTION
## Summary

- Adds `--ignore-vuln CVE-2026-44431` to the `security/dependency-scan` pip-audit step in `.github/workflows/_required.yml`.
- Tracked in #723 (revisit after the next `actions/runner-images` refresh ships `urllib3 >= 2.7.0` in the baseline).

## Why allowlist (not bump)?

Myrmidons declares **zero PyPI dependencies**: no `pyproject.toml`, nothing in `pixi.toml` or `pixi.lock` references `urllib3`. The finding originates from the `ubuntu-latest` GitHub Actions runner image baseline Python packages, matching the pattern already documented in the same workflow file (see comment block and issue #713). Bumping is not possible from this repo.

## Impact

Unblocks the 9 wave-2 PRs (#714–#722), whose `security/dependency-scan` check is currently red on this single CVE finding. Each will need a rebase after this merges to pick up the fix.

## Test plan

- [ ] `security/dependency-scan` passes on this PR
- [ ] Remaining `_required.yml` jobs stay green
- [ ] After merge: rebase one wave-2 PR and confirm `security/dependency-scan` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)