### PR TITLE
ci: prepare main for merge-queue readiness

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.head_ref || github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,12 @@ conda install -c conda-forge actionlint
 
 ## CI/CD
 
-- **On PR** — `.github/workflows/validate.yml` (pre-commit parity + schema validation + fleet-ref validation) and `_required.yml` (lint, unit-tests, build, install, package, schema-validation, security scans).
+- **On PR** — `.github/workflows/validate.yml` provides pre-commit parity,
+  schema validation, and fleet-ref validation.
+- **On PR / `main` push / merge-group checks** —
+  `.github/workflows/_required.yml` emits every live required context. The
+  `merge_group` trigger is restricted to `checks_requested` so queued commits
+  run the same gates without changing pull-request or push behavior.
 - **On PR / `main` push / `v*` tag** — `.github/workflows/release.yml` packages the
   dataset snapshot (`scripts/package-dataset.sh`, read-only job emitting the
   canonical `release` check-run for the Odysseus ecosystem CI board); on `v*`

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ Every PR runs:
 - Schema-hint policy (`yaml-language-server` comment required on every agent YAML)
 
 Branch protection on `main` enforces the required-check set documented in
-[`docs/branch-protection.md`](docs/branch-protection.md).
+[`docs/branch-protection.md`](docs/branch-protection.md). The required-check
+workflow runs for pull requests, `main` pushes, and merge-group
+`checks_requested` events so the same gates protect queued commits.
 
 ## Security
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,20 +1,19 @@
-# Branch Protection — Required Status Checks
+# Main Protection and Merge Queue
 
-## Required checks on `main`
+## Live required checks on `main`
 
-The following GitHub Actions jobs must pass before any PR can merge into `main`.
-All are defined in `.github/workflows/_required.yml`.
+The active repository ruleset is `homeric-main-baseline` (ID `15556489`). As
+verified on 2026-07-16, it requires the following GitHub Actions jobs before a
+pull request can merge into `main`. All are defined in
+`.github/workflows/_required.yml`.
 
 | Job name (exact string in GitHub) | Job key in YAML |
-|-----------------------------------|-----------------|
+| --- | --- |
 | `lint` | `lint` |
 | `unit-tests` | `unit-tests` |
 | `build` | `build` |
-| `package` | `package` |
-| `typecheck` | `typecheck` |
 | `schema-validation` | `schema-validation` |
 | `deps/version-sync` | `deps-version-sync` |
-| `install` | `install` |
 | `security/dependency-scan` | `security-dependency-scan` |
 | `security/secrets-scan` | `security-secrets-scan` |
 
@@ -22,80 +21,122 @@ All are defined in `.github/workflows/_required.yml`.
 > YAML key. These two differ for `deps-version-sync` (`deps/version-sync`) and both
 > security jobs.
 
-## Restoring required checks after a protection reset
+The workflow also emits `forbid-suppressions`, `package`, `typecheck`, and
+`install`; these are visible CI signals but are not required by the live
+ruleset. The separate `release` workflow is also not required.
 
-> **Tip:** If only adding new required checks (not restoring after a wipe), use the incremental snippet below instead — it preserves any extras already configured.
+The required workflow runs for all three relevant event paths:
 
-If branch protection is wiped (e.g. after a repo transfer or settings reset), run:
+- `pull_request` targeting `main`;
+- `push` to `main`;
+- `merge_group` with action `checks_requested`.
 
-```bash
-# Fetch current required contexts first to avoid overwriting any extras
-gh api repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks
+This keeps every required context available when GitHub synthesizes a merge
+group commit without changing existing pull-request or push behavior.
 
-# Replace with the full desired list (PATCH replaces, not appends)
-gh api --method PATCH \
-  repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
-  --input - <<'EOF'
-{
-  "strict": false,
-  "contexts": [
-    "lint",
-    "unit-tests",
-    "integration-tests",
-    "build",
-    "package",
-    "typecheck",
-    "schema-validation",
-    "deps/version-sync",
-    "install",
-    "security/dependency-scan",
-    "security/secrets-scan"
-  ]
-}
-EOF
-```
-
-### Incrementally adding a required check
-
-When you only need to add one or more new contexts (e.g. registering
-`security/secrets-scan` and `security/dependency-scan` without disturbing
-anything else already configured), use `jq` to merge the new entries into the
-current list rather than rewriting it:
+## Verifying the live ruleset
 
 ```bash
-# Add security jobs without overwriting existing required checks
-gh api repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
-  | jq '.contexts += ["security/secrets-scan", "security/dependency-scan"] | .contexts |= unique' \
-  | gh api --method PATCH \
-    repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
-    --input -
+repo=HomericIntelligence/Myrmidons
+ruleset_id=15556489
+
+gh api "repos/${repo}/rulesets/${ruleset_id}" \
+  --jq '.rules[]
+        | select(.type == "required_status_checks")
+        | .parameters.required_status_checks[].context'
 ```
 
-The `| .contexts |= unique` step makes the command idempotent — re-running it
-will not produce duplicate entries.
+Compare the result byte-for-byte with the seven entries in the table above.
+Do not add, remove, or rename a required context as part of merge-queue
+activation.
+
+## Merge-queue policy
+
+Myrmidons has no canonical repository-owned ruleset automation or ruleset JSON.
+Queue activation is therefore an explicit post-merge administrative step. Land
+and strictly review workflow support first, then activate the live rule and run
+one representative queued pull request before closing issue #765.
+
+| Setting | Required value |
+| --- | --- |
+| Target branch | `main` |
+| Merge method | `SQUASH` |
+| Grouping strategy | `ALLGREEN` |
+| Maximum queue builds | `10` |
+| Maximum entries merged per group | `5` |
+| Minimum entries per group | `1` |
+| Minimum wait | `5` minutes |
+| Required-check timeout | `60` minutes |
+
+### Post-merge activation
+
+The rulesets API replaces the full ruleset. Snapshot first, append only the
+`merge_queue` rule, preserve every existing protection field and required
+context, then read the rule back. Run this only after the readiness PR merges:
 
 ```bash
-# Register the package job without overwriting existing required checks
-gh api repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
-  | jq '.contexts += ["package"] | .contexts |= unique' \
-  | gh api --method PATCH \
-    repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
-    --input -
+set -euo pipefail
+
+repo=HomericIntelligence/Myrmidons
+ruleset_name=homeric-main-baseline
+ruleset_id="$(gh api "repos/${repo}/rulesets" \
+  --jq ".[] | select(.name == \"${ruleset_name}\") | .id")"
+snapshot="$(mktemp)"
+payload="$(mktemp)"
+restore="$(mktemp)"
+trap 'rm -f "${snapshot}" "${payload}" "${restore}"' EXIT
+
+gh api "repos/${repo}/rulesets/${ruleset_id}" > "${snapshot}"
+jq '
+  if any(.rules[]; .type == "merge_queue") then
+    error("merge_queue already exists; inspect live state instead of replacing it")
+  else
+    {
+      name,
+      target,
+      enforcement,
+      conditions,
+      bypass_actors,
+      rules: (.rules + [{
+        type: "merge_queue",
+        parameters: {
+          merge_method: "SQUASH",
+          grouping_strategy: "ALLGREEN",
+          max_entries_to_build: 10,
+          max_entries_to_merge: 5,
+          min_entries_to_merge: 1,
+          min_entries_to_merge_wait_minutes: 5,
+          check_response_timeout_minutes: 60
+        }
+      }])
+    }
+  end
+' "${snapshot}" > "${payload}"
+
+gh api --method PUT "repos/${repo}/rulesets/${ruleset_id}" \
+  --input "${payload}"
+gh api "repos/${repo}/rulesets/${ruleset_id}" \
+  --jq '.rules[] | select(.type == "merge_queue") | .parameters'
 ```
 
-## Verifying current required checks
+The read-back must report all seven policy values from the table. Also re-read
+the `required_status_checks` rule and confirm the seven original contexts are
+unchanged. If either assertion fails, immediately restore the pre-change
+snapshot:
 
 ```bash
-gh api repos/mvillmow/Myrmidons/branches/main/protection/required_status_checks \
-  | jq '.contexts'
+jq '{name, target, enforcement, conditions, bypass_actors, rules}' \
+  "${snapshot}" > "${restore}"
+gh api --method PUT "repos/${repo}/rulesets/${ruleset_id}" \
+  --input "${restore}"
 ```
-
-Expected output includes `"security/secrets-scan"` and `"security/dependency-scan"`.
 
 ## Design notes
 
-- `strict: false` — stale branches may merge without rebasing; set to `true` to require branches to be up-to-date before merging.
-- Path-filtered workflows should not be added as required checks (they skip on unrelated PRs and would block merges incorrectly).
+- The live ruleset keeps `strict_required_status_checks_policy: false`; the
+  merge queue tests the synthesized commit that will actually merge.
+- Path-filtered workflows should not be added as required checks. They skip on
+  unrelated changes and leave the required context pending.
 - `release` (`.github/workflows/release.yml`) is intentionally **not** a required
   check: it exists to emit the canonical `release` check-run on `main` for the
   Odysseus ecosystem CI board and to publish dataset snapshots. Publishing is a
@@ -155,6 +196,6 @@ information, not as a merge block:
 ### Quick reference
 
 | Job | Behaviour | Reason |
-|-----|-----------|--------|
+| --- | --- | --- |
 | `security/secrets-scan` | Hard block. Any gitleaks hit fails the PR. | Leaked secrets are irrecoverable; rotation is not a substitute for prevention. |
 | `security/dependency-scan` | Informational. `pip-audit --ignore-vuln`, `trivy --exit-code 0`. | Findings are dominated by runner-image baseline CVEs outside our control. Tracked via dated allowlists. |

--- a/tests/unit/test_merge_queue_readiness.bats
+++ b/tests/unit/test_merge_queue_readiness.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# Regression coverage for the repository-owned half of merge-queue readiness.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+WORKFLOW="${SCRIPT_DIR}/.github/workflows/_required.yml"
+
+@test "required checks workflow handles merge-group checks_requested events" {
+    run yq eval --exit-status \
+        '(.on.merge_group.types | length) == 1 and
+         .on.merge_group.types[0] == "checks_requested"' \
+        "$WORKFLOW"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "required checks workflow preserves pull-request and push main triggers" {
+    run yq eval --exit-status \
+        '(.on.pull_request.branches | length) == 1 and
+         .on.pull_request.branches[0] == "main" and
+         (.on.push.branches | length) == 1 and
+         .on.push.branches[0] == "main"' \
+        "$WORKFLOW"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "required checks workflow supplies every live required context" {
+    # Captured from the active homeric-main-baseline ruleset on 2026-07-16.
+    local required_contexts=(
+        "lint"
+        "unit-tests"
+        "security/dependency-scan"
+        "security/secrets-scan"
+        "build"
+        "schema-validation"
+        "deps/version-sync"
+    )
+    local context
+
+    for context in "${required_contexts[@]}"; do
+        run yq eval --exit-status \
+            ".jobs[] | select(.name == \"${context}\") | .name" \
+            "$WORKFLOW"
+
+        [ "$status" -eq 0 ]
+    done
+}


### PR DESCRIPTION
## Summary

- add `merge_group: checks_requested` support to the only workflow that emits live required contexts
- preserve existing `pull_request` and `push` behavior and all seven required check names
- add focused BATS regression coverage for queue events, existing triggers, and required contexts
- synchronize merge-protection documentation with the live `homeric-main-baseline` ruleset
- document staged post-merge activation and rollback without mutating GitHub settings in this PR

## Live baseline inspected

At baseline `b4787b04bd06ca796dd04bf8b44e4836b8e19b75`, active ruleset
`homeric-main-baseline` (ID `15556489`) targets `main` and requires exactly:

- `lint`
- `unit-tests`
- `security/dependency-scan`
- `security/secrets-scan`
- `build`
- `schema-validation`
- `deps/version-sync`

`.github/workflows/_required.yml` is the only workflow supplying those contexts.
Recent `main` and pull-request check runs emitted all seven successfully. No
canonical repository-owned ruleset automation or configuration exists.

## Verification

- `pixi run bats tests/unit/test_merge_queue_readiness.bats` — PASS, 3/3
- `pixi run test` — PASS, 110/110 BATS plus schema, fleet-reference, documentation-drift, and schema-hint suites
- `pixi run --environment lint lint` — PASS
- `pixi run --environment lint lint-shell` — PASS
- `pre-commit run --all-files --show-diff-on-failure` in the lint environment — PASS, 18/18 hooks
- `actionlint .github/workflows/*.yml` — PASS
- `markdownlint docs/branch-protection.md` — PASS
- `yq eval '.' .github/workflows/_required.yml` — PASS
- `yamllint -d relaxed .github/workflows/_required.yml` — PASS with existing line-length warnings only
- `bash scripts/check-dangerous-flags.sh` — PASS
- `git diff --check` — PASS

`pixi run just validate` validates all repository YAML and unique names, then
exits 1 at its final shellcheck step because `pixi run lint-shell` is ambiguous
between the default and lint environments. This is pre-existing on `main`; the
explicit underlying command `pixi run --environment lint lint-shell` passes.

## Exact post-merge activation

Do not activate before this PR merges and the repository smoke check is ready.
An administrator should snapshot the full live ruleset, append only this rule,
PUT the preserved full ruleset, and verify the read-back:

```json
{
  "type": "merge_queue",
  "parameters": {
    "merge_method": "SQUASH",
    "grouping_strategy": "ALLGREEN",
    "max_entries_to_build": 10,
    "max_entries_to_merge": 5,
    "min_entries_to_merge": 1,
    "min_entries_to_merge_wait_minutes": 5,
    "check_response_timeout_minutes": 60
  }
}
```

The exact snapshot, append-only `jq`, full-ruleset `PUT`, read-back,
required-context verification, and rollback commands are in
`docs/branch-protection.md`. After activation, queue one representative PR and
record its `merge_group/checks_requested` run before closing the rollout issue.

Closes #765

Umbrella rollout: https://github.com/HomericIntelligence/Odysseus/issues/386
