### PR TITLE
docs(security): document scan blocking rationale (#568)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: gitleaks-system
         pass_filenames: false
 
-  # Myrmidons dataset validators
+  # Myrmidons schema validation
   - repo: local
     hooks:
       - id: myrmidons-validate
@@ -59,12 +59,33 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets|schemas|tests)/'
 
+      - id: check-xtrace-exposure
+        name: Check for unguarded xtrace auth exposure in curl calls
+        language: script
+        entry: scripts/check-xtrace-exposure.sh
+        files: '\.sh$'
+        pass_filenames: false
+
+      - id: check-adr-index
+        name: ADR README index completeness
+        language: script
+        entry: scripts/check-adr-index.sh
+        pass_filenames: false
+        files: ^docs/adr/.*\.md$
+
       - id: myrmidons-doc-drift
         name: Documentation drift check
         language: script
         entry: tests/detect-doc-drift.sh
         pass_filenames: false
         files: '(^(Architecture|README|CLAUDE|CONTRIBUTING)\.md$|^tests/detect-doc-drift\.sh$|^docs/(?!adr/).*\.md$)'
+
+      - id: check-duplicate-functions
+        name: Check for duplicate shell function definitions
+        entry: scripts/check-duplicate-functions.sh
+        language: script
+        types: [shell]
+        pass_filenames: false
 
       - id: myrmidons-validate-fleet-refs
         name: Fleet ref validation
@@ -73,6 +94,17 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 
+      - id: docs-crossref
+        name: CLAUDE.md → AGENTS.md cross-reference check
+        language: script
+        entry: scripts/check-docs-crossref.sh
+        files: '^(CLAUDE\.md|AGENTS\.md)$'
+        pass_filenames: false
+        # Trade-off: `files:` scopes incremental runs to CLAUDE.md/AGENTS.md changes, but
+        # `pre-commit run --all-files` (used in CI parity) always triggers all hooks
+        # regardless of file filters. The hook is fast (two greps), so the CI overhead is
+        # acceptable. always_run is intentionally omitted (defaults to false).
+
       - id: myrmidons-schema-hints
         name: Myrmidons yaml-language-server hint check
         language: system
@@ -80,12 +112,26 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
+      - id: myrmidons-changelog-gaps
+        name: Changelog gap detection
+        language: python
+        entry: python scripts/check-changelog-gaps.py
+        pass_filenames: false
+        always_run: true
+
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
+
+      - id: no-gitleaks-continue-on-error
+        name: gitleaks step must not have continue-on-error
+        language: script
+        entry: scripts/check-gitleaks-coe.sh
+        files: '^\.github/workflows/.*\.yml$'
+        pass_filenames: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
@@ -98,6 +144,22 @@ repos:
         entry: '\|\|\s*true(\s*$|\s+#)'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
+        pass_filenames: true
+
+      - id: forbid-bats-run-or-true
+        name: "forbid `run ... || true` antipattern in BATS files"
+        description: >
+          In BATS, `run COMMAND` already captures COMMAND's exit code into
+          `$status`. Appending `|| true` to the `run` line wraps it in an
+          always-zero subshell, making `$status` meaningless and silently
+          neutralising any later `[ "$status" -eq N ]` assertion. The global
+          `forbid-or-true` rule excludes `.bats` files because legitimate
+          cleanup hooks (`kill ... || true`) and command substitutions
+          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
+          rule targets only the dangerous form. See issue #507.
+        language: script
+        entry: scripts/check-bats-run-or-true.sh
+        files: '\.bats$'
         pass_filenames: true
 
       - id: forbid-continue-on-error
@@ -119,8 +181,11 @@ repos:
           underlying problem still goes unfixed. Make the step fail-fast
           instead. The only legitimate use is annotating a step that runs
           BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit.
+          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
         language: pygrep
+        # Match the GitHub Actions advisory-annotation prefix. We exempt
+        # this workflow file (the lint rule itself contains the literal
+        # for self-documentation) via the `exclude` regex below.
         entry: '::warning::'
         files: ^\.github/workflows/.*\.ya?ml$
         exclude: ^\.github/workflows/_required\.yml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: gitleaks-system
         pass_filenames: false
 
-  # Myrmidons schema validation
+  # Myrmidons dataset validators
   - repo: local
     hooks:
       - id: myrmidons-validate
@@ -59,33 +59,12 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets|schemas|tests)/'
 
-      - id: check-xtrace-exposure
-        name: Check for unguarded xtrace auth exposure in curl calls
-        language: script
-        entry: scripts/check-xtrace-exposure.sh
-        files: '\.sh$'
-        pass_filenames: false
-
-      - id: check-adr-index
-        name: ADR README index completeness
-        language: script
-        entry: scripts/check-adr-index.sh
-        pass_filenames: false
-        files: ^docs/adr/.*\.md$
-
       - id: myrmidons-doc-drift
         name: Documentation drift check
         language: script
         entry: tests/detect-doc-drift.sh
         pass_filenames: false
         files: '(^(Architecture|README|CLAUDE|CONTRIBUTING)\.md$|^tests/detect-doc-drift\.sh$|^docs/(?!adr/).*\.md$)'
-
-      - id: check-duplicate-functions
-        name: Check for duplicate shell function definitions
-        entry: scripts/check-duplicate-functions.sh
-        language: script
-        types: [shell]
-        pass_filenames: false
 
       - id: myrmidons-validate-fleet-refs
         name: Fleet ref validation
@@ -94,17 +73,6 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 
-      - id: docs-crossref
-        name: CLAUDE.md → AGENTS.md cross-reference check
-        language: script
-        entry: scripts/check-docs-crossref.sh
-        files: '^(CLAUDE\.md|AGENTS\.md)$'
-        pass_filenames: false
-        # Trade-off: `files:` scopes incremental runs to CLAUDE.md/AGENTS.md changes, but
-        # `pre-commit run --all-files` (used in CI parity) always triggers all hooks
-        # regardless of file filters. The hook is fast (two greps), so the CI overhead is
-        # acceptable. always_run is intentionally omitted (defaults to false).
-
       - id: myrmidons-schema-hints
         name: Myrmidons yaml-language-server hint check
         language: system
@@ -112,26 +80,12 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
-      - id: myrmidons-changelog-gaps
-        name: Changelog gap detection
-        language: python
-        entry: python scripts/check-changelog-gaps.py
-        pass_filenames: false
-        always_run: true
-
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
-
-      - id: no-gitleaks-continue-on-error
-        name: gitleaks step must not have continue-on-error
-        language: script
-        entry: scripts/check-gitleaks-coe.sh
-        files: '^\.github/workflows/.*\.yml$'
-        pass_filenames: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
@@ -144,22 +98,6 @@ repos:
         entry: '\|\|\s*true(\s*$|\s+#)'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
-        pass_filenames: true
-
-      - id: forbid-bats-run-or-true
-        name: "forbid `run ... || true` antipattern in BATS files"
-        description: >
-          In BATS, `run COMMAND` already captures COMMAND's exit code into
-          `$status`. Appending `|| true` to the `run` line wraps it in an
-          always-zero subshell, making `$status` meaningless and silently
-          neutralising any later `[ "$status" -eq N ]` assertion. The global
-          `forbid-or-true` rule excludes `.bats` files because legitimate
-          cleanup hooks (`kill ... || true`) and command substitutions
-          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
-          rule targets only the dangerous form. See issue #507.
-        language: script
-        entry: scripts/check-bats-run-or-true.sh
-        files: '\.bats$'
         pass_filenames: true
 
       - id: forbid-continue-on-error
@@ -181,11 +119,8 @@ repos:
           underlying problem still goes unfixed. Make the step fail-fast
           instead. The only legitimate use is annotating a step that runs
           BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
+          not wrapping the tool's own exit.
         language: pygrep
-        # Match the GitHub Actions advisory-annotation prefix. We exempt
-        # this workflow file (the lint rule itself contains the literal
-        # for self-documentation) via the `exclude` regex below.
         entry: '::warning::'
         files: ^\.github/workflows/.*\.ya?ml$
         exclude: ^\.github/workflows/_required\.yml$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,26 @@ positive.
 The CI step in `.github/workflows/_required.yml` always passes
 `--config .gitleaks.toml` so allowlist entries are applied automatically.
 
+### CI security scans: hard block vs informational
+
+Two required checks cover security: `security/secrets-scan` and
+`security/dependency-scan`. They are configured asymmetrically on purpose.
+
+- **`security/secrets-scan` (gitleaks) — hard block.** Any finding fails the
+  PR. Leaked secrets are an immediate, irrecoverable risk. The
+  `forbid-continue-on-error` and `forbid-advisory-warnings` pre-commit hooks
+  prevent anyone from downgrading this step to advisory mode.
+- **`security/dependency-scan` (pip-audit + Trivy) — informational.**
+  `pip-audit` runs with an explicit `--ignore-vuln` list and `trivy fs` runs
+  with `--exit-code 0`. Myrmidons has zero PyPI dependencies, so findings are
+  dominated by baseline `ubuntu-latest` runner-image CVEs we cannot fix from
+  this repo. Blocking PRs on transient upstream advisories would halt every
+  merge with no remediation path. Findings are tracked via dated allowlists
+  in the workflow itself.
+
+Full rationale and the regression-guard hook list:
+[`docs/branch-protection.md`](docs/branch-protection.md#ci-security-scans--blocking-rationale).
+
 ## Known gotchas
 
 ### jq 1.6: `label` is a reserved keyword

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -61,6 +61,61 @@ Expected output includes `"security/secrets-scan"` and `"security/dependency-sca
 ## Design notes
 
 - `strict: false` — stale branches may merge without rebasing; set to `true` to require branches to be up-to-date before merging.
-- `security/secrets-scan` must **not** have `continue-on-error: true` on the gitleaks step — the `forbid-continue-on-error` pre-commit hook (pygrep over all workflow files) enforces this repo-wide.
-- `security/dependency-scan` uses `|| true` on pip-audit and Trivy intentionally — those tools are informational. Only `security/secrets-scan` is a hard block.
 - Path-filtered workflows should not be added as required checks (they skip on unrelated PRs and would block merges incorrectly).
+
+## CI security scans — blocking rationale
+
+The two security required-checks behave very differently on purpose. The
+asymmetry is deliberate, not an oversight.
+
+### `security/secrets-scan` (gitleaks) — **hard block**
+
+- **What it does:** runs `gitleaks detect --source . --config .gitleaks.toml --no-git -v` over the full tree on every PR.
+- **Why it blocks:** a leaked secret in source is an immediate, irrecoverable
+  security incident — once a credential is pushed to a public-history branch it
+  must be treated as compromised even if the commit is later removed. There is
+  no acceptable "merge now, rotate later" workflow for this class of finding.
+- **No `continue-on-error` allowed.** The gitleaks step intentionally has no
+  `continue-on-error: true` and no `|| true`. Two regression guards enforce
+  this repo-wide:
+  - `forbid-continue-on-error` (pre-commit + CI) — a pygrep hook in
+    `.pre-commit-config.yaml` that blocks `continue-on-error: true` anywhere
+    under `.github/workflows/`.
+  - `forbid-advisory-warnings` (pre-commit + CI) — blocks `|| true` patterns in
+    workflow `run:` blocks so an author cannot silently downgrade gitleaks to
+    advisory mode.
+- **False positives** are handled exclusively via `.gitleaks.toml` allowlist
+  entries with `# gitleaks-allowlist: <justification>` comments. See the
+  Gitleaks allowlist section of [CLAUDE.md](../CLAUDE.md).
+
+### `security/dependency-scan` (pip-audit + Trivy) — **informational**
+
+The job is required-to-run (so the signal is visible on every PR) but the two
+scanners inside are configured to surface vulnerability findings as
+information, not as a merge block:
+
+- **`pip-audit`** runs with an explicit `--ignore-vuln <ID>` list against the
+  baseline `ubuntu-latest` runner image (issue #713). Myrmidons declares zero
+  PyPI dependencies, so every advisory pip-audit raises is in the runner image
+  itself — outside our control until `actions/runner-images` ships a refresh.
+  Blocking PRs on transient upstream runner CVEs would halt all merges with no
+  remediation available to the contributor.
+- **`Trivy filesystem scan`** runs with `--exit-code 0` (vulnerability findings
+  non-fatal). Install/extraction failures still fail the step — we want to
+  know when the scanner stops working, just not when it reports a HIGH against
+  an upstream package.
+- **Why we don't hard-block:** (a) baseline CVEs in the runner image are out
+  of our control, and (b) blocking on transient upstream advisories would
+  block every PR for reasons unrelated to the change under review.
+- **How findings are tracked:** dated allowlists in the workflow itself
+  (`--ignore-vuln` IDs with a review date — see the comment block above the
+  `pip-audit` step in `.github/workflows/_required.yml`). Each allowlisted CVE
+  carries a `review YYYY-MM-DD` marker so the list can be pruned after the
+  next runner-image refresh.
+
+### Quick reference
+
+| Job | Behaviour | Reason |
+|-----|-----------|--------|
+| `security/secrets-scan` | Hard block. Any gitleaks hit fails the PR. | Leaked secrets are irrecoverable; rotation is not a substitute for prevention. |
+| `security/dependency-scan` | Informational. `pip-audit --ignore-vuln`, `trivy --exit-code 0`. | Findings are dominated by runner-image baseline CVEs outside our control. Tracked via dated allowlists. |


### PR DESCRIPTION
## Summary

- Expand `docs/branch-protection.md` with a dedicated "CI security scans — blocking rationale" section
- Explain why `security/secrets-scan` (gitleaks) is a **hard block** while `security/dependency-scan` (pip-audit + Trivy) is **informational**
- Document the regression guards that prevent the secrets-scan step from being silently downgraded (`forbid-continue-on-error`, `forbid-advisory-warnings`)
- Cross-reference the rationale from `CLAUDE.md` so contributors land on it from either entry point

## Rationale captured

- **`security/secrets-scan`** — leaked secrets are irrecoverable; rotation is not a substitute for prevention. No `continue-on-error`, no `|| true`. Pre-commit hooks enforce this repo-wide.
- **`security/dependency-scan`** — Myrmidons declares zero PyPI dependencies, so findings are dominated by baseline `ubuntu-latest` runner-image CVEs that we cannot fix from this repo. `pip-audit --ignore-vuln <ID>` and `trivy fs --exit-code 0` keep the signal visible without blocking on transient upstream advisories. Tracked via dated allowlists in the workflow itself (see issue #713).

## Stacking

Branched from `cleanup/c4-remove-meta-tooling`. Stacks behind PRs #730–#733 (dataset-only reshape). Retarget to `main` once those merge; the doc edits are based on the post-cleanup `CLAUDE.md`.

## Test plan

- [ ] CI passes (`pre-commit run --all-files` parity job + doc-drift checks)
- [ ] Renders correctly on GitHub (anchor `#ci-security-scans--blocking-rationale` resolves from the CLAUDE.md cross-link)
- [ ] No behaviour change — pure documentation

Closes #568

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>