### PR TITLE
chore(security): annotate urllib3 CVE-2026-44431 allowlist entry (#723)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -192,7 +192,7 @@ jobs:
             --ignore-vuln CVE-2025-66471 \
             --ignore-vuln CVE-2026-21441 \
             --ignore-vuln CVE-2026-24049 \
-            --ignore-vuln CVE-2026-44431
+            --ignore-vuln CVE-2026-44431  # urllib3 < 2.7.0 — runner-image baseline; revisit after runner refresh ships urllib3 >= 2.7.0 (#723)
 
       # Trivy filesystem scan — informational. `--exit-code 0` already makes
       # vulnerability findings non-fatal; install/extraction failures should


### PR DESCRIPTION
## Summary

- Adds an inline tracking comment to the `--ignore-vuln CVE-2026-44431` line in `.github/workflows/_required.yml` referencing #723.
- The allowlist entry itself was added by PR #724 (already merged). This PR closes the cosmetic gap flagged in #723: the entry had no per-line revisit pointer, only a group-level block comment.

## Why

When the next `actions/runner-images` refresh ships `urllib3 >= 2.7.0`, the next maintainer can grep the workflow for `#723` and prune the line directly. Without the inline ref, they would have to cross-reference the block comment + issue tracker.

## Stacking

Branched off `origin/cleanup/c4-remove-meta-tooling`. Sits behind stacked PRs #730–#733. Other Wave-D PRs (#713, #563, #558, #559, #565) also touch `_required.yml`; rebase will resolve.

## Test plan

- [ ] `security/dependency-scan` (pip-audit) passes — the allowlist semantics are unchanged; the trailing `# ...` is a YAML/shell comment on the last argument of the multi-line pip-audit call.
- [ ] `actionlint` passes.

Closes #723