### PR TITLE
ci: fast (<5 min) merge-queue smoke check

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.head_ref || github.sha }}

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,65 @@
+name: Merge Queue Smoke
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue-smoke:
+    name: merge-queue-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+
+      - name: Verify lockfile is in sync and install (locked)
+        run: |
+          set -euo pipefail
+          uv lock --check
+          uv sync --locked
+
+      - name: Validate agent YAML definitions against schema
+        run: |
+          uv run --frozen python - <<'EOF'
+          import yaml, glob, json, jsonschema, sys
+
+          schema_path = "schemas/agent-v1.schema.json"
+          with open(schema_path) as f:
+              schema = json.load(f)
+
+          agent_files = glob.glob("agents/**/*.yaml", recursive=True)
+          errors = []
+          for filepath in sorted(agent_files):
+              with open(filepath) as f:
+                  try:
+                      doc = yaml.safe_load(f)
+                  except yaml.YAMLError as e:
+                      errors.append(f"YAML parse error in {filepath}: {e}")
+                      continue
+              try:
+                  jsonschema.validate(doc, schema)
+              except jsonschema.ValidationError as e:
+                  errors.append(f"Schema error in {filepath}: {e.message}")
+
+          if errors:
+              for err in errors:
+                  print(f"ERROR: {err}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"Validated {len(agent_files)} agent definitions — all OK.")
+          EOF
+
+      - name: yamllint agent definitions
+        run: uv run --frozen yamllint -d relaxed agents/

--- a/tests/unit/test_merge_queue_contract.bats
+++ b/tests/unit/test_merge_queue_contract.bats
@@ -5,6 +5,7 @@ setup() {
     POLICY="${ROOT}/configs/github/merge-queue-policy.json"
     FIXTURE="${ROOT}/tests/fixtures/github/myrmidons-ruleset-before.json"
     WORKFLOW="${ROOT}/.github/workflows/_required.yml"
+    SMOKE="${ROOT}/.github/workflows/merge-queue-smoke.yml"
     MUTATOR="${ROOT}/tools/github/configure-merge-queue.sh"
     FAKE_GH="${ROOT}/tests/fixtures/github/fake-gh.sh"
 }
@@ -49,11 +50,30 @@ assert_main_only_scope() {
     [ "$status" -eq 0 ]
 }
 
-@test "required checks workflow handles merge-group checks_requested events" {
+@test "required checks workflow no longer runs on merge-group events" {
+    run yq eval --exit-status '.on | has("merge_group") | not' "$WORKFLOW"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "merge-queue smoke workflow handles merge-group checks_requested events only" {
     run yq eval --exit-status '
+        (.on | keys | length) == 1 and
+        (.on | keys | .[0]) == "merge_group" and
         (.on.merge_group.types | length) == 1 and
         .on.merge_group.types[0] == "checks_requested"
-    ' "$WORKFLOW"
+    ' "$SMOKE"
+
+    [ "$status" -eq 0 ]
+}
+
+@test "merge-queue smoke workflow runs exactly one fast job named merge-queue-smoke" {
+    run yq eval --exit-status '
+        (.jobs | keys | length) == 1 and
+        (.jobs | keys | .[0]) == "merge-queue-smoke" and
+        .jobs."merge-queue-smoke".name == "merge-queue-smoke" and
+        .jobs."merge-queue-smoke".timeout-minutes == 5
+    ' "$SMOKE"
 
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Diagnosis

Merge-queue (`merge_group`) runs re-execute the full required workflow — up to 16 jobs — and each job waits 8–16+ minutes for a runner slot. Total wall time per queued merge: 70–90 minutes, for code that already passed the identical checks on the pull request minutes earlier.

## Design

- `_required.yml` no longer triggers on `merge_group`. PR-side CI is otherwise completely untouched — no jobs added, removed, or changed; `pull_request` and `push: main` behavior is byte-identical to main.
- A new `.github/workflows/merge-queue-smoke.yml` triggers ONLY on `merge_group` and runs a single job named `merge-queue-smoke` (one runner slot, `timeout-minutes: 5`) with real fast validation borrowed from the repo's existing quick jobs: `uv lock --check` + `uv sync --locked`, agent-YAML JSON-schema validation (same script as the required `build` job), and `yamllint` over `agents/`. No `continue-on-error`, no `|| true`.
- Exactly one `merge-queue-smoke` check run exists per merge_group event; the full suites no longer run in the queue.
- `tests/unit/test_merge_queue_contract.bats` (run by the required `unit-tests` job) pinned the old trigger contract, so it was minimally updated: `_required.yml` must have no `merge_group` trigger, and `merge-queue-smoke.yml` must handle `merge_group`/`checks_requested` with exactly one fast `merge-queue-smoke` job.

## Post-merge ruleset rollout (REQUIRED — read before using the queue)

After merge, replace ALL `required_status_checks` contexts (in every ruleset, including the extras rulesets) with the single context `merge-queue-smoke` and set `min_entries_to_merge_wait_minutes` to 0; PR-side checks keep running but become non-blocking; the queue must not be used between merge and flip (the old contexts are no longer produced on `merge_group` and every queue entry would time out and fail). At flip time, `configs/github/merge-queue-policy.json` and its fixture-backed bats contract should be updated to match the new required-context list.

DO NOT MERGE until the flip is scheduled. No rulesets were modified by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
