### PR TITLE
fix(precommit): run fleet-refs hook once per pre-commit invocation (#657)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,11 @@ repos:
         name: Fleet ref validation
         language: system
         entry: tests/validate-fleet-refs.sh
+        # pass_filenames: false → the hook scans the whole dataset, not
+        # individual staged files. Combined with the single hook definition,
+        # this ensures the validator runs exactly once per `pre-commit run`
+        # invocation even when a commit touches BOTH agents/*.yaml AND
+        # fleets/*.yaml in the same commit. See issue #657.
         pass_filenames: false
         files: '^(agents|fleets)/.*\.ya?ml$'
 

--- a/tests/unit/test_validate_fleet_refs.bats
+++ b/tests/unit/test_validate_fleet_refs.bats
@@ -292,3 +292,49 @@ YAML
     [ "$status" -eq 0 ]
     [[ "$output" == *"Checked: 0 refs, 0 inline agents, Errors: 0"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Test 13 (issue #657): idempotency — re-invocation under the sentinel
+# env var skips the validation rather than running it a second time.
+# This protects against duplicate hook firings within a single pre-commit
+# invocation when a commit touches BOTH agents/ AND fleets/ YAMLs.
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: skips re-run when MYRMIDONS_FLEET_REFS_VALIDATED=1 (issue #657)" {
+    cat > "${TMP_ROOT}/fleets/valid.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: valid-fleet
+spec:
+  agents:
+    - ref: hermes/real-agent
+YAML
+
+    # Simulate a re-invocation: caller already exported the sentinel.
+    MYRMIDONS_FLEET_REFS_VALIDATED=1 run bash "${TMP_ROOT}/tests/validate-fleet-refs.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already ran"* ]]
+    # The "Validating fleet ref..." banner only appears on a real run.
+    [[ "$output" != *"Validating fleet ref"* ]]
+}
+
+@test "validate-fleet-refs: still runs normally when sentinel is unset (issue #657)" {
+    cat > "${TMP_ROOT}/fleets/valid.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: valid-fleet
+spec:
+  agents:
+    - ref: hermes/real-agent
+YAML
+
+    # Explicitly unset the sentinel so a stale value from the bats parent
+    # process can never leak into this assertion.
+    unset MYRMIDONS_FLEET_REFS_VALIDATED
+    run _run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Validating fleet ref"* ]]
+    [[ "$output" != *"already ran"* ]]
+}

--- a/tests/validate-fleet-refs.sh
+++ b/tests/validate-fleet-refs.sh
@@ -20,6 +20,18 @@
 
 set -euo pipefail
 
+# Idempotency sentinel (issue #657): if this script has already run inside
+# the current pre-commit invocation (or any parent process tree that exported
+# the marker), skip the re-run. The pre-commit hook config already sets
+# `pass_filenames: false`, which should make pre-commit invoke the hook only
+# once per run, but this guard is defensive against any future regression
+# (duplicate hook id, wrapper that calls the script twice, etc.).
+if [[ "${MYRMIDONS_FLEET_REFS_VALIDATED:-}" == "1" ]]; then
+    echo "Fleet ref validation already ran in this pre-commit invocation — skipping."
+    exit 0
+fi
+export MYRMIDONS_FLEET_REFS_VALIDATED=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 


### PR DESCRIPTION
## Summary

Resolves issue #657: pre-commit hook `myrmidons-validate-fleet-refs` could appear to run twice when a commit touches both `agents/*.yaml` and `fleets/*.yaml`.

Root cause analysis: the hook already declares `pass_filenames: false`, which causes pre-commit to invoke the hook exactly once per `pre-commit run`, regardless of how many files match `files:`. Only one hook definition exists. So in practice the duplication should already be prevented — but the issue is worth a belt-and-suspenders fix plus a regression anchor.

Changes:
- **`.pre-commit-config.yaml`** — inline comment on the `myrmidons-validate-fleet-refs` hook documenting why `pass_filenames: false` is load-bearing and referencing issue #657.
- **`tests/validate-fleet-refs.sh`** — defensive idempotency sentinel (`MYRMIDONS_FLEET_REFS_VALIDATED=1`). If a wrapper / future duplicate hook id / shell loop invokes the script more than once in the same parent process tree, the second invocation short-circuits with a clear log message rather than duplicating the work.
- **`tests/unit/test_validate_fleet_refs.bats`** — two new regression tests:
  - re-invocation under the sentinel skips and prints "already ran"
  - a fresh invocation (sentinel unset) still runs normally and prints the "Validating fleet ref..." banner

## Stacking

Branched off `origin/cleanup/c4-remove-meta-tooling` — stacked on top of PRs #730-#733. Parallel Wave-D work also touched `tests/validate-fleet-refs.sh` and `tests/unit/test_validate_fleet_refs.bats` (PRs #736, #737, and the parallel #658/#656); merge conflicts will be resolved via rebase after upstream lands.

## Test plan

- [ ] CI `Pre-commit (parity)` job passes (validates `pass_filenames: false` change does not break the hook)
- [ ] CI bats job runs the two new tests in `tests/unit/test_validate_fleet_refs.bats` and they pass
- [ ] Existing 12 bats tests still pass (sentinel guard does not affect normal-run paths)
- [ ] Manual smoke: stage one agent + one fleet YAML in a single commit and confirm only one "Validating fleet ref..." banner appears

Closes #657

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>