### PR TITLE
docs(readme): standardize CI/CD badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Myrmidons
 
+[![Lint](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lint.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lint.yml)
 [![Validate YAML](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/validate.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/validate.yml)
+[![Test](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/test.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/test.yml)
+[![Lock Check](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lock-check.yml/badge.svg)](https://github.com/HomericIntelligence/Myrmidons/actions/workflows/lock-check.yml)
 
 **The agent dataset for the HomericIntelligence mesh.**
 


### PR DESCRIPTION
Part of HomericIntelligence/Odysseus#352

Add CI/CD workflow badges for Lint, Test, and Lock Check to the README, matching the ecosystem-wide badge standardization convention. The existing Validate YAML badge is retained; three new badges are added for full workflow coverage.

Generated with [Claude Code](https://claude.com/claude-code)