### PR TITLE
feat(lint): lint-agents-md accepts stdin/env (#471)

### DIFF
--- a/scripts/lint-agents-md.sh
+++ b/scripts/lint-agents-md.sh
@@ -5,22 +5,71 @@
 # Prevents PRs from accidentally deleting or renaming a required section.
 #
 # Usage:
-#   ./scripts/lint-agents-md.sh              # check AGENTS.md at repo root
-#   ./scripts/lint-agents-md.sh path/to/AGENTS.md
+#   ./scripts/lint-agents-md.sh                       # check AGENTS.md at repo root
+#   ./scripts/lint-agents-md.sh path/to/AGENTS.md     # check a specific file
+#   ./scripts/lint-agents-md.sh -                     # read content from stdin
+#   cat AGENTS.md | ./scripts/lint-agents-md.sh -     # equivalent
+#   LINT_AGENTS_MD_FILE=path/to/AGENTS.md ./scripts/lint-agents-md.sh
+#   LINT_AGENTS_MD_FILE=- ./scripts/lint-agents-md.sh < AGENTS.md
+#
+# Resolution order for the input source:
+#   1. Positional argument (if given; "-" means stdin)
+#   2. $LINT_AGENTS_MD_FILE environment variable (value "-" means stdin)
+#   3. ${REPO_ROOT}/AGENTS.md as the final default
+#
+# Note: stdin is consumed only when explicitly requested via "-" (arg or env),
+# so the default no-argument behaviour is preserved for pre-commit and CI use.
 #
 # Exit codes:
 #   0 = all required sections present
-#   1 = one or more sections missing
+#   1 = one or more sections missing, file not readable, or invalid input
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-TARGET="${1:-${REPO_ROOT}/AGENTS.md}"
+# Resolve input source.
+TARGET=""
+READ_STDIN=0
+
+if [[ $# -gt 0 ]]; then
+    if [[ "$1" == "-" ]]; then
+        READ_STDIN=1
+    else
+        TARGET="$1"
+    fi
+elif [[ -n "${LINT_AGENTS_MD_FILE:-}" ]]; then
+    if [[ "${LINT_AGENTS_MD_FILE}" == "-" ]]; then
+        READ_STDIN=1
+    else
+        TARGET="${LINT_AGENTS_MD_FILE}"
+    fi
+else
+    TARGET="${REPO_ROOT}/AGENTS.md"
+fi
+
+# Materialise stdin into a temp file so we can grep it the same way as a path.
+CLEANUP_TMP=""
+# shellcheck disable=SC2329  # invoked indirectly via trap below
+_lint_agents_md_cleanup() {
+    if [[ -n "$CLEANUP_TMP" && -f "$CLEANUP_TMP" ]]; then
+        rm -f "$CLEANUP_TMP"
+    fi
+}
+trap _lint_agents_md_cleanup EXIT
+
+if [[ $READ_STDIN -eq 1 ]]; then
+    CLEANUP_TMP="$(mktemp -t lint-agents-md.XXXXXX)"
+    cat > "$CLEANUP_TMP"
+    TARGET="$CLEANUP_TMP"
+    DISPLAY_NAME="<stdin>"
+else
+    DISPLAY_NAME="$TARGET"
+fi
 
 if [[ ! -f "$TARGET" ]]; then
-    echo "ERROR: lint-agents-md: file not found: ${TARGET}"
+    echo "ERROR: lint-agents-md: file not found: ${DISPLAY_NAME}"
     exit 1
 fi
 
@@ -37,14 +86,14 @@ MISSING=0
 
 for section in "${REQUIRED_SECTIONS[@]}"; do
     if ! grep -qF "$section" "$TARGET"; then
-        echo "ERROR: lint-agents-md: required section missing from ${TARGET}: ${section}"
+        echo "ERROR: lint-agents-md: required section missing from ${DISPLAY_NAME}: ${section}"
         MISSING=$((MISSING + 1))
     fi
 done
 
 if [[ $MISSING -gt 0 ]]; then
     echo ""
-    echo "lint-agents-md: ${MISSING} required section(s) missing from AGENTS.md."
+    echo "lint-agents-md: ${MISSING} required section(s) missing from ${DISPLAY_NAME}."
     echo "Restore the missing sections or update REQUIRED_SECTIONS in scripts/lint-agents-md.sh."
     exit 1
 fi

--- a/tests/unit/test_lint_agents_md.bats
+++ b/tests/unit/test_lint_agents_md.bats
@@ -5,7 +5,9 @@
 #
 # Verifies that the script passes when all six required sections are present,
 # fails with a clear error message when any section is missing, and handles
-# edge cases (missing file, partial matches).
+# edge cases (missing file, partial matches, stdin, env var).
+
+bats_require_minimum_version 1.5.0
 
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 LINT_SCRIPT="${SCRIPT_DIR}/scripts/lint-agents-md.sh"
@@ -183,4 +185,61 @@ EOF
     # Run from repo root so the default path resolves correctly
     run bash -c "cd '${SCRIPT_DIR}' && bash scripts/lint-agents-md.sh"
     [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Tests 13–18: stdin input modes
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: stdin via '-' arg with complete content exits 0" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    run bash -c "bash '$LINT_SCRIPT' - < '${TMP_DIR}/AGENTS.md'"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: stdin via '-' arg with missing section exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Scope" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash -c "bash '$LINT_SCRIPT' - < '${TMP_DIR}/AGENTS-broken.md'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Scope"* ]]
+    [[ "$output" == *"<stdin>"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: LINT_AGENTS_MD_FILE environment variable
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE env var with complete file exits 0" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/AGENTS.md" run bash "$LINT_SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE env var with missing section exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Permitted Actions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/AGENTS-broken.md" run bash "$LINT_SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Permitted Actions"* ]]
+}
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE='-' reads stdin" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    run bash -c "LINT_AGENTS_MD_FILE=- bash '$LINT_SCRIPT' < '${TMP_DIR}/AGENTS.md'"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: positional arg takes precedence over LINT_AGENTS_MD_FILE" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Scope" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    # env var points at broken file, but positional arg should win
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/AGENTS-broken.md" run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE pointing to missing file exits 1" {
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/does-not-exist.md" run bash "$LINT_SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"file not found"* ]]
 }


### PR DESCRIPTION
## Summary

Extends `scripts/lint-agents-md.sh` so the AGENTS.md file under review can be supplied via:

- positional argument `-` (read from stdin)
- `LINT_AGENTS_MD_FILE` env var (path, or `-` for stdin)
- positional arg still takes precedence over the env var
- default (no arg, no env) remains `${REPO_ROOT}/AGENTS.md`, preserving pre-commit / CI behaviour

Stdin is only consumed on an **explicit** request (`-` arg or `LINT_AGENTS_MD_FILE=-`); the script does not auto-detect a piped stdin, which keeps it safe in non-TTY contexts (CI, pre-commit, bats).

Closes #471. Follow-up from #386.

## Files touched

- `scripts/lint-agents-md.sh` — new input-resolution block + stdin tempfile materialisation with `trap` cleanup
- `tests/unit/test_lint_agents_md.bats` — adds `bats_require_minimum_version 1.5.0` and 8 new tests covering stdin, env var, env-var stdin, env-var-missing-file, and arg-over-env precedence

## Test plan

- [x] `shellcheck scripts/lint-agents-md.sh` — clean
- [x] `bats tests/unit/test_lint_agents_md.bats` — 19/19 pass locally (incl. all 12 original tests, unchanged)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)