### PR TITLE
feat(lint): enforce gitleaks allowlist justification annotations (#561)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,13 @@ repos:
         pass_filenames: true
         files: ^(agents|fleets)/.*\.ya?ml$
 
+      - id: check-gitleaks-annotations
+        name: Gitleaks allowlist justification check
+        language: system
+        entry: scripts/check-gitleaks-annotations.sh
+        pass_filenames: false
+        files: ^\.gitleaks\.toml$
+
       - id: myrmidons-lint-agents-md
         name: AGENTS.md required sections
         language: script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ talk to Agamemnon or any other runtime.
 |--------|----------------|
 | `scripts/check-dangerous-flags.sh` | `--dangerously-skip-permissions` requires inline suppression with justification |
 | `scripts/check-schema-hints.sh` | Every agent/fleet YAML carries a `yaml-language-server` schema-hint comment |
+| `scripts/check-gitleaks-annotations.sh` | Every `.gitleaks.toml` allowlist entry carries a `# gitleaks-allowlist:` justification |
 | `scripts/lint-names.sh` | `metadata.name` uniqueness across all agent YAMLs |
 | `scripts/lint-agents-md.sh` | `AGENTS.md` has the required sections |
 | `scripts/lint-shell.sh` | Shellcheck over every shell file in this repo |
@@ -218,6 +219,11 @@ paths = [
 Every allowlist entry **must** include an inline comment
 `# gitleaks-allowlist: <justification>` describing why the match is a false
 positive.
+
+**Lint guard:** `scripts/check-gitleaks-annotations.sh` enforces this policy by
+scanning every entry inside an `[allowlist]` block of `.gitleaks.toml`. Runs as
+a pre-commit hook (`check-gitleaks-annotations`) and in CI via pre-commit
+parity.
 
 The CI step in `.github/workflows/_required.yml` always passes
 `--config .gitleaks.toml` so allowlist entries are applied automatically.

--- a/scripts/check-gitleaks-annotations.sh
+++ b/scripts/check-gitleaks-annotations.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/check-gitleaks-annotations.sh — lint guard for .gitleaks.toml allowlist entries
+#
+# Enforces the project policy that every regex / path / commit / fingerprint
+# entry inside a `[allowlist]` block of .gitleaks.toml carries an inline
+# justification annotation:
+#
+#   '''your-placeholder-token''',   # gitleaks-allowlist: <justification>
+#
+# Entries without a non-empty justification cause this script to exit non-zero
+# and print the offending line numbers.
+#
+# Usage:
+#   ./scripts/check-gitleaks-annotations.sh                  # lint <repo>/.gitleaks.toml
+#   ./scripts/check-gitleaks-annotations.sh path/to/.gitleaks.toml ...
+#
+# Exit codes:
+#   0 = no violations
+#   1 = violations found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+VIOLATIONS=0
+FILES_CHECKED=0
+
+# Collect files to scan
+if [[ $# -gt 0 ]]; then
+    FILES=("$@")
+else
+    FILES=("${REPO_ROOT}/.gitleaks.toml")
+fi
+
+# Recognises an entry line that requires a justification annotation.
+#
+# Entries inside `regexes = [ ... ]`, `paths = [ ... ]`, `commits = [ ... ]`,
+# or `fingerprints = [ ... ]` arrays look like one of:
+#
+#     '''regex-or-path''',
+#     '''regex-or-path'''
+#     "double-quoted-value",
+#     "double-quoted-value"
+#     abcdef1234567890,                   # 40-char SHA commit hash
+#     "abcdef..:rule-id:path",            # gitleaks fingerprint string
+#
+# The conservative trigger: any non-blank, non-comment, non-bracket, non-header,
+# non-`key = value` line inside an [allowlist] section is treated as a data
+# entry that must carry an annotation.
+_is_entry_line() {
+    local content="$1"
+    local trimmed="${content#"${content%%[![:space:]]*}"}"
+    [[ -z "$trimmed" ]] && return 1
+    [[ "$trimmed" == "#"* ]] && return 1
+    [[ "$trimmed" == "["* ]] && return 1
+    [[ "$trimmed" == "]"* ]] && return 1
+    # Skip key = value assignments (e.g. `description = "..."`, `regexes = [`).
+    if [[ "$trimmed" =~ ^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*= ]]; then
+        return 1
+    fi
+    return 0
+}
+
+for file in "${FILES[@]}"; do
+    if [[ ! -f "$file" ]]; then
+        echo "ERROR: ${file}: file not found"
+        VIOLATIONS=$((VIOLATIONS + 1))
+        continue
+    fi
+
+    FILES_CHECKED=$((FILES_CHECKED + 1))
+
+    in_allowlist=0
+    lineno=0
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        lineno=$((lineno + 1))
+
+        # Track which TOML section we're in. A line like `[allowlist]` or
+        # `[[allowlist]]` enters; any other top-level `[section]` exits.
+        if [[ "$line" =~ ^[[:space:]]*\[\[?allowlist(\..*)?\]?\][[:space:]]*$ ]]; then
+            in_allowlist=1
+            continue
+        elif [[ "$line" =~ ^[[:space:]]*\[ ]]; then
+            in_allowlist=0
+            continue
+        fi
+
+        [[ $in_allowlist -eq 1 ]] || continue
+        _is_entry_line "$line" || continue
+
+        # Require `# gitleaks-allowlist: <non-empty>` on the same line.
+        if [[ "$line" =~ \#[[:space:]]*gitleaks-allowlist:[[:space:]]*([^[:space:]].*)?$ ]]; then
+            justification="${BASH_REMATCH[1]:-}"
+            justification="${justification%"${justification##*[![:space:]]}"}"
+            if [[ -z "$justification" ]]; then
+                echo "ERROR: ${file}:${lineno}: empty gitleaks-allowlist justification."
+                echo "       Expected:  # gitleaks-allowlist: <non-empty justification>"
+                echo "       Line:      ${line}"
+                VIOLATIONS=$((VIOLATIONS + 1))
+            fi
+        else
+            echo "ERROR: ${file}:${lineno}: allowlist entry missing # gitleaks-allowlist: annotation."
+            echo "       Expected suffix:  # gitleaks-allowlist: <justification>"
+            echo "       Line:             ${line}"
+            VIOLATIONS=$((VIOLATIONS + 1))
+        fi
+    done < "$file"
+done
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+    echo ""
+    echo "check-gitleaks-annotations: ${VIOLATIONS} violation(s) found in ${FILES_CHECKED} file(s)."
+    echo "Add '# gitleaks-allowlist: <justification>' to each allowlist entry in .gitleaks.toml."
+    exit 1
+fi
+
+exit 0

--- a/tests/unit/test_check_gitleaks_annotations.bats
+++ b/tests/unit/test_check_gitleaks_annotations.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+# tests/unit/test_check_gitleaks_annotations.bats
+#
+# Issue #561: lint guard for .gitleaks.toml allowlist annotation policy.
+#
+# Verifies scripts/check-gitleaks-annotations.sh enforces that every regex /
+# path / commit / fingerprint entry inside an [allowlist] block carries an
+# inline `# gitleaks-allowlist: <non-empty justification>` comment.
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-gitleaks-annotations.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: write content to a .gitleaks.toml fixture under TMP_DIR.
+_write_toml() {
+    local name="$1"
+    local content="$2"
+    local path="${TMP_DIR}/${name}"
+    printf '%s' "$content" > "$path"
+    printf '%s\n' "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Test: fully-annotated fixture passes (exit 0)
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-annotations: compliant fixture exits 0" {
+    file="$(_write_toml compliant.toml '# Test fixture
+title = "Myrmidons gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures and documentation examples"
+regexes = [
+  '"'"''"'"''"'"'your-token-here'"'"''"'"''"'"',         # gitleaks-allowlist: placeholder token in CLAUDE.md
+  '"'"''"'"''"'"'fake-api-key'"'"''"'"''"'"',            # gitleaks-allowlist: doc example, not a real credential
+]
+paths = [
+  '"'"''"'"''"'"'tests/.*'"'"''"'"''"'"',                # gitleaks-allowlist: test fixtures contain fake secrets
+]
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test: missing annotation on a regex entry → exit 1 with line number
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-annotations: missing annotation fails with line number" {
+    file="$(_write_toml missing.toml '# Test fixture
+title = "Myrmidons gitleaks configuration"
+
+[allowlist]
+description = "Test fixtures"
+regexes = [
+  '"'"''"'"''"'"'your-token-here'"'"''"'"''"'"',         # gitleaks-allowlist: ok justification
+  '"'"''"'"''"'"'missing-annotation'"'"''"'"''"'"',
+]
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing # gitleaks-allowlist: annotation"* ]]
+    # The offending entry is on line 8 of the fixture above.
+    [[ "$output" == *":8:"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: annotation present but empty → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-annotations: empty justification fails" {
+    file="$(_write_toml empty.toml '[allowlist]
+description = "Test fixtures"
+regexes = [
+  '"'"''"'"''"'"'token'"'"''"'"''"'"',                   # gitleaks-allowlist:
+]
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"empty gitleaks-allowlist justification"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: entries outside [allowlist] are not enforced
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-annotations: entries outside [allowlist] are ignored" {
+    file="$(_write_toml outside.toml '[extend]
+useDefault = true
+
+[[rules]]
+id = "my-rule"
+regex = '"'"''"'"''"'"'some-pattern'"'"''"'"''"'"'
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test: paths entries also require annotations
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-annotations: paths entries without annotation fail" {
+    file="$(_write_toml paths.toml '[allowlist]
+description = "Test fixtures"
+paths = [
+  '"'"''"'"''"'"'tests/.*'"'"''"'"''"'"',
+]
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing # gitleaks-allowlist: annotation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: real repo .gitleaks.toml passes (regression guard for issue #562)
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-annotations: real repository .gitleaks.toml passes" {
+    run bash "$CHECKER" "${SCRIPT_DIR}/.gitleaks.toml"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/check-gitleaks-annotations.sh`, a lint guard that requires every regex / path / commit / fingerprint entry inside an `[allowlist]` block of `.gitleaks.toml` to carry an inline `# gitleaks-allowlist: <justification>` comment. Empty justifications fail; entries outside `[allowlist]` are ignored.
- Wires the script as a pre-commit hook (`check-gitleaks-annotations`, `files: ^\.gitleaks\.toml$`, `pass_filenames: false`). CI picks it up automatically via the pre-commit parity job.
- Documents the new guard under the existing **Gitleaks allowlist** section in `CLAUDE.md`, matching the one-sentence + lint-guard pattern used by `check-dangerous-flags.sh` and `check-schema-hints.sh`.
- Adds `tests/unit/test_check_gitleaks_annotations.bats` (6 cases): compliant fixture, missing annotation (line-number assertion), empty justification, entries outside `[allowlist]`, `paths` enforcement, and a regression guard against the real `.gitleaks.toml`.

The current `.gitleaks.toml` is already fully annotated (verified in #562), so this hook passes on day 1.

Closes #561.

## Stacking

Branched off `origin/cleanup/c4-remove-meta-tooling`; stacks on top of #730-#733.

## Test plan

- [ ] `bats tests/unit/test_check_gitleaks_annotations.bats` — all 6 cases pass locally.
- [ ] `./scripts/check-gitleaks-annotations.sh` — exits 0 on the repository's `.gitleaks.toml`.
- [ ] `pre-commit run check-gitleaks-annotations --all-files` (CI parity) — passes.
- [ ] Manually mutate `.gitleaks.toml` to drop an annotation and confirm the hook fails with the correct line number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)