### PR TITLE
feat(lint): check-schema-hints supports .yml extension (#465)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: gitleaks-system
         pass_filenames: false
 
-  # Myrmidons dataset validators
+  # Myrmidons schema validation
   - repo: local
     hooks:
       - id: myrmidons-validate
@@ -59,12 +59,33 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets|schemas|tests)/'
 
+      - id: check-xtrace-exposure
+        name: Check for unguarded xtrace auth exposure in curl calls
+        language: script
+        entry: scripts/check-xtrace-exposure.sh
+        files: '\.sh$'
+        pass_filenames: false
+
+      - id: check-adr-index
+        name: ADR README index completeness
+        language: script
+        entry: scripts/check-adr-index.sh
+        pass_filenames: false
+        files: ^docs/adr/.*\.md$
+
       - id: myrmidons-doc-drift
         name: Documentation drift check
         language: script
         entry: tests/detect-doc-drift.sh
         pass_filenames: false
         files: '(^(Architecture|README|CLAUDE|CONTRIBUTING)\.md$|^tests/detect-doc-drift\.sh$|^docs/(?!adr/).*\.md$)'
+
+      - id: check-duplicate-functions
+        name: Check for duplicate shell function definitions
+        entry: scripts/check-duplicate-functions.sh
+        language: script
+        types: [shell]
+        pass_filenames: false
 
       - id: myrmidons-validate-fleet-refs
         name: Fleet ref validation
@@ -73,6 +94,17 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 
+      - id: docs-crossref
+        name: CLAUDE.md → AGENTS.md cross-reference check
+        language: script
+        entry: scripts/check-docs-crossref.sh
+        files: '^(CLAUDE\.md|AGENTS\.md)$'
+        pass_filenames: false
+        # Trade-off: `files:` scopes incremental runs to CLAUDE.md/AGENTS.md changes, but
+        # `pre-commit run --all-files` (used in CI parity) always triggers all hooks
+        # regardless of file filters. The hook is fast (two greps), so the CI overhead is
+        # acceptable. always_run is intentionally omitted (defaults to false).
+
       - id: myrmidons-schema-hints
         name: Myrmidons yaml-language-server hint check
         language: system
@@ -80,12 +112,26 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
+      - id: myrmidons-changelog-gaps
+        name: Changelog gap detection
+        language: python
+        entry: python scripts/check-changelog-gaps.py
+        pass_filenames: false
+        always_run: true
+
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
+
+      - id: no-gitleaks-continue-on-error
+        name: gitleaks step must not have continue-on-error
+        language: script
+        entry: scripts/check-gitleaks-coe.sh
+        files: '^\.github/workflows/.*\.yml$'
+        pass_filenames: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
@@ -98,6 +144,22 @@ repos:
         entry: '\|\|\s*true(\s*$|\s+#)'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
+        pass_filenames: true
+
+      - id: forbid-bats-run-or-true
+        name: "forbid `run ... || true` antipattern in BATS files"
+        description: >
+          In BATS, `run COMMAND` already captures COMMAND's exit code into
+          `$status`. Appending `|| true` to the `run` line wraps it in an
+          always-zero subshell, making `$status` meaningless and silently
+          neutralising any later `[ "$status" -eq N ]` assertion. The global
+          `forbid-or-true` rule excludes `.bats` files because legitimate
+          cleanup hooks (`kill ... || true`) and command substitutions
+          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
+          rule targets only the dangerous form. See issue #507.
+        language: script
+        entry: scripts/check-bats-run-or-true.sh
+        files: '\.bats$'
         pass_filenames: true
 
       - id: forbid-continue-on-error
@@ -119,8 +181,11 @@ repos:
           underlying problem still goes unfixed. Make the step fail-fast
           instead. The only legitimate use is annotating a step that runs
           BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit.
+          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
         language: pygrep
+        # Match the GitHub Actions advisory-annotation prefix. We exempt
+        # this workflow file (the lint rule itself contains the literal
+        # for self-documentation) via the `exclude` regex below.
         entry: '::warning::'
         files: ^\.github/workflows/.*\.ya?ml$
         exclude: ^\.github/workflows/_required\.yml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: gitleaks-system
         pass_filenames: false
 
-  # Myrmidons schema validation
+  # Myrmidons dataset validators
   - repo: local
     hooks:
       - id: myrmidons-validate
@@ -59,33 +59,12 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets|schemas|tests)/'
 
-      - id: check-xtrace-exposure
-        name: Check for unguarded xtrace auth exposure in curl calls
-        language: script
-        entry: scripts/check-xtrace-exposure.sh
-        files: '\.sh$'
-        pass_filenames: false
-
-      - id: check-adr-index
-        name: ADR README index completeness
-        language: script
-        entry: scripts/check-adr-index.sh
-        pass_filenames: false
-        files: ^docs/adr/.*\.md$
-
       - id: myrmidons-doc-drift
         name: Documentation drift check
         language: script
         entry: tests/detect-doc-drift.sh
         pass_filenames: false
         files: '(^(Architecture|README|CLAUDE|CONTRIBUTING)\.md$|^tests/detect-doc-drift\.sh$|^docs/(?!adr/).*\.md$)'
-
-      - id: check-duplicate-functions
-        name: Check for duplicate shell function definitions
-        entry: scripts/check-duplicate-functions.sh
-        language: script
-        types: [shell]
-        pass_filenames: false
 
       - id: myrmidons-validate-fleet-refs
         name: Fleet ref validation
@@ -94,17 +73,6 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 
-      - id: docs-crossref
-        name: CLAUDE.md → AGENTS.md cross-reference check
-        language: script
-        entry: scripts/check-docs-crossref.sh
-        files: '^(CLAUDE\.md|AGENTS\.md)$'
-        pass_filenames: false
-        # Trade-off: `files:` scopes incremental runs to CLAUDE.md/AGENTS.md changes, but
-        # `pre-commit run --all-files` (used in CI parity) always triggers all hooks
-        # regardless of file filters. The hook is fast (two greps), so the CI overhead is
-        # acceptable. always_run is intentionally omitted (defaults to false).
-
       - id: myrmidons-schema-hints
         name: Myrmidons yaml-language-server hint check
         language: system
@@ -112,26 +80,12 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
-      - id: myrmidons-changelog-gaps
-        name: Changelog gap detection
-        language: python
-        entry: python scripts/check-changelog-gaps.py
-        pass_filenames: false
-        always_run: true
-
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
-
-      - id: no-gitleaks-continue-on-error
-        name: gitleaks step must not have continue-on-error
-        language: script
-        entry: scripts/check-gitleaks-coe.sh
-        files: '^\.github/workflows/.*\.yml$'
-        pass_filenames: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
@@ -144,22 +98,6 @@ repos:
         entry: '\|\|\s*true(\s*$|\s+#)'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
-        pass_filenames: true
-
-      - id: forbid-bats-run-or-true
-        name: "forbid `run ... || true` antipattern in BATS files"
-        description: >
-          In BATS, `run COMMAND` already captures COMMAND's exit code into
-          `$status`. Appending `|| true` to the `run` line wraps it in an
-          always-zero subshell, making `$status` meaningless and silently
-          neutralising any later `[ "$status" -eq N ]` assertion. The global
-          `forbid-or-true` rule excludes `.bats` files because legitimate
-          cleanup hooks (`kill ... || true`) and command substitutions
-          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
-          rule targets only the dangerous form. See issue #507.
-        language: script
-        entry: scripts/check-bats-run-or-true.sh
-        files: '\.bats$'
         pass_filenames: true
 
       - id: forbid-continue-on-error
@@ -181,11 +119,8 @@ repos:
           underlying problem still goes unfixed. Make the step fail-fast
           instead. The only legitimate use is annotating a step that runs
           BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
+          not wrapping the tool's own exit.
         language: pygrep
-        # Match the GitHub Actions advisory-annotation prefix. We exempt
-        # this workflow file (the lint rule itself contains the literal
-        # for self-documentation) via the `exclude` regex below.
         entry: '::warning::'
         files: ^\.github/workflows/.*\.ya?ml$
         exclude: ^\.github/workflows/_required\.yml$

--- a/tests/unit/test_check_schema_hints.bats
+++ b/tests/unit/test_check_schema_hints.bats
@@ -209,6 +209,48 @@ apiVersion: myrmidons/v1
 }
 
 # ---------------------------------------------------------------------------
+# Issue #465: .yml extension is also covered (parity with .yaml)
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: .yml file with correct canonical hint exits 0" {
+    file="$(_write_yaml correct.yml '# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "check-schema-hints: .yml file with missing hint exits 1" {
+    file="$(_write_yaml missing.yml 'apiVersion: myrmidons/v1
+kind: Agent
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or malformed"* ]]
+    [[ "$output" == *"missing.yml"* ]]
+}
+
+@test "check-schema-hints: default scan picks up .yml fixtures under agents/" {
+    # Stage a fixture under a synthetic REPO_ROOT to verify the default
+    # `find -name "*.yaml" -o -name "*.yml"` glob in check-schema-hints.sh
+    # also reports .yml files (issue #465).
+    fake_root="${TMP_DIR}/fakerepo"
+    mkdir -p "${fake_root}/agents/hermes" "${fake_root}/fleets"
+    # Place a bad .yml file (missing hint) so the scan must surface it.
+    printf 'apiVersion: myrmidons/v1\n' > "${fake_root}/agents/hermes/bad.yml"
+    # Copy the checker to a sibling scripts/ dir so its REPO_ROOT resolution
+    # (parent of SCRIPT_DIR) lands on fake_root.
+    mkdir -p "${fake_root}/scripts"
+    cp "$CHECKER" "${fake_root}/scripts/check-schema-hints.sh"
+    run bash "${fake_root}/scripts/check-schema-hints.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bad.yml"* ]]
+    [[ "$output" == *"missing or malformed"* ]]
+}
+
+# ---------------------------------------------------------------------------
 # Regression guard: real repo default scan exits 0
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #465.

- Backfills bats unit tests proving `scripts/check-schema-hints.sh` covers `.yml`-extension files at parity with `.yaml`.
- The script's default `find` glob (`-name "*.yaml" -o -name "*.yml"`) and the `myrmidons-schema-hints` pre-commit `files:` regex (`\.ya?ml$`) already supported both extensions; this change locks the behavior down with explicit tests.

## Stacking note

This branch is part of a stack on top of `cleanup/c4-remove-meta-tooling`. Targets `main` directly per task instructions; will rebase as PRs #730-#733 land.

## Test plan

- [ ] `bats tests/unit/test_check_schema_hints.bats` passes locally
- [ ] `pre-commit run myrmidons-schema-hints --all-files` clean
- [ ] CI parity job green