### PR TITLE
docs(agents): document lint-agents-md (#472)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,9 @@ pixi run --environment lint lint-shell
 # YAML lint
 pixi run --environment lint lint-yaml
 
+# Validate required H2 sections in AGENTS.md (run before editing this file)
+pixi run --environment lint lint-agents-md
+
 # Dry-run reconciliation (requires Agamemnon running)
 ./scripts/plan.sh
 ```


### PR DESCRIPTION
## Summary
- Add `pixi run --environment lint lint-agents-md` to the Verification Commands section of AGENTS.md so contributors run the required-sections check before opening a PR.
- Matches the existing style (command + brief description) of the surrounding lint entries.

Closes #472

## Test plan
- [ ] CI green (lint, shell, YAML, AGENTS.md required-sections)
- [ ] Rendered AGENTS.md verification commands block reads naturally

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)