### PR TITLE
docs(security): document incremental add for required status checks

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -22,6 +22,8 @@ All are defined in `.github/workflows/_required.yml`.
 
 ## Restoring required checks after a protection reset
 
+> **Tip:** If only adding new required checks (not restoring after a wipe), use the incremental snippet below instead — it preserves any extras already configured.
+
 If branch protection is wiped (e.g. after a repo transfer or settings reset), run:
 
 ```bash
@@ -48,6 +50,25 @@ gh api --method PATCH \
 }
 EOF
 ```
+
+### Incrementally adding a required check
+
+When you only need to add one or more new contexts (e.g. registering
+`security/secrets-scan` and `security/dependency-scan` without disturbing
+anything else already configured), use `jq` to merge the new entries into the
+current list rather than rewriting it:
+
+```bash
+# Add security jobs without overwriting existing required checks
+gh api repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
+  | jq '.contexts += ["security/secrets-scan", "security/dependency-scan"] | .contexts |= unique' \
+  | gh api --method PATCH \
+    repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
+    --input -
+```
+
+The `| .contexts |= unique` step makes the command idempotent — re-running it
+will not produce duplicate entries.
 
 ## Verifying current required checks
 


### PR DESCRIPTION
## Summary

- Adds an "Incrementally adding a required check" snippet to `docs/branch-protection.md` showing how to register `security/secrets-scan` and `security/dependency-scan` (or any new context) without overwriting the existing required-checks list.
- Adds a one-line tip at the top of the restore-after-reset section pointing operators at the incremental helper when they don't actually need a full restore.
- The full restore snippet already lists both security jobs; this PR just fills in the routine "add one" path.

## Context

Closes #565. The actual `gh api PATCH` invocation that wires `security/secrets-scan` and `security/dependency-scan` into the live branch-protection ruleset on `main` is a **manual admin step** (only @mvillmow has admin rights). The deliverable here is the documented runbook — once merged, the admin can paste the new snippet to register the checks.

Stacked on top of #730, #731, #732, #733 (branched from `origin/cleanup/c4-remove-meta-tooling`).

## Test plan

- [ ] Render `docs/branch-protection.md` and confirm the tip + new section appear in the right place
- [ ] After merge, admin runs the incremental snippet against `repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks`
- [ ] Verify with `gh api .../required_status_checks | jq '.contexts'` that both security contexts appear