### PR TITLE
chore(pixi): wire check-docs-crossref into lint (#476)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -48,6 +48,7 @@ lint-names    = "bash scripts/lint-names.sh"
 lint-shell    = "bash scripts/lint-shell.sh"
 check-adr-index = "bash scripts/check-adr-index.sh"
 lint-agents-md = "bash scripts/lint-agents-md.sh"
+lint-docs-crossref = "bash scripts/check-docs-crossref.sh"
 
 test-unit        = "bats tests/unit/"
 test-integration = "bats tests/integration/"
@@ -64,4 +65,5 @@ build-hello-world = "just build-hello-world"
 [feature.lint.tasks]
 lint-shell     = { cmd = "find scripts tests hooks \\( -name '*.sh' -o -name '*.bats' -o -name 'pre-commit' \\) | sort | xargs shellcheck --severity=warning --enable=SC2154", description = "ShellCheck all shell scripts and bats tests at warning severity" }
 lint-agents-md = "bash scripts/lint-agents-md.sh"
-lint           = { depends-on = ["lint-shell", "check-adr-index", "lint-agents-md"] }
+lint-docs-crossref = "bash scripts/check-docs-crossref.sh"
+lint           = { depends-on = ["lint-shell", "check-adr-index", "lint-agents-md", "lint-docs-crossref"] }


### PR DESCRIPTION
## Summary
- Adds `lint-docs-crossref` pixi task (default and `lint` feature) calling `scripts/check-docs-crossref.sh`
- Chains the new task into the `lint` depends-on group alongside `lint-shell`, `check-adr-index`, and `lint-agents-md`
- Matches the existing pattern so developers can run `pixi run lint-docs-crossref` (and it runs as part of `pixi run lint`)

Closes #476

## Test plan
- [ ] CI green
- [ ] `pixi run lint-docs-crossref` exits 0 on a healthy tree
- [ ] `pixi run lint` includes the new check