### PR TITLE
chore(tests): add bats_require_minimum_version sweep

### DIFF
--- a/tests/unit/test_fleet.bats
+++ b/tests/unit/test_fleet.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
 # tests/unit/test_fleet.bats — unit tests for fleet resolution (scripts/lib/reconcile.sh)
 #
 # Tests cover:


### PR DESCRIPTION
## Summary

Fixes BW02 warnings (escalated to errors by Myrmidons CI) across all bats test files using `run` with flags. Follows the single-file pattern from PR #719 but applies it as a sweep.

Files touched:
- `tests/unit/test_fleet.bats`

(A full repo sweep of `tests/**/*.bats` found only this one file missing the directive while using `run` with flags; all other bats files either already declare `bats_require_minimum_version` or do not use flagged `run`.)

This unblocks wave PRs #715 and #718 (and likely others in #714-#722) which all fail Unit Tests with the same BW02 error.

## Test plan
- [ ] CI Unit Tests job passes (no BW02 escalation)
- [ ] No other CI checks regress

Generated with [Claude Code](https://claude.com/claude-code)