### PR TITLE
chore(security): baseline pip-audit runner-image CVEs with 2026-08-08 review

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -144,12 +144,24 @@ jobs:
       # before merging. No advisory mode. See docs/runbooks/no-silent-failures.md
       # Bucket F.
       #
-      # Baseline runner-image CVEs allowlisted per issue #713 (review 2026-08-08).
-      # Each --ignore-vuln below corresponds to a finding in #713 against the
-      # `ubuntu-latest` baseline Python packages (pip, setuptools, requests,
-      # cryptography, twisted, urllib3, jinja2, etc.). Myrmidons declares zero
-      # PyPI dependencies, so these come from the runner image, not our source
-      # tree — revisit and prune after each `actions/runner-images` refresh.
+      # Baseline review schedule: 2026-08-08 (see #713)
+      #
+      # The --ignore-vuln allowlist below is the runner-image baseline captured
+      # in issue #713 against the `ubuntu-latest` baseline Python packages
+      # (certifi, configobj, cryptography, idna, jinja2, pip, pyasn1, pygments,
+      # pyjwt, pyopenssl, requests, setuptools, twisted, urllib3, wheel).
+      # Myrmidons declares zero PyPI dependencies, so these CVEs come from the
+      # GitHub runner image, not our source tree.
+      #
+      # On 2026-08-08 (or sooner if `actions/runner-images` ships a refresh):
+      #   1. Re-run pip-audit WITHOUT --ignore-vuln on a fresh runner.
+      #   2. Prune any IDs below that are no longer reported (drop the line).
+      #   3. If NEW IDs appear, open a follow-up issue rather than blind-adding.
+      #   4. Bump this review-marker date or close #713 if the list is empty.
+      #
+      # Each ID below is tracked by issue #713; the consolidated marker above
+      # is intentional (per-line tracking refs were tried in earlier iterations
+      # but break shell line-continuation with inline `# comment \` syntax).
       - name: pip-audit
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- Adds an explicit dated review-marker header above the pip-audit `--ignore-vuln` allowlist:
  `# Baseline review schedule: 2026-08-08 (see #713)`
- Documents a numbered re-audit checklist for the review date (re-run without `--ignore-vuln` on a fresh runner, prune IDs no longer reported, open a follow-up for any new IDs).
- The set of allowlisted CVE IDs is unchanged — this is a documentation-only edit.

A consolidated header marker (rather than per-line `(#713)` tracking comments) was chosen because inline `# comment \` after each `--ignore-vuln` line would consume the trailing backslash and break shell line continuation. PR #739 already added the only safe inline tracking comment (on the final, no-continuation `CVE-2026-44431` line).

## Stacking

- Branched off `origin/cleanup/c4-remove-meta-tooling` (stacked on the PR #730-#733 chain).
- Adjacent to PRs #739 / #738 / #558 which edit the same pip-audit step. No conflicts expected — this PR only touches the comment block above the `run:` block.

## Test plan

- [ ] CI `security/dependency-scan` job still passes (no behavioural change to pip-audit args).
- [ ] `yamllint` clean (only comment lines added).
- [ ] Header text renders with the literal string "Baseline review schedule: 2026-08-08 (see #713)".

Closes #713

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)