### PR TITLE
feat(validate): fleet-refs detect duplicate ref entries (#658)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: gitleaks-system
         pass_filenames: false
 
-  # Myrmidons dataset validators
+  # Myrmidons schema validation
   - repo: local
     hooks:
       - id: myrmidons-validate
@@ -59,12 +59,33 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets|schemas|tests)/'
 
+      - id: check-xtrace-exposure
+        name: Check for unguarded xtrace auth exposure in curl calls
+        language: script
+        entry: scripts/check-xtrace-exposure.sh
+        files: '\.sh$'
+        pass_filenames: false
+
+      - id: check-adr-index
+        name: ADR README index completeness
+        language: script
+        entry: scripts/check-adr-index.sh
+        pass_filenames: false
+        files: ^docs/adr/.*\.md$
+
       - id: myrmidons-doc-drift
         name: Documentation drift check
         language: script
         entry: tests/detect-doc-drift.sh
         pass_filenames: false
         files: '(^(Architecture|README|CLAUDE|CONTRIBUTING)\.md$|^tests/detect-doc-drift\.sh$|^docs/(?!adr/).*\.md$)'
+
+      - id: check-duplicate-functions
+        name: Check for duplicate shell function definitions
+        entry: scripts/check-duplicate-functions.sh
+        language: script
+        types: [shell]
+        pass_filenames: false
 
       - id: myrmidons-validate-fleet-refs
         name: Fleet ref validation
@@ -73,6 +94,17 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 
+      - id: docs-crossref
+        name: CLAUDE.md → AGENTS.md cross-reference check
+        language: script
+        entry: scripts/check-docs-crossref.sh
+        files: '^(CLAUDE\.md|AGENTS\.md)$'
+        pass_filenames: false
+        # Trade-off: `files:` scopes incremental runs to CLAUDE.md/AGENTS.md changes, but
+        # `pre-commit run --all-files` (used in CI parity) always triggers all hooks
+        # regardless of file filters. The hook is fast (two greps), so the CI overhead is
+        # acceptable. always_run is intentionally omitted (defaults to false).
+
       - id: myrmidons-schema-hints
         name: Myrmidons yaml-language-server hint check
         language: system
@@ -80,12 +112,26 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
+      - id: myrmidons-changelog-gaps
+        name: Changelog gap detection
+        language: python
+        entry: python scripts/check-changelog-gaps.py
+        pass_filenames: false
+        always_run: true
+
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
+
+      - id: no-gitleaks-continue-on-error
+        name: gitleaks step must not have continue-on-error
+        language: script
+        entry: scripts/check-gitleaks-coe.sh
+        files: '^\.github/workflows/.*\.yml$'
+        pass_filenames: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
@@ -98,6 +144,22 @@ repos:
         entry: '\|\|\s*true(\s*$|\s+#)'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
+        pass_filenames: true
+
+      - id: forbid-bats-run-or-true
+        name: "forbid `run ... || true` antipattern in BATS files"
+        description: >
+          In BATS, `run COMMAND` already captures COMMAND's exit code into
+          `$status`. Appending `|| true` to the `run` line wraps it in an
+          always-zero subshell, making `$status` meaningless and silently
+          neutralising any later `[ "$status" -eq N ]` assertion. The global
+          `forbid-or-true` rule excludes `.bats` files because legitimate
+          cleanup hooks (`kill ... || true`) and command substitutions
+          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
+          rule targets only the dangerous form. See issue #507.
+        language: script
+        entry: scripts/check-bats-run-or-true.sh
+        files: '\.bats$'
         pass_filenames: true
 
       - id: forbid-continue-on-error
@@ -119,8 +181,11 @@ repos:
           underlying problem still goes unfixed. Make the step fail-fast
           instead. The only legitimate use is annotating a step that runs
           BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit.
+          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
         language: pygrep
+        # Match the GitHub Actions advisory-annotation prefix. We exempt
+        # this workflow file (the lint rule itself contains the literal
+        # for self-documentation) via the `exclude` regex below.
         entry: '::warning::'
         files: ^\.github/workflows/.*\.ya?ml$
         exclude: ^\.github/workflows/_required\.yml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: gitleaks-system
         pass_filenames: false
 
-  # Myrmidons schema validation
+  # Myrmidons dataset validators
   - repo: local
     hooks:
       - id: myrmidons-validate
@@ -59,33 +59,12 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets|schemas|tests)/'
 
-      - id: check-xtrace-exposure
-        name: Check for unguarded xtrace auth exposure in curl calls
-        language: script
-        entry: scripts/check-xtrace-exposure.sh
-        files: '\.sh$'
-        pass_filenames: false
-
-      - id: check-adr-index
-        name: ADR README index completeness
-        language: script
-        entry: scripts/check-adr-index.sh
-        pass_filenames: false
-        files: ^docs/adr/.*\.md$
-
       - id: myrmidons-doc-drift
         name: Documentation drift check
         language: script
         entry: tests/detect-doc-drift.sh
         pass_filenames: false
         files: '(^(Architecture|README|CLAUDE|CONTRIBUTING)\.md$|^tests/detect-doc-drift\.sh$|^docs/(?!adr/).*\.md$)'
-
-      - id: check-duplicate-functions
-        name: Check for duplicate shell function definitions
-        entry: scripts/check-duplicate-functions.sh
-        language: script
-        types: [shell]
-        pass_filenames: false
 
       - id: myrmidons-validate-fleet-refs
         name: Fleet ref validation
@@ -94,17 +73,6 @@ repos:
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 
-      - id: docs-crossref
-        name: CLAUDE.md → AGENTS.md cross-reference check
-        language: script
-        entry: scripts/check-docs-crossref.sh
-        files: '^(CLAUDE\.md|AGENTS\.md)$'
-        pass_filenames: false
-        # Trade-off: `files:` scopes incremental runs to CLAUDE.md/AGENTS.md changes, but
-        # `pre-commit run --all-files` (used in CI parity) always triggers all hooks
-        # regardless of file filters. The hook is fast (two greps), so the CI overhead is
-        # acceptable. always_run is intentionally omitted (defaults to false).
-
       - id: myrmidons-schema-hints
         name: Myrmidons yaml-language-server hint check
         language: system
@@ -112,26 +80,12 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
-      - id: myrmidons-changelog-gaps
-        name: Changelog gap detection
-        language: python
-        entry: python scripts/check-changelog-gaps.py
-        pass_filenames: false
-        always_run: true
-
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
-
-      - id: no-gitleaks-continue-on-error
-        name: gitleaks step must not have continue-on-error
-        language: script
-        entry: scripts/check-gitleaks-coe.sh
-        files: '^\.github/workflows/.*\.yml$'
-        pass_filenames: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
@@ -144,22 +98,6 @@ repos:
         entry: '\|\|\s*true(\s*$|\s+#)'
         files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
         types: [text]
-        pass_filenames: true
-
-      - id: forbid-bats-run-or-true
-        name: "forbid `run ... || true` antipattern in BATS files"
-        description: >
-          In BATS, `run COMMAND` already captures COMMAND's exit code into
-          `$status`. Appending `|| true` to the `run` line wraps it in an
-          always-zero subshell, making `$status` meaningless and silently
-          neutralising any later `[ "$status" -eq N ]` assertion. The global
-          `forbid-or-true` rule excludes `.bats` files because legitimate
-          cleanup hooks (`kill ... || true`) and command substitutions
-          (`x=$(grep -c ... || true)`) are still allowed there. This narrower
-          rule targets only the dangerous form. See issue #507.
-        language: script
-        entry: scripts/check-bats-run-or-true.sh
-        files: '\.bats$'
         pass_filenames: true
 
       - id: forbid-continue-on-error
@@ -181,11 +119,8 @@ repos:
           underlying problem still goes unfixed. Make the step fail-fast
           instead. The only legitimate use is annotating a step that runs
           BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
+          not wrapping the tool's own exit.
         language: pygrep
-        # Match the GitHub Actions advisory-annotation prefix. We exempt
-        # this workflow file (the lint rule itself contains the literal
-        # for self-documentation) via the `exclude` regex below.
         entry: '::warning::'
         files: ^\.github/workflows/.*\.ya?ml$
         exclude: ^\.github/workflows/_required\.yml$

--- a/tests/unit/test_validate_fleet_refs.bats
+++ b/tests/unit/test_validate_fleet_refs.bats
@@ -292,3 +292,57 @@ YAML
     [ "$status" -eq 0 ]
     [[ "$output" == *"Checked: 0 refs, 0 inline agents, Errors: 0"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Test 13: fleet listing the same ref twice exits 1 with a duplicate message
+# (Issue #658)
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 1 when a ref is listed twice in the same fleet" {
+    cat > "${TMP_ROOT}/fleets/dup.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: dup-fleet
+spec:
+  agents:
+    - ref: hermes/real-agent
+    - ref: hermes/real-agent
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"duplicate ref"* ]]
+    [[ "$output" == *"hermes/real-agent"* ]]
+    [[ "$output" == *"fleets/dup.yaml"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 14: duplicate detection is scoped per-fleet — the same ref may appear
+# in two separate fleet files without triggering a failure (Issue #658).
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: same ref in two separate fleets is not a duplicate" {
+    cat > "${TMP_ROOT}/fleets/fleet-a.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: fleet-a
+spec:
+  agents:
+    - ref: hermes/real-agent
+YAML
+    cat > "${TMP_ROOT}/fleets/fleet-b.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: fleet-b
+spec:
+  agents:
+    - ref: hermes/real-agent
+YAML
+
+    run _run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"duplicate ref"* ]]
+}

--- a/tests/validate-fleet-refs.sh
+++ b/tests/validate-fleet-refs.sh
@@ -54,6 +54,10 @@ while IFS= read -r -d '' fleet_file; do
 
     echo "  ${fleet_rel} (${fleet_name}):"
 
+    # Track refs seen within THIS fleet so we can flag duplicates.
+    # Bash 4+ associative array; key = ref string, value = first index seen.
+    declare -A SEEN_REFS=()
+
     # Process each agent entry by index
     for (( idx=0; idx<agent_count; idx++ )); do
         ref="$(yq eval ".spec.agents[${idx}].ref // \"\"" "$fleet_file" 2>/dev/null || true)"
@@ -69,6 +73,16 @@ while IFS= read -r -d '' fleet_file; do
             else
                 echo "FAIL (agents/${ref}.yaml not found)"
                 ERRORS=$((ERRORS + 1))
+            fi
+
+            # Duplicate detection: a ref listed twice in the same fleet is an
+            # authoring error — the consumer would reconcile the agent against
+            # whichever entry it encountered last. Flag it loudly.
+            if [[ -n "${SEEN_REFS[$ref]+x}" ]]; then
+                echo "    FAIL (duplicate ref '${ref}' in ${fleet_rel}; first seen at index ${SEEN_REFS[$ref]}, repeated at index ${idx})"
+                ERRORS=$((ERRORS + 1))
+            else
+                SEEN_REFS[$ref]="$idx"
             fi
         else
             # --- inline agent: validate required fields ---
@@ -96,6 +110,7 @@ while IFS= read -r -d '' fleet_file; do
             fi
         fi
     done
+    unset SEEN_REFS
     echo ""
 
 done < <(find "${REPO_ROOT}/fleets" -name "*.yaml" -print0 2>/dev/null)


### PR DESCRIPTION
## Summary

- `tests/validate-fleet-refs.sh` now flags any `ref:` value that appears more than once within the same fleet YAML, naming the duplicate ref, the fleet file, and the two offending indices.
- Duplicate detection is scoped per-fleet via a per-iteration associative array — the same agent legitimately participating in two separate fleets still passes.
- Adds two bats cases (`tests/unit/test_validate_fleet_refs.bats`): positive (same ref across two fleets, passes) and negative (same ref twice in one fleet, fails with the expected message).

Closes #658.

## Stacking

Branched off `origin/cleanup/c4-remove-meta-tooling` and stacks on top of PRs #730-#733 (the C4 dataset-only reshape series). Rebase onto `main` will be straightforward once the stack merges; this change only touches `tests/validate-fleet-refs.sh` and its bats file.

Note: issues #656 and #657 are being implemented in parallel and touch the same script — they should rebase cleanly against each other since the changes are in disjoint regions.

## Test plan

- [x] `pixi run bats tests/unit/test_validate_fleet_refs.bats` — all 14 cases pass (12 pre-existing + 2 new)
- [ ] CI `Pre-commit (parity)` job green
- [ ] CI fleet-ref validation step green against the real `fleets/` tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)