### PR TITLE
chore(ci): promote Trivy version to TV_VER workflow env var

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   GITLEAKS_VERSION: "8.24.3"
+  TV_VER: "0.70.0"
 
 jobs:
   forbid-suppressions:
@@ -198,13 +199,11 @@ jobs:
       # vulnerability findings non-fatal; install/extraction failures should
       # still fail the step so we know when the scan stopped working.
       - name: Trivy filesystem scan
-        env:
-          TV_VER: "0.70.0"
         run: |
           set -euo pipefail
           base="https://github.com/aquasecurity/trivy/releases/download"
           curl -sSfL \
-            "${base}/v${TV_VER}/trivy_${TV_VER}_Linux-64bit.tar.gz" \
+            "${base}/v${{ env.TV_VER }}/trivy_${{ env.TV_VER }}_Linux-64bit.tar.gz" \
             | tar -xz -C /usr/local/bin trivy
           trivy fs --severity HIGH,CRITICAL --exit-code 0 .
 


### PR DESCRIPTION
## Summary

- Promote the Trivy version from an inline step-level `env:` to the workflow-level `env:` block in `.github/workflows/_required.yml` as `TV_VER`.
- The version is now set once at the top of the file and referenced via `${{ env.TV_VER }}`, mirroring the existing `GITLEAKS_VERSION` pattern.

Closes #558.

## Stacking note

This change touches `_required.yml`, which other Wave-D agents (PRs #730-#733 and siblings) may also be modifying in parallel. Branched off `origin/cleanup/c4-remove-meta-tooling`; rebase will sort out any conflicts on merge.

## Test plan

- [ ] CI `security/dependency-scan` job still installs Trivy `0.70.0` and the filesystem scan runs.
- [ ] `actionlint` / schema-validation pass on the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)