### PR TITLE
feat(agents): HMAS mesh worker pool manifests for the ADR-013 slice

### DIFF
--- a/agents/hermes/mesh-pipeline-chief-architect.yaml
+++ b/agents/hermes/mesh-pipeline-chief-architect.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+# HMAS mesh pool worker (Odysseus ADR-013): pipeline.chief-architect.
+# Serves hi.myrmidon.pipeline.chief-architect.task.> — epic decomposition:
+# plans the epic's children and ingests the brief via POST /v1/briefs.
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: mesh-pipeline-chief-architect
+  host: hermes
+spec:
+  label: Mesh-Pipeline-Chief-Architect
+  program: claude-code
+  model: opus
+  workingDirectory: /home/mvillmow/Agents/mesh
+  programArgs: ""
+  taskDescription: "HMAS pipeline-pool chief-architect (planner) myrmidon (ADR-013 slice)"
+  tags:
+    - mesh
+    - "pool:pipeline.chief-architect"
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-mesh:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/mesh-pipeline-task-agent.yaml
+++ b/agents/hermes/mesh-pipeline-task-agent.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+# HMAS mesh pool worker (Odysseus ADR-013): pipeline.task-agent.
+# Serves hi.myrmidon.pipeline.task-agent.task.> — implements individual
+# issues to merged-ready PRs (advise before / learn after every task).
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: mesh-pipeline-task-agent
+  host: hermes
+spec:
+  label: Mesh-Pipeline-Task-Agent
+  program: claude-code
+  model: sonnet
+  workingDirectory: /home/mvillmow/Agents/mesh
+  programArgs: ""
+  taskDescription: "HMAS pipeline-pool task-agent myrmidon (ADR-013 slice)"
+  tags:
+    - mesh
+    - "pool:pipeline.task-agent"
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-mesh:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/agents/hermes/mesh-research-chief-architect.yaml
+++ b/agents/hermes/mesh-research-chief-architect.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+# HMAS mesh pool worker (Odysseus ADR-013): research.chief-architect.
+# Serves the durable pull queue hi.myrmidon.research.chief-architect.task.>
+# — intake, user interview, ideation, researched brief, epic registration.
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: mesh-research-chief-architect
+  host: hermes
+spec:
+  label: Mesh-Research-Chief-Architect
+  program: claude-code
+  model: opus
+  workingDirectory: /home/mvillmow/Agents/mesh
+  programArgs: ""
+  taskDescription: "HMAS research-pool chief-architect myrmidon (ADR-013 slice)"
+  tags:
+    - mesh
+    - "pool:research.chief-architect"
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-mesh:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active


### PR DESCRIPTION
Declares the three slice pool workers per Odysseus ADR-013 (HomericIntelligence/Odysseus#378): research.chief-architect (opus), pipeline.chief-architect (opus), pipeline.task-agent (sonnet), all running the `achaean-mesh` vessel (HomericIntelligence/AchaeanFleet#714) with `pool:{domain}.{role}` tags.

Test plan: `tests/validate-schemas.sh` ok for all three (labels match filename stems); name-uniqueness, schema-hint, and dangerous-flags lints pass; pre-commit parity green locally (actionlint skipped — system binary absent, no workflow files touched).

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)