### PR TITLE
feat(ci): detect gitleaks version skew across pin sites (#559)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,8 +1,12 @@
 # Myrmidons gitleaks configuration
 # Pinned version: v8.24.3 (mirrors GITLEAKS_VERSION in .github/workflows/_required.yml)
 # The workflow env var is the source of truth; this comment exists so the pre-commit hook
-# and the CI binary stay in sync. Issue #559 tracks automated skew detection between this
-# header and the workflow env var.
+# and the CI binary stay in sync. This pin is enforced across three sites by
+# scripts/check-gitleaks-version-skew.sh:
+#   1. .github/workflows/_required.yml — env.GITLEAKS_VERSION
+#   2. .gitleaks.toml — the "Pinned version:" comment above (this file)
+#   3. .pre-commit-config.yaml — gitleaks-system hook rev
+# When bumping the version, update all three sites in the same commit. See issue #559.
 # This config extends gitleaks' built-in rules and adds allowlist entries for documentation
 # examples and test fixtures that match secret patterns but are not real credentials.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
 
   # Secret scanning — uses system-installed gitleaks binary (avoids Go build)
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
+    rev: v8.24.3
     hooks:
       - id: gitleaks-system
         pass_filenames: false
@@ -98,6 +98,18 @@ repos:
         entry: scripts/lint-agents-md.sh
         files: ^AGENTS\.md$
         pass_filenames: false
+
+      - id: check-gitleaks-version-skew
+        name: "check gitleaks version pin consistency"
+        description: >
+          The gitleaks binary version is pinned in three sites — the CI
+          workflow env, .gitleaks.toml header, and the pre-commit hook rev.
+          This hook fails if any drift apart. See issue #559.
+        language: system
+        entry: scripts/check-gitleaks-version-skew.sh
+        files: '^(\.gitleaks\.toml|\.github/workflows/_required\.yml|\.pre-commit-config\.yaml)$'
+        pass_filenames: false
+        always_run: true
 
       - id: forbid-or-true
         name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"

--- a/scripts/check-gitleaks-version-skew.sh
+++ b/scripts/check-gitleaks-version-skew.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# scripts/check-gitleaks-version-skew.sh — detect skew across gitleaks version pins.
+#
+# Issue #559: the gitleaks binary version is pinned in THREE places. If they
+# drift out of sync, CI and pre-commit scan with different rulesets, which
+# means PR checks and merges can produce different findings.
+#
+# The three pin sites are:
+#   1. .github/workflows/_required.yml — env.GITLEAKS_VERSION
+#   2. .gitleaks.toml                  — header comment "Pinned version: vX.Y.Z"
+#   3. .pre-commit-config.yaml         — rev: under the gitleaks-system hook
+#
+# This script extracts each pinned version, normalises them (strips a leading
+# "v"), and exits non-zero with a diff if they disagree.
+#
+# Usage:
+#   ./scripts/check-gitleaks-version-skew.sh
+#
+# Optional environment overrides (used by the BATS suite):
+#   WORKFLOW_FILE      — path to _required.yml          (default: .github/workflows/_required.yml)
+#   GITLEAKS_TOML      — path to .gitleaks.toml         (default: .gitleaks.toml)
+#   PRECOMMIT_CONFIG   — path to .pre-commit-config.yaml (default: .pre-commit-config.yaml)
+#
+# Exit codes:
+#   0 = all three pins agree
+#   1 = skew detected, or a pin could not be extracted
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+WORKFLOW_FILE="${WORKFLOW_FILE:-${REPO_ROOT}/.github/workflows/_required.yml}"
+GITLEAKS_TOML="${GITLEAKS_TOML:-${REPO_ROOT}/.gitleaks.toml}"
+PRECOMMIT_CONFIG="${PRECOMMIT_CONFIG:-${REPO_ROOT}/.pre-commit-config.yaml}"
+
+errors=0
+
+_fail() {
+    echo "ERROR: $*" >&2
+    errors=$((errors + 1))
+}
+
+# ---------------------------------------------------------------------------
+# 1. Workflow env.GITLEAKS_VERSION
+# ---------------------------------------------------------------------------
+# Matches:   GITLEAKS_VERSION: "8.24.3"
+# Or:        GITLEAKS_VERSION: 8.24.3
+workflow_version=""
+if [[ -f "$WORKFLOW_FILE" ]]; then
+    # Tolerate grep no-match: use a non-pipefail subshell.
+    workflow_version="$(set +o pipefail; \
+        grep -E '^[[:space:]]+GITLEAKS_VERSION:' "$WORKFLOW_FILE" \
+        | head -n 1 \
+        | sed -E 's/^[[:space:]]+GITLEAKS_VERSION:[[:space:]]*"?v?([0-9]+\.[0-9]+\.[0-9]+)"?[[:space:]]*$/\1/')"
+else
+    _fail "workflow file not found: ${WORKFLOW_FILE}"
+fi
+if [[ -z "$workflow_version" || "$workflow_version" == *"GITLEAKS_VERSION"* ]]; then
+    _fail "could not extract GITLEAKS_VERSION from ${WORKFLOW_FILE}"
+    workflow_version=""
+fi
+
+# ---------------------------------------------------------------------------
+# 2. .gitleaks.toml header "Pinned version: vX.Y.Z"
+# ---------------------------------------------------------------------------
+toml_version=""
+if [[ -f "$GITLEAKS_TOML" ]]; then
+    toml_version="$(set +o pipefail; \
+        grep -E '^#[[:space:]]*Pinned version:[[:space:]]*v?[0-9]+\.[0-9]+\.[0-9]+' "$GITLEAKS_TOML" \
+        | head -n 1 \
+        | sed -E 's/^#[[:space:]]*Pinned version:[[:space:]]*v?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')"
+else
+    _fail "gitleaks config not found: ${GITLEAKS_TOML}"
+fi
+if [[ -z "$toml_version" ]]; then
+    _fail "could not extract 'Pinned version: vX.Y.Z' header comment from ${GITLEAKS_TOML}"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. .pre-commit-config.yaml gitleaks rev
+# ---------------------------------------------------------------------------
+# Find the rev: line immediately following the gitleaks repo declaration.
+precommit_version=""
+if [[ -f "$PRECOMMIT_CONFIG" ]]; then
+    precommit_version="$(
+        awk '
+            /^[[:space:]]*-[[:space:]]*repo:[[:space:]]*https:\/\/github\.com\/gitleaks\/gitleaks[[:space:]]*$/ {
+                in_block = 1
+                next
+            }
+            in_block && /^[[:space:]]*rev:[[:space:]]*/ {
+                line = $0
+                sub(/^[[:space:]]*rev:[[:space:]]*/, "", line)
+                sub(/[[:space:]]*(#.*)?$/, "", line)
+                sub(/^v/, "", line)
+                print line
+                exit
+            }
+        ' "$PRECOMMIT_CONFIG"
+    )"
+else
+    _fail "pre-commit config not found: ${PRECOMMIT_CONFIG}"
+fi
+if [[ -z "$precommit_version" ]]; then
+    _fail "could not extract gitleaks rev from ${PRECOMMIT_CONFIG}"
+fi
+
+# ---------------------------------------------------------------------------
+# Compare
+# ---------------------------------------------------------------------------
+if [[ $errors -gt 0 ]]; then
+    exit 1
+fi
+
+if [[ "$workflow_version" == "$toml_version" && "$toml_version" == "$precommit_version" ]]; then
+    echo "OK: gitleaks version aligned across all pin sites: v${workflow_version}"
+    exit 0
+fi
+
+echo "ERROR: gitleaks version skew detected across pin sites:"
+echo ""
+printf '  %-30s %s\n' ".github/workflows/_required.yml" "v${workflow_version}"
+printf '  %-30s %s\n' ".gitleaks.toml" "v${toml_version}"
+printf '  %-30s %s\n' ".pre-commit-config.yaml" "v${precommit_version}"
+echo ""
+echo "All three sites must pin the same gitleaks version. See issue #559."
+echo "When bumping gitleaks, update:"
+echo "  - env.GITLEAKS_VERSION in .github/workflows/_required.yml"
+echo "  - the 'Pinned version: vX.Y.Z' comment at the top of .gitleaks.toml"
+echo "  - the rev: under the gitleaks-system hook in .pre-commit-config.yaml"
+exit 1

--- a/tests/unit/test_check_gitleaks_version_skew.bats
+++ b/tests/unit/test_check_gitleaks_version_skew.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+# tests/unit/test_check_gitleaks_version_skew.bats
+#
+# Issue #559: verify the gitleaks-version-skew detector catches each axis of
+# disagreement and accepts aligned pins.
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-gitleaks-version-skew.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+    mkdir -p "${TMP_DIR}/.github/workflows"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: write the three pin sites with the given versions.
+_write_fixtures() {
+    local workflow_v="$1"
+    local toml_v="$2"
+    local precommit_v="$3"
+
+    cat > "${TMP_DIR}/.github/workflows/_required.yml" <<EOF
+name: Required Checks
+env:
+  GITLEAKS_VERSION: "${workflow_v}"
+EOF
+
+    cat > "${TMP_DIR}/.gitleaks.toml" <<EOF
+# Myrmidons gitleaks configuration
+# Pinned version: v${toml_v}
+title = "fixture"
+EOF
+
+    cat > "${TMP_DIR}/.pre-commit-config.yaml" <<EOF
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v${precommit_v}
+    hooks:
+      - id: gitleaks-system
+EOF
+}
+
+_run_checker() {
+    WORKFLOW_FILE="${TMP_DIR}/.github/workflows/_required.yml" \
+        GITLEAKS_TOML="${TMP_DIR}/.gitleaks.toml" \
+        PRECOMMIT_CONFIG="${TMP_DIR}/.pre-commit-config.yaml" \
+        bash "$CHECKER" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Happy path: all three sites agree → exit 0
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: aligned versions exit 0" {
+    _write_fixtures "8.24.3" "8.24.3" "8.24.3"
+    run _run_checker
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"aligned"* ]]
+    [[ "$output" == *"v8.24.3"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Skew axis 1: workflow drifts from the others
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: workflow drift exits 1" {
+    _write_fixtures "8.30.1" "8.24.3" "8.24.3"
+    run _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"skew detected"* ]]
+    [[ "$output" == *"v8.30.1"* ]]
+    [[ "$output" == *"v8.24.3"* ]]
+    [[ "$output" == *"_required.yml"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Skew axis 2: .gitleaks.toml drifts from the others
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: toml drift exits 1" {
+    _write_fixtures "8.24.3" "8.30.1" "8.24.3"
+    run _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"skew detected"* ]]
+    [[ "$output" == *".gitleaks.toml"* ]]
+    [[ "$output" == *"v8.30.1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Skew axis 3: pre-commit rev drifts from the others
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: pre-commit rev drift exits 1" {
+    _write_fixtures "8.24.3" "8.24.3" "8.30.1"
+    run _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"skew detected"* ]]
+    [[ "$output" == *".pre-commit-config.yaml"* ]]
+    [[ "$output" == *"v8.30.1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# All three differ
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: three-way skew exits 1" {
+    _write_fixtures "8.20.0" "8.24.3" "8.30.1"
+    run _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v8.20.0"* ]]
+    [[ "$output" == *"v8.24.3"* ]]
+    [[ "$output" == *"v8.30.1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Missing 'Pinned version:' comment in toml → error (cannot validate)
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: missing toml pin comment exits 1" {
+    _write_fixtures "8.24.3" "8.24.3" "8.24.3"
+    cat > "${TMP_DIR}/.gitleaks.toml" <<EOF
+# Myrmidons gitleaks configuration
+# No pin comment here
+title = "fixture"
+EOF
+    run _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Pinned version"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workflow accepts unquoted version
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: unquoted workflow version parses correctly" {
+    _write_fixtures "8.24.3" "8.24.3" "8.24.3"
+    cat > "${TMP_DIR}/.github/workflows/_required.yml" <<EOF
+env:
+  GITLEAKS_VERSION: 8.24.3
+EOF
+    run _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Regression guard: real repo files are aligned
+# ---------------------------------------------------------------------------
+
+@test "gitleaks-version-skew: real repo pins are aligned" {
+    run bash "$CHECKER"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/check-gitleaks-version-skew.sh` — extracts the gitleaks pin from `.github/workflows/_required.yml` (`env.GITLEAKS_VERSION`), `.gitleaks.toml` (header `Pinned version: vX.Y.Z` comment), and `.pre-commit-config.yaml` (`gitleaks-system` hook `rev:`) and fails with a three-column diff when any disagree.
- Wires the script into `.pre-commit-config.yaml` as `check-gitleaks-version-skew` with `always_run: true` so drift is caught on every commit.
- Realigns the pins as part of the same change: `.gitleaks.toml` gains an explicit `Pinned version: v8.24.3` header (consumed by the script), and the pre-commit `rev:` is moved from `v8.30.1` down to `v8.24.3` to match the workflow env, which CLAUDE.md documents as the source-of-truth pin.
- BATS coverage in `tests/unit/test_check_gitleaks_version_skew.bats` exercises each skew axis separately, the missing-comment failure mode, and a regression guard that the real repo pins are aligned.

## Stacking & relation to other PRs

- Branched off `origin/cleanup/c4-remove-meta-tooling`, so stacks behind PRs #730–#733.
- Complements #740 (which landed the `.gitleaks.toml` pin reference), and #743 / #563 in the broader gitleaks-hardening series.

## Test plan

- [x] `bats tests/unit/test_check_gitleaks_version_skew.bats` — all 8 cases pass locally.
- [x] `./scripts/check-gitleaks-version-skew.sh` against the real repo exits 0 (`OK: gitleaks version aligned across all pin sites: v8.24.3`).
- [x] Manual fixture runs confirm exit 1 + a readable three-column diff for each individual skew axis (workflow / toml / pre-commit) and for three-way disagreement.
- [x] `pixi run --environment lint lint-shell` clean on the new script.
- [ ] CI green (pre-commit-parity, unit-tests, required checks).

Closes #559

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>