### PR TITLE
docs(agents): add Design Philosophy section (heritage: ProjectOdyssey)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,34 @@ stay within that scope:
 
 ---
 
+## Design Philosophy
+
+> Heritage: this repository's design descends from ProjectOdyssey — the same
+> "declare desired state, let validators enforce it" lineage.
+
+The safety boundaries in this document follow from four principles. When a rule
+below seems strict, it is because one of these principles made it so.
+
+1. **Dataset, not reconciler.** Myrmidons declares *desired* agent state as
+   YAML and nothing more. Anything that talks to a runtime — applying,
+   planning, polling status — lives in the consumer (ProjectAgamemnon). Agents
+   here never construct calls to an external API; that is why "Reintroducing the
+   reconciler" and "Direct external API calls" are prohibited.
+2. **Desired state is data.** Every agent and fleet is a declarative document
+   validated against a versioned schema (`myrmidons/v1`). Agents edit data and
+   the schemas/validators that guard it — they do not encode runtime behavior.
+3. **Policy is enforced, not trusted.** Security-relevant rules (the
+   `--dangerously-skip-permissions` annotation, schema hints, gitleaks
+   allowlist justifications, name uniqueness) are enforced by pure, offline
+   validators that run identically in pre-commit and CI. A rule that cannot be
+   mechanically checked is a rule that will drift.
+4. **Fail closed, escalate to humans.** When a change touches the dataset
+   contract, CI workflows, schemas, or a new validator, the agent stops and
+   asks. Ambiguity is resolved by a human operator, never by guessing — see
+   [Escalation](#escalation--human-review-required).
+
+---
+
 ## Permitted Actions
 
 - Read any file in the repository

--- a/scripts/lint-agents-md.sh
+++ b/scripts/lint-agents-md.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/lint-agents-md.sh — validate required sections in AGENTS.md
 #
-# Checks that all six required H2 sections are present in AGENTS.md.
+# Checks that all seven required H2 sections are present in AGENTS.md.
 # Prevents PRs from accidentally deleting or renaming a required section.
 #
 # Usage:
@@ -75,6 +75,7 @@ fi
 
 REQUIRED_SECTIONS=(
     "## Scope"
+    "## Design Philosophy"
     "## Permitted Actions"
     "## Prohibited Actions"
     "## \`--dangerously-skip-permissions\` Policy"

--- a/tests/unit/test_lint_agents_md.bats
+++ b/tests/unit/test_lint_agents_md.bats
@@ -3,7 +3,7 @@
 #
 # Unit tests for scripts/lint-agents-md.sh
 #
-# Verifies that the script passes when all six required sections are present,
+# Verifies that the script passes when all seven required sections are present,
 # fails with a clear error message when any section is missing, and handles
 # edge cases (missing file, partial matches, stdin, env var).
 
@@ -25,6 +25,10 @@ _write_complete_agents_md() {
 ## Scope
 
 In scope content here.
+
+## Design Philosophy
+
+Design philosophy content here.
 
 ## Permitted Actions
 
@@ -76,7 +80,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Tests 3–8: each required section missing → exit 1 with helpful message
+# Tests 3–9: each required section missing → exit 1 with helpful message
 # ---------------------------------------------------------------------------
 
 @test "lint-agents-md: missing '## Scope' exits 1" {
@@ -85,6 +89,14 @@ teardown() {
     run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"## Scope"* ]]
+}
+
+@test "lint-agents-md: missing '## Design Philosophy' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Design Philosophy" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Design Philosophy"* ]]
 }
 
 @test "lint-agents-md: missing '## Permitted Actions' exits 1" {


### PR DESCRIPTION
## Summary

Adds a `## Design Philosophy` H2 section to `AGENTS.md`, documenting the four principles behind this repository's safety boundaries (dataset-not-reconciler, desired-state-as-data, validator-enforced policy, fail-closed escalation), with heritage attribution to ProjectOdyssey. The new heading is registered as a required section in the AGENTS.md validator so it cannot be silently dropped, and the bats suite is updated to enforce it.

Implements the approved plan from #758.

## What changed

- **`AGENTS.md`** — new `## Design Philosophy` section inserted after `## Scope`, before `## Permitted Actions`. Content is derived from the repo's established principles in CLAUDE.md/AGENTS.md/ADRs; includes a heritage note referencing ProjectOdyssey.
- **`scripts/lint-agents-md.sh`** — `"## Design Philosophy"` added to `REQUIRED_SECTIONS` (second, matching document order); header comment updated "six" → "seven".
- **`tests/unit/test_lint_agents_md.bats`** — `_write_complete_agents_md` fixture gains the section; header comment "six" → "seven"; section-label comment "Tests 3–8" → "Tests 3–9"; new `missing '## Design Philosophy' exits 1` test following the existing per-section pattern.

## Verification

- `bash scripts/lint-agents-md.sh` on the real AGENTS.md: exit 0
- Guard works: `grep -v '## Design Philosophy' AGENTS.md | bash scripts/lint-agents-md.sh -` exits 1 with the expected missing-section error
- `bats tests/unit/test_lint_agents_md.bats`: 20/20 pass (was 19; new missing-section test green)
- `shellcheck --severity=warning --enable=SC2154` (CI-parity flags) on both edited shell files: clean
- `bash tests/detect-doc-drift.sh`: 9 files checked, 0 errors
- Commit is GPG-signed and DCO signed-off; GitHub reports `verified: true`

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)
