### PR TITLE
chore(gitignore): exclude _test_*/ and .issue_implementer/ sandboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ hello-world/main.py
 
 # Reconciliation reports (runtime state, not config)
 reports/last-reconciliation.json
+
+# Transient sandboxes from hook debugging / automation runs — never commit
+_test_*/
+.issue_implementer/


### PR DESCRIPTION
## Summary

- Adds `_test_*/` and `.issue_implementer/` to `.gitignore` so transient hook-debug and automation sandboxes don't keep showing up as untracked.
- These directories accumulate from local debugging runs; none have ever been committed.
- Phase C1 of the dataset-charter narrowing.

## Test plan

- [x] After this lands, `git status` on a fresh checkout no longer flags `_test_*/` or `.issue_implementer/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)