### PR TITLE
ci: add canonical install check for ecosystem CI board

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -389,3 +389,37 @@ jobs:
       # Verify pixi.lock matches pixi.toml — exits non-zero if lock is stale
       - name: Install dependencies (locked)
         run: pixi install --locked
+
+  install:
+    name: install
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - uses: ./.github/actions/setup-pixi
+
+      # Canonical `install` check (Odysseus ecosystem CI-naming, issue #750).
+      # The "artifact" this dataset repo ships to developers and CI is the
+      # pixi-managed validator toolchain plus the git hooks. Verify both
+      # environments install from the lockfile, every pinned tool executes,
+      # and the documented developer install path (just install-hooks) works.
+      - name: Install default environment (locked)
+        run: pixi install --locked
+
+      - name: Install lint environment (locked)
+        run: pixi install --locked --environment lint
+
+      - name: Smoke-test installed toolchain
+        run: |
+          set -euo pipefail
+          pixi run -- just --version
+          pixi run -- jq --version
+          pixi run -- yq --version
+          pixi run -- bats --version
+          pixi run --environment lint -- shellcheck --version
+          pixi run --environment lint -- yamllint --version
+          pixi run --environment lint -- pre-commit --version
+
+      - name: Install git hooks (just install-hooks)
+        run: pixi run -- just install-hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ conda install -c conda-forge actionlint
 
 ## CI/CD
 
-- **On PR** — `.github/workflows/validate.yml` (pre-commit parity + schema validation + fleet-ref validation) and `_required.yml` (lint, unit-tests, build, schema-validation, security scans).
+- **On PR** — `.github/workflows/validate.yml` (pre-commit parity + schema validation + fleet-ref validation) and `_required.yml` (lint, unit-tests, build, install, schema-validation, security scans).
 - **Branch protection on `main`** — required-check list in [`docs/branch-protection.md`](docs/branch-protection.md).
 
 ## Security

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -13,6 +13,7 @@ All are defined in `.github/workflows/_required.yml`.
 | `typecheck` | `typecheck` |
 | `schema-validation` | `schema-validation` |
 | `deps/version-sync` | `deps-version-sync` |
+| `install` | `install` |
 | `security/dependency-scan` | `security-dependency-scan` |
 | `security/secrets-scan` | `security-secrets-scan` |
 
@@ -44,6 +45,7 @@ gh api --method PATCH \
     "typecheck",
     "schema-validation",
     "deps/version-sync",
+    "install",
     "security/dependency-scan",
     "security/secrets-scan"
   ]


### PR DESCRIPTION
## Summary
Add a canonical `install` CI check-run to satisfy ecosystem CI-naming convention. Myrmidons validates declarative manifests via pixi, so the install step runs `pixi install` to verify the dependency lock is functional.

## Changes
- Add `install` job to `.github/workflows/_required.yml` that runs `pixi install` to verify environment setup
- Update `docs/branch-protection.md` to document `install` as a required check on main
- Update `CLAUDE.md` to reference the install check in CI/CD section

## Testing
- Verify the `install` check-run appears on PR and main branch CI status
- Confirm `install` job succeeds when pixi.lock is valid
- Confirm `install` job fails when pixi.lock is broken or dependencies are unresolvable

## Closes
Closes #750

Generated by Claude Code via ProjectHephaestus automation.
