### PR TITLE
chore(security): pin gitleaks version reference in .gitleaks.toml (#563)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,8 @@
 # Myrmidons gitleaks configuration
-# GITLEAKS_VERSION: pinned via .github/workflows/_required.yml env.GITLEAKS_VERSION
+# Pinned version: v8.24.3 (mirrors GITLEAKS_VERSION in .github/workflows/_required.yml)
+# The workflow env var is the source of truth; this comment exists so the pre-commit hook
+# and the CI binary stay in sync. Issue #559 tracks automated skew detection between this
+# header and the workflow env var.
 # This config extends gitleaks' built-in rules and adds allowlist entries for documentation
 # examples and test fixtures that match secret patterns but are not real credentials.
 


### PR DESCRIPTION
## Summary

- Adds an explicit version-pin header in `.gitleaks.toml` that mirrors `GITLEAKS_VERSION` (currently `8.24.3`) in `.github/workflows/_required.yml`.
- The workflow env var remains the single source of truth; the config header provides a second documentation tie so the pre-commit hook and the CI binary stay in sync.
- References issue #559, which tracks automated skew detection between the two pins.

Closes #563.

## Stacking

Branched off `origin/cleanup/c4-remove-meta-tooling`. Stacks on top of PRs #730-#733.

## Test plan

- [ ] CI `Pre-commit (parity)` passes.
- [ ] CI gitleaks scan step still uses pinned `8.24.3` and the new header does not introduce a false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)