### PR TITLE
ci: podman-by-default — containerized CI

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -98,6 +98,12 @@ jobs:
           fi
           echo 'OK: no advisory annotations found'
 
+  # ---------------------------------------------------------------------------
+  # Containerized jobs: the toolchain is baked into the CI image
+  # (ci/Containerfile) and every check runs inside a podman container.
+  # scripts/run_ci_local.sh auto-detects podman on the runner.
+  # ---------------------------------------------------------------------------
+
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -105,15 +111,19 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      # ShellCheck on all .sh files via the just lint-shell recipe
-      - name: Run shellcheck (just lint-shell)
-        run: just lint-shell
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
-      # yamllint (Python tool) on agent YAML definitions, via uv
-      - name: yamllint agent definitions
-        run: uv run --frozen yamllint -d relaxed agents/
+      - name: Run shellcheck (just lint-shell) + yamllint (in container)
+        run: ./scripts/run_ci_local.sh lint
 
   unit-tests:
     name: unit-tests
@@ -122,12 +132,19 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-tools: 'false'
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Run unit tests (bats)
-        run: just test-unit
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      - name: Run unit tests (bats) (in container)
+        run: ./scripts/run_ci_local.sh test
 
   security-dependency-scan:
     name: security/dependency-scan
@@ -135,6 +152,17 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
       # pip-audit: scan Python dependencies for known vulnerabilities.
       # Fail-fast on findings — if pip-audit reports a CVE, bump the offending
@@ -179,76 +207,8 @@ jobs:
       # `ubuntu-latest` image system Python — Myrmidons pins no PyPI deps —
       # so these are runner-image baseline CVEs like the rest: allowlisted
       # here and folded into the #713 baseline review. Surfaced by #763.
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
-        with:
-          enable-cache: true
-
-      - name: pip-audit
-        run: |
-          set -euo pipefail
-          uv sync --locked
-          uv run --frozen pip-audit \
-            --ignore-vuln PYSEC-2024-230 \
-            --ignore-vuln CVE-2023-26112 \
-            --ignore-vuln PYSEC-2024-225 \
-            --ignore-vuln CVE-2023-50782 \
-            --ignore-vuln CVE-2024-0727 \
-            --ignore-vuln GHSA-h4gh-qq45-vh27 \
-            --ignore-vuln CVE-2026-26007 \
-            --ignore-vuln CVE-2026-34073 \
-            --ignore-vuln GHSA-537c-gmf6-5ccf \
-            --ignore-vuln PYSEC-2024-60 \
-            --ignore-vuln CVE-2024-22195 \
-            --ignore-vuln CVE-2024-34064 \
-            --ignore-vuln CVE-2024-56326 \
-            --ignore-vuln CVE-2024-56201 \
-            --ignore-vuln CVE-2025-27516 \
-            --ignore-vuln CVE-2025-8869 \
-            --ignore-vuln CVE-2026-1703 \
-            --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln CVE-2026-6357 \
-            --ignore-vuln CVE-2026-30922 \
-            --ignore-vuln CVE-2026-4539 \
-            --ignore-vuln CVE-2026-32597 \
-            --ignore-vuln CVE-2026-27448 \
-            --ignore-vuln CVE-2026-27459 \
-            --ignore-vuln CVE-2024-35195 \
-            --ignore-vuln CVE-2024-47081 \
-            --ignore-vuln CVE-2026-25645 \
-            --ignore-vuln PYSEC-2025-49 \
-            --ignore-vuln CVE-2024-6345 \
-            --ignore-vuln PYSEC-2024-75 \
-            --ignore-vuln CVE-2024-41671 \
-            --ignore-vuln CVE-2026-42304 \
-            --ignore-vuln CVE-2024-37891 \
-            --ignore-vuln CVE-2025-50181 \
-            --ignore-vuln CVE-2025-66418 \
-            --ignore-vuln CVE-2025-66471 \
-            --ignore-vuln CVE-2026-21441 \
-            --ignore-vuln CVE-2026-24049 \
-            --ignore-vuln CVE-2026-44431 \
-            --ignore-vuln CVE-2026-45409 \
-            --ignore-vuln PYSEC-2026-196 \
-            --ignore-vuln PYSEC-2025-183 \
-            --ignore-vuln PYSEC-2026-179 \
-            --ignore-vuln PYSEC-2026-175 \
-            --ignore-vuln PYSEC-2026-2132 \
-            --ignore-vuln PYSEC-2026-3444 \
-            --ignore-vuln PYSEC-2026-3447 \
-            --ignore-vuln PYSEC-2026-177  # idna/pip/pyjwt/click/httplib2/setuptools runner-image baseline (#713, #762)
-
-      # Trivy filesystem scan — informational. `--exit-code 0` already makes
-      # vulnerability findings non-fatal; install/extraction failures should
-      # still fail the step so we know when the scan stopped working.
-      - name: Trivy filesystem scan
-        run: |
-          set -euo pipefail
-          base="https://github.com/aquasecurity/trivy/releases/download"
-          curl -sSfL \
-            "${base}/v${{ env.TV_VER }}/trivy_${{ env.TV_VER }}_Linux-64bit.tar.gz" \
-            | tar -xz -C /usr/local/bin trivy
-          trivy fs --severity HIGH,CRITICAL --exit-code 0 .
+      - name: pip-audit + trivy (in container)
+        run: ./scripts/run_ci_local.sh security
 
   security-secrets-scan:
     name: security/secrets-scan
@@ -259,16 +219,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Use the unlicensed gitleaks binary — no GITLEAKS_LICENSE required.
-      - name: Install gitleaks
-        run: |
-          url="https://github.com/gitleaks/gitleaks/releases/download"
-          curl -sSfL \
-            "${url}/v${{ env.GITLEAKS_VERSION }}/gitleaks_${{ env.GITLEAKS_VERSION }}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Scan for secrets (gitleaks)
-        run: gitleaks detect --source . --config .gitleaks.toml --no-git -v
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      # gitleaks is baked into the CI image (pinned release).
+      - name: Scan for secrets (gitleaks) (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local gitleaks detect --source /workspace --config .gitleaks.toml --no-git -v
 
   build:
     name: build
@@ -277,46 +241,21 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      # Validate all agent YAML files parse and conform to schema.
-      # pyyaml + jsonschema come from the uv-managed dev dependency group.
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Sync Python tooling (locked)
-        run: uv sync --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
-      - name: Validate agent YAML definitions
-        run: |
-          uv run --frozen python - <<'EOF'
-          import yaml, glob, json, jsonschema, sys
-
-          schema_path = "schemas/agent-v1.schema.json"
-          with open(schema_path) as f:
-              schema = json.load(f)
-
-          agent_files = glob.glob("agents/**/*.yaml", recursive=True)
-          errors = []
-          for filepath in sorted(agent_files):
-              with open(filepath) as f:
-                  try:
-                      doc = yaml.safe_load(f)
-                  except yaml.YAMLError as e:
-                      errors.append(f"YAML parse error in {filepath}: {e}")
-                      continue
-              try:
-                  jsonschema.validate(doc, schema)
-              except jsonschema.ValidationError as e:
-                  errors.append(f"Schema error in {filepath}: {e.message}")
-
-          if errors:
-              for err in errors:
-                  print(f"ERROR: {err}", file=sys.stderr)
-              sys.exit(1)
-
-          print(f"Validated {len(agent_files)} agent definitions — all OK.")
-          EOF
+      # Validate all agent YAML files parse and conform to schema.
+      # pyyaml + jsonschema are baked into the CI image's uv environment.
+      - name: Validate agent YAML definitions (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local uv run --frozen python scripts/validate-agent-schemas.py
 
   package:
     name: package
@@ -327,36 +266,22 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
       # The distributable for a dataset repo is the dataset itself: a
       # reproducible tar.gz of agents/ + fleets/ + schemas/ with a checksum.
       # See Odysseus docs/ci-naming-convention.md ("package" = release archive).
-      - name: Build dataset release archive
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          sha="$(git rev-parse --short HEAD)"
-          archive="dist/myrmidons-dataset-${sha}.tar.gz"
-          tar --sort=name --owner=0 --group=0 --numeric-owner \
-            --mtime='UTC 2020-01-01' \
-            -czf "${archive}" agents/ fleets/ schemas/
-          (cd dist && sha256sum -- *.tar.gz > SHA256SUMS)
-          ls -l dist/
-
-      - name: Verify archive integrity (round-trip)
-        run: |
-          set -euo pipefail
-          workdir="$(mktemp -d)"
-          tar -xzf dist/myrmidons-dataset-*.tar.gz -C "${workdir}"
-          for dir in agents fleets schemas; do
-            diff -r "${dir}" "${workdir}/${dir}"
-          done
-          yaml_count="$(find "${workdir}/agents" -name '*.yaml' | wc -l)"
-          if [ "${yaml_count}" -eq 0 ]; then
-            echo '::error::Packaged archive contains no agent YAMLs'
-            exit 1
-          fi
-          (cd dist && sha256sum --check SHA256SUMS)
-          echo "OK: archive round-trips (${yaml_count} agent YAMLs packaged)"
+      - name: Build dataset release archive + verify round-trip (in container)
+        run: ./scripts/run_ci_local.sh package
 
       - name: Upload dataset artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -373,38 +298,20 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Sync Python tooling (locked)
-        run: uv sync --locked
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
       # Run mypy on Python scripts if any exist; fall back to py_compile check
-      - name: mypy / py_compile on Python files
-        run: |
-          PY_FILES=$(find . -name "*.py" \
-            -not -path "*/.git/*" \
-            -not -path "*/__pycache__/*")
-          if [ -z "$PY_FILES" ]; then
-            echo "No Python files found — skipping mypy."
-            exit 0
-          fi
-          # Attempt mypy on scripts/ if it exists. Surface type errors as a
-          # workflow warning rather than failing the job (mypy on a partial
-          # codebase produces noisy results), but log the actual rc so it is
-          # visible in the build summary.
-          if [ -d "scripts" ] && find scripts -name "*.py" | grep -q .; then
-            mypy_rc=0
-            uv run --frozen mypy --ignore-missing-imports scripts/ || mypy_rc=$?
-            if [ "$mypy_rc" -ne 0 ]; then
-              echo "::warning::mypy on scripts/ exited $mypy_rc — review the output above."
-            fi
-          fi
-          # Always run py_compile as a hard syntax check
-          echo "$PY_FILES" | head -20 | xargs uv run --frozen python -m py_compile
-          echo "py_compile passed on all Python files."
+      - name: mypy / py_compile on Python files (in container)
+        run: ./scripts/run_ci_local.sh typecheck
 
   schema-validation:
     name: schema-validation
@@ -413,40 +320,21 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      # Validate workflow YAML files are well-formed (go-yq)
-      - name: Lint workflow YAML files (yq)
-        run: |
-          find .github/workflows -name '*.yml' | sort | while read -r f; do
-            echo "  checking: $f"
-            yq eval '.' "$f" > /dev/null
-          done
-          echo "All workflow YAML files are well-formed."
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
-      # Validate GitHub workflow schema via check-jsonschema (uv-managed tool)
-      - name: Validate GitHub workflow schemas
-        run: |
-          mapfile -t workflow_files < <(find .github/workflows -name '*.yml' | sort)
-          # Retry up to 3 times to handle transient schemastore.org 503s
-          for attempt in 1 2 3; do
-            uv run --frozen check-jsonschema \
-              --schemafile https://json.schemastore.org/github-workflow \
-              "${workflow_files[@]}" && break
-            echo "::warning::Schema validation attempt $attempt failed; retrying in 15s..."
-            sleep 15
-          done
-
-      # Validate pyproject.toml is parseable TOML
-      - name: Validate pyproject.toml
-        run: |
-          uv run --frozen python - <<'EOF'
-          import tomllib
-          with open("pyproject.toml", "rb") as f:
-              data = tomllib.load(f)
-          name = data.get('project', {}).get('name', 'unknown')
-          print(f"pyproject.toml OK — project: {name}")
-          EOF
+      # Validate workflow YAML files, GitHub workflow schemas, and pyproject.toml
+      # (yq + check-jsonschema + Python are baked into the CI image)
+      - name: Validate workflows + pyproject (in container)
+        run: ./scripts/run_ci_local.sh schema
 
   deps-version-sync:
     name: deps/version-sync
@@ -455,20 +343,21 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      # Verify uv.lock matches pyproject.toml — exits non-zero if lock is stale.
-      # This preserves the deps/version-sync intent: the dependency lockfile
-      # must be in sync with its manifest before merge.
-      - name: Verify lockfile is in sync
-        run: uv lock --check
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
-      # Verify the locked environment installs cleanly.
-      - name: Install dependencies (locked)
-        run: uv sync --locked
+      # Verify uv.lock matches pyproject.toml and the locked environment installs
+      # cleanly — inside the container.
+      - name: Verify lockfile sync + locked install (in container)
+        run: ./scripts/run_ci_local.sh deps
 
   install:
     name: install
@@ -477,24 +366,22 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
+
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
       # Canonical `install` check (Odysseus ecosystem CI-naming, issue #750).
       # The "artifact" this dataset repo ships to developers and CI is the
-      # validator toolchain (just/jq/go-yq/bats/shellcheck sourced outside uv,
-      # plus the uv-managed Python tools) and the git hooks. Verify the locked
-      # environment installs, every pinned tool executes, and the documented
-      # developer install path (just install-hooks) works.
-      - name: Smoke-test installed toolchain
-        run: |
-          set -euo pipefail
-          just --version
-          jq --version
-          yq --version
-          bats --version
-          shellcheck --version
-          uv run --frozen yamllint --version
-          uv run --frozen pre-commit --version
-
-      - name: Install git hooks (just install-hooks)
-        run: just install-hooks
+      # validator toolchain (just/jq/go-yq/bats/shellcheck plus the uv-managed
+      # Python tools) and the git hooks. Verify every pinned tool executes and
+      # the documented developer install path (just install-hooks) works —
+      # inside the container.
+      - name: Smoke-test installed toolchain + hooks (in container)
+        run: ./scripts/run_ci_local.sh install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,12 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-tools: 'false'
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Run shellcheck
-        run: just lint-shell
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      - name: Run shellcheck (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local just lint-shell
 
   schema:
     name: Schema Validation Tests
@@ -35,12 +42,19 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-tools: 'false'
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Validate YAML schemas
-        run: just test-schema
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
-      - name: Check documentation drift
-        run: just test-doc-drift
+      - name: Validate YAML schemas (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local just test-schema
+
+      - name: Check documentation drift (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local just test-doc-drift

--- a/.github/workflows/lock-check.yml
+++ b/.github/workflows/lock-check.yml
@@ -11,13 +11,20 @@ jobs:
   lock-check:
     name: Verify uv.lock is in sync
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Verify lockfile is in sync
-        run: uv lock --check
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      - name: Verify lockfile is in sync (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local uv lock --check

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -19,47 +19,22 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          enable-cache: true
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Verify lockfile is in sync and install (locked)
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      - name: Verify lockfile sync + locked install + schema + yamllint (in container)
         run: |
-          set -euo pipefail
-          uv lock --check
-          uv sync --locked
-
-      - name: Validate agent YAML definitions against schema
-        run: |
-          uv run --frozen python - <<'EOF'
-          import yaml, glob, json, jsonschema, sys
-
-          schema_path = "schemas/agent-v1.schema.json"
-          with open(schema_path) as f:
-              schema = json.load(f)
-
-          agent_files = glob.glob("agents/**/*.yaml", recursive=True)
-          errors = []
-          for filepath in sorted(agent_files):
-              with open(filepath) as f:
-                  try:
-                      doc = yaml.safe_load(f)
-                  except yaml.YAMLError as e:
-                      errors.append(f"YAML parse error in {filepath}: {e}")
-                      continue
-              try:
-                  jsonschema.validate(doc, schema)
-              except jsonschema.ValidationError as e:
-                  errors.append(f"Schema error in {filepath}: {e.message}")
-
-          if errors:
-              for err in errors:
-                  print(f"ERROR: {err}", file=sys.stderr)
-              sys.exit(1)
-
-          print(f"Validated {len(agent_files)} agent definitions — all OK.")
-          EOF
-
-      - name: yamllint agent definitions
-        run: uv run --frozen yamllint -d relaxed agents/
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local \
+            bash -c 'set -euo pipefail
+              uv lock --check
+              uv sync --locked
+              uv run --frozen python scripts/validate-agent-schemas.py
+              uv run --frozen yamllint -d relaxed agents/'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-tools: 'false'
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Run unit tests
-        run: just test-unit
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      - name: Run unit tests (in container)
+        run: podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local just test-unit

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,10 +26,6 @@ permissions:
   contents: read
   pull-requests: read
 
-env:
-  GITLEAKS_VERSION: "8.24.3"
-  ACTIONLINT_VERSION: "1.7.7"
-
 jobs:
   # Single source-of-truth lint job: runs every hook in .pre-commit-config.yaml.
   # Adding a linter? Add it to .pre-commit-config.yaml — it auto-runs here.
@@ -37,31 +33,27 @@ jobs:
   pre-commit:
     name: Pre-commit (parity)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Install gitleaks (required by gitleaks-system pre-commit hook)
-        run: |
-          url="https://github.com/gitleaks/gitleaks/releases/download"
-          curl -sSfL \
-            "${url}/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz -C /usr/local/bin gitleaks
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
 
-      - name: Install actionlint (required by actionlint-system pre-commit hook)
-        run: |
-          url="https://github.com/rhysd/actionlint/releases/download"
-          curl -sSfL \
-            "${url}/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin actionlint
-
-      - name: Run pre-commit on all files
-        run: |
-          uv run --frozen pre-commit run \
-            --all-files --show-diff-on-failure
+      # gitleaks + actionlint (required by the gitleaks-system /
+      # actionlint-system hooks) are baked into the CI image.
+      - name: Run pre-commit on all files (in container)
+        run: ./scripts/run_ci_local.sh precommit
 
   validate:
     name: Validate YAML Schemas
@@ -71,31 +63,41 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - uses: ./.github/actions/setup-tools
+      - name: Cache podman container storage
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          python-tools: 'false'
+          path: ~/.local/share/containers/storage
+          key: podman-myrmidons-${{ runner.os }}-${{ hashFiles('uv.lock', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            podman-myrmidons-${{ runner.os }}-
 
-      - name: Check dependencies
+      - name: Build CI image (podman)
+        run: podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+      - name: Check dependencies (in container)
         run: |
-          echo "--- Checking required tools ---"
-          yq --version
-          jq --version
-          bash --version | head -1
-          echo "All required dependencies present."
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local \
+            bash -c 'yq --version && jq --version && bash --version | head -1 && echo "All required dependencies present."'
 
-      - name: Lint workflow YAML files
+      - name: Lint workflow YAML files (in container)
         run: |
-          echo "--- Validating workflow YAML files ---"
-          find .github/workflows -name '*.yml' | sort | while read -r f; do
-            echo "  checking: $f"
-            yq eval '.' "$f" > /dev/null
-          done
-          echo "All workflow YAML files are well-formed."
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local \
+            bash -c '
+              find .github/workflows -name "*.yml" | sort | while read -r f; do
+                echo "  checking: $f"
+                yq eval "." "$f" > /dev/null
+              done
+              echo "All workflow YAML files are well-formed."
+            '
 
-      - name: Validate all YAML files
+      - name: Validate all YAML files (in container)
         env:
           CI: "true"
-        run: just test-schema
+        run: |
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 \
+            -e CI=true myrmidons-ci:local just test-schema
 
-      - name: Fleet ref validation
-        run: tests/validate-fleet-refs.sh
+      - name: Fleet ref validation (in container)
+        run: |
+          podman run --rm -v "$PWD:/workspace:Z" --userns=keep-id:uid=1000,gid=1000 myrmidons-ci:local \
+            tests/validate-fleet-refs.sh

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -1,0 +1,139 @@
+# Containerfile for myrmidons-ci — CI image for the Myrmidons dataset repo.
+#
+# This image provides the complete validator toolchain:
+# - Python 3.13 environment (matches requires-python >=3.13,<3.14)
+# - uv with the locked dev dependency group pre-installed (yamllint, pyyaml,
+#   jsonschema, check-jsonschema, mypy, pip-audit, pre-commit)
+# - System tools: just, jq, go-yq (yq), bats, shellcheck (apt)
+# - gitleaks + actionlint (required by the gitleaks-system / actionlint-system
+#   pre-commit hooks)
+# - trivy (dependency filesystem scan)
+# - pre-commit hook environments baked in
+# - Non-root user 'ci' for rootless Podman compatibility
+#
+# Toolchain: uv (Odysseus ADR-017). Myrmidons is a dataset repo — it ships no
+# importable Python package ([tool.uv] package = false), so the dev group is
+# installed without a project build.
+#
+# Build (OCI-compliant — works with both podman and docker):
+#   podman build -f ci/Containerfile -t myrmidons-ci:local .
+#   docker build -f ci/Containerfile -t myrmidons-ci:local .
+#
+# Run:
+#   podman run --rm -v .:/workspace:Z myrmidons-ci:local just lint-shell
+#   podman run --rm -v .:/workspace:Z myrmidons-ci:local uv run pre-commit run --all-files
+
+# ============================================================================
+# Stage 0: uv binary — installed from a pinned GitHub release so the checksum
+# is reproducible and the build resolves identically under both podman/buildah
+# and docker (no cross-registry COPY of a third-party image). The ghcr.io
+# astral-sh/uv image's version-tag scheme does not track uv CLI versions
+# (0.11.21 does not exist there), so we pin the release tarball instead.
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://github.com/astral-sh/uv/releases/download/0.12.1/uv-x86_64-unknown-linux-gnu.tar.gz -o /tmp/uv.tar.gz \
+    && echo "90b2f223fb69d19db49e117da601f64978593417988530aa733d456141b4bcbb  /tmp/uv.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/uv.tar.gz -C /usr/local/bin --strip-components=1 \
+    && rm /tmp/uv.tar.gz
+
+# ============================================================================
+# Stage 1: Runtime — the full toolchain in one image (dataset repo: no compile
+# stage required, and the shell/YAML toolchain is needed at runtime anyway)
+# ============================================================================
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+
+LABEL org.opencontainers.image.title="myrmidons-ci"
+LABEL org.opencontainers.image.description="CI container for Myrmidons — dataset validation, linting, packaging"
+LABEL org.opencontainers.image.vendor="Myrmidons"
+LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Myrmidons"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/myrmidons-venv \
+    UV_LINK_MODE=copy \
+    PATH="/opt/myrmidons-venv/bin:$PATH"
+
+# System packages: git (pre-commit / just install-hooks), curl/ca-certificates
+# (tool downloads), jq + bats + shellcheck (apt — same sources as the
+# ubuntu-latest runner image), openssh-client (git over ssh in GitOps tooling)
+# apt-get upgrade picks up any security patches released after the base image was pinned
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    jq \
+    bats \
+    shellcheck \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv — pinned release (keep in sync with astral-sh/setup-uv in workflows)
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+# just — pinned release (mirrors extractions/setup-just; setup-tools action
+# installs the latest, but the image pins for reproducibility)
+RUN curl -fsSL https://github.com/casey/just/releases/download/1.58.0/just-1.58.0-x86_64-unknown-linux-musl.tar.gz -o /tmp/just.tar.gz \
+    && echo "4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d  /tmp/just.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/just.tar.gz -C /usr/local/bin just \
+    && rm /tmp/just.tar.gz
+
+# go-yq (mikefarah/yq) — pinned release binary (same version as setup-tools)
+RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 -o /usr/local/bin/yq \
+    && echo "a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7  /usr/local/bin/yq" | sha256sum --check \
+    && chmod +x /usr/local/bin/yq
+
+# gitleaks — pinned release binary (required by gitleaks-system pre-commit hook
+# and the security-secrets-scan job)
+RUN curl -fsSL https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz -o /tmp/gitleaks.tar.gz \
+    && echo "9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c  /tmp/gitleaks.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks \
+    && rm /tmp/gitleaks.tar.gz
+
+# actionlint — pinned release binary (required by actionlint-system pre-commit hook)
+RUN curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz -o /tmp/actionlint.tar.gz \
+    && echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  /tmp/actionlint.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/actionlint.tar.gz -C /usr/local/bin actionlint \
+    && rm /tmp/actionlint.tar.gz
+
+# trivy — pinned release binary (dependency filesystem scan, informational)
+RUN curl -fsSL https://github.com/aquasecurity/trivy/releases/download/v0.70.0/trivy_0.70.0_Linux-64bit.tar.gz -o /tmp/trivy.tar.gz \
+    && echo "8b4376d5d6befe5c24d503f10ff136d9e0c49f9127a4279fd110b727929a5aa9  /tmp/trivy.tar.gz" | sha256sum --check \
+    && tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy \
+    && rm /tmp/trivy.tar.gz
+
+# Layer: Dependency files — cache layer invalidated only when deps change.
+WORKDIR /opt/myrmidons-build
+COPY uv.lock pyproject.toml .pre-commit-config.yaml ./
+
+# Install the locked dev dependency group into the venv.
+# Myrmidons declares zero runtime deps ([tool.uv] package = false) — this
+# installs only the developer/CI tool group.
+RUN uv sync --locked
+
+# Create non-root user for rootless Podman compatibility
+# UID 1000 is the default first user on most Linux systems, matching typical
+# developer UIDs for smooth volume mount permissions without --userns=keep-id
+RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci && \
+    chown -R ci:ci /opt/myrmidons-venv /opt/myrmidons-build
+
+# Layer: pre-commit hook environments (baked in so 'pre-commit run --all-files'
+# starts immediately without downloading hook repos at CI time). Requires a git
+# repo, so we init a temporary one. Run as the ci user so the pre-commit cache
+# (db + repo clones) lives under /home/ci/.cache with correct paths. The
+# gitleaks-system and actionlint-system hooks use the binaries installed above.
+USER ci
+WORKDIR /opt/myrmidons-build
+RUN git init . && \
+    uv run --frozen pre-commit install-hooks && \
+    rm -rf .git
+
+# Working directory is the mounted repo root at runtime
+WORKDIR /workspace
+
+# No ENTRYPOINT — commands are provided externally by CI or run_ci_local.sh
+
+USER ci

--- a/justfile
+++ b/justfile
@@ -127,3 +127,63 @@ install-hooks-legacy:
     cp hooks/pre-commit .git/hooks/pre-commit
     chmod +x .git/hooks/pre-commit
     @echo "Legacy hook installed (dangerous-flags only, no pre-commit framework)."
+
+# =============================================================================
+# Containerized CI (podman-by-default)
+# =============================================================================
+# These recipes run the same checks as the GitHub Actions workflows, but inside
+# the CI container image (ci/Containerfile) instead of on the native host.
+# Engine: podman (rootless, preferred) or docker — auto-detected by
+# scripts/run_ci_local.sh. Override with CONTAINER_ENGINE=docker.
+
+# Build the CI container image (ci/Containerfile)
+ci-build:
+    podman build -f ci/Containerfile -t myrmidons-ci:local .
+
+# Run the forbid-suppressions policy scans in the container
+ci-forbid:
+    ./scripts/run_ci_local.sh forbid
+
+# Run lint (shellcheck + yamllint) in the container
+ci-lint:
+    ./scripts/run_ci_local.sh lint
+
+# Run bats unit tests in the container
+ci-test:
+    ./scripts/run_ci_local.sh test
+
+# Run agent YAML schema validation in the container
+ci-validate:
+    ./scripts/run_ci_local.sh build
+
+# Run typecheck (mypy / py_compile) in the container
+ci-typecheck:
+    ./scripts/run_ci_local.sh typecheck
+
+# Run schema-validation (workflow YAML + jsonschema + pyproject) in the container
+ci-schema:
+    ./scripts/run_ci_local.sh schema
+
+# Run deps-version-sync (lockfile) in the container
+ci-deps:
+    ./scripts/run_ci_local.sh deps
+
+# Run security scans (pip-audit + gitleaks + trivy) in the container
+ci-security:
+    ./scripts/run_ci_local.sh security
+
+# Run the package job in the container
+ci-package:
+    ./scripts/run_ci_local.sh package
+
+# Run the install smoke-test + hooks in the container
+ci-install:
+    ./scripts/run_ci_local.sh install
+
+# Run the full pre-commit suite in the container
+ci-precommit:
+    ./scripts/run_ci_local.sh precommit
+
+# Run the full required-check suite in the container
+ci-check:
+    ./scripts/run_ci_local.sh all

--- a/scripts/run_ci_local.sh
+++ b/scripts/run_ci_local.sh
@@ -1,0 +1,399 @@
+#!/bin/bash
+# Run the Myrmidons CI suite locally inside a container.
+#
+# Mirrors what GitHub Actions runs, using the same CI container image.
+# Supports both Podman (rootless, no SU — preferred) and Docker.
+#
+# Usage:
+#   ./scripts/run_ci_local.sh                  # Run all CI checks
+#   ./scripts/run_ci_local.sh lint             # shellcheck + yamllint (lint job)
+#   ./scripts/run_ci_local.sh test             # bats unit tests (unit-tests job)
+#   ./scripts/run_ci_local.sh build            # agent YAML schema validation (build job)
+#   ./scripts/run_ci_local.sh typecheck        # mypy / py_compile (typecheck job)
+#   ./scripts/run_ci_local.sh schema           # workflow YAML + jsonschema + pyproject (schema-validation job)
+#   ./scripts/run_ci_local.sh deps             # lockfile sync (deps-version-sync job)
+#   ./scripts/run_ci_local.sh security         # pip-audit + gitleaks + trivy (security jobs)
+#   ./scripts/run_ci_local.sh package          # dataset archive + round-trip (package job)
+#   ./scripts/run_ci_local.sh install          # toolchain smoke test + hooks (install job)
+#   ./scripts/run_ci_local.sh forbid           # silent-failure policy scans (forbid-suppressions job)
+#   ./scripts/run_ci_local.sh precommit        # full pre-commit run (validate.yml)
+#
+# Container engine: auto-detected (podman first, docker fallback).
+# Override: CONTAINER_ENGINE=docker ./scripts/run_ci_local.sh
+#
+# Image: uses 'myrmidons-ci:local'.
+# Build locally: just ci-build  (or: podman build -f ci/Containerfile -t myrmidons-ci:local .)
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUBSET="${1:-all}"
+
+LOCAL_IMAGE="myrmidons-ci:local"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[CI]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[CI]${NC} $*"; }
+log_error() { echo -e "${RED}[CI]${NC} $*" >&2; }
+log_step()  { echo -e "\n${BLUE}==>${NC} $*"; }
+
+# ============================================================================
+# Container engine detection
+# ============================================================================
+
+detect_engine() {
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+        if ! command -v "${CONTAINER_ENGINE}" &> /dev/null; then
+            log_error "CONTAINER_ENGINE=${CONTAINER_ENGINE} not found in PATH"
+            exit 1
+        fi
+        log_info "Container engine: ${CONTAINER_ENGINE} (from env)"
+        return
+    fi
+
+    if command -v podman &> /dev/null; then
+        CONTAINER_ENGINE="podman"
+        log_info "Container engine: podman (rootless)"
+    elif command -v docker &> /dev/null; then
+        CONTAINER_ENGINE="docker"
+        log_info "Container engine: docker"
+    else
+        log_error "No container engine found. Install podman (recommended) or docker."
+        log_error "  Podman: https://podman.io/getting-started/installation"
+        exit 1
+    fi
+    export CONTAINER_ENGINE
+}
+
+# ============================================================================
+# Image resolution
+# ============================================================================
+
+resolve_image() {
+    if "${CONTAINER_ENGINE}" image exists "${LOCAL_IMAGE}" 2>/dev/null || \
+       "${CONTAINER_ENGINE}" images -q "${LOCAL_IMAGE}" 2>/dev/null | grep -q .; then
+        CI_IMAGE="${LOCAL_IMAGE}"
+        log_info "Using local CI image: ${CI_IMAGE}"
+    else
+        log_error "Local image '${LOCAL_IMAGE}' not found."
+        log_error "Build it first: just ci-build"
+        log_error "  (podman build -f ci/Containerfile -t ${LOCAL_IMAGE} .)"
+        exit 1
+    fi
+    export CI_IMAGE
+}
+
+# ============================================================================
+# Run a command inside the CI container
+# ============================================================================
+
+run_in_container() {
+    local cmd=("$@")
+    local engine_flags=()
+
+    if [ "${CONTAINER_ENGINE}" = "podman" ]; then
+        engine_flags+=("--userns=keep-id:uid=1000,gid=1000")
+    fi
+
+    "${CONTAINER_ENGINE}" run --rm \
+        "${engine_flags[@]}" \
+        --volume "${PROJECT_ROOT}:/workspace:Z" \
+        --workdir /workspace \
+        "${CI_IMAGE}" \
+        "${cmd[@]}"
+}
+
+# ============================================================================
+# CI steps (mirror .github/workflows/_required.yml + validate.yml)
+# ============================================================================
+
+run_forbid() {
+    log_step "forbid-suppressions: silent-failure / continue-on-error / advisory policy"
+    run_in_container bash -c '
+        set -euo pipefail
+        mapfile -t files < <(git ls-files -- "*.sh" "*.bash" "*.yml" "*.yaml" "*.hcl" "Dockerfile*" "**/Dockerfile*" "justfile" "**/justfile" "Justfile" "**/Justfile")
+        declare -a scan_files=()
+        for f in "${files[@]}"; do
+            case "$f" in
+                .github/workflows/_required.yml) continue ;;
+                docs/runbooks/no-silent-failures.md) continue ;;
+            esac
+            scan_files+=("$f")
+        done
+        if [ "${#scan_files[@]}" -eq 0 ]; then echo "No files to scan"; exit 0; fi
+        if grep -nE '"'"'\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)'"'"' "${scan_files[@]}"; then
+            echo "::error::Found silent-failure workarounds above."; exit 1
+        fi
+        echo "OK: no silent-failure workarounds found"
+        mapfile -t wf < <(git ls-files -- ".github/workflows/*.yml" ".github/workflows/*.yaml")
+        if grep -nE '"'"'^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$'"'"' "${wf[@]}"; then
+            echo "::error::Found continue-on-error: true above."; exit 1
+        fi
+        echo "OK: no continue-on-error found"
+        # Exempt this workflow file: its own advisory-pattern check self-matches.
+        declare -a wf_scan=()
+        for f in "${wf[@]}"; do
+            case "$f" in
+                .github/workflows/_required.yml) continue ;;
+            esac
+            wf_scan+=("$f")
+        done
+        if grep -nF '"'"'::warning::'"'"' "${wf_scan[@]}"; then
+            echo "::error::Found advisory annotations above."; exit 1
+        fi
+        echo "OK: no advisory annotations found"
+    '
+}
+
+run_lint() {
+    log_step "lint: shellcheck + yamllint"
+    run_in_container bash -c 'just lint-shell && uv run --frozen yamllint -d relaxed agents/'
+}
+
+run_test() {
+    log_step "unit-tests: bats"
+    run_in_container bash -c 'just test-unit'
+}
+
+run_build() {
+    log_step "build: agent YAML schema validation"
+    run_in_container uv run --frozen python scripts/validate-agent-schemas.py
+}
+
+run_typecheck() {
+    log_step "typecheck: mypy / py_compile"
+    run_in_container bash -c '
+        PY_FILES=$(find . -name "*.py" -not -path "*/.git/*" -not -path "*/__pycache__/*")
+        if [ -z "$PY_FILES" ]; then echo "No Python files found — skipping mypy."; exit 0; fi
+        if [ -d "scripts" ] && find scripts -name "*.py" | grep -q .; then
+            mypy_rc=0
+            uv run --frozen mypy --ignore-missing-imports scripts/ || mypy_rc=$?
+            if [ "$mypy_rc" -ne 0 ]; then
+                echo "::warning::mypy on scripts/ exited $mypy_rc — review the output above."
+            fi
+        fi
+        echo "$PY_FILES" | head -20 | xargs uv run --frozen python -m py_compile
+        echo "py_compile passed on all Python files."
+    '
+}
+
+run_schema() {
+    log_step "schema-validation: workflow YAML + GitHub schema + pyproject"
+    run_in_container bash -c '
+        find .github/workflows -name "*.yml" | sort | while read -r f; do
+            echo "  checking: $f"
+            yq eval "." "$f" > /dev/null
+        done
+        echo "All workflow YAML files are well-formed."
+        mapfile -t workflow_files < <(find .github/workflows -name "*.yml" | sort)
+        uv run --frozen check-jsonschema --schemafile https://json.schemastore.org/github-workflow "${workflow_files[@]}"
+        uv run --frozen python - <<'"'"'EOF'"'"'
+import tomllib
+with open("pyproject.toml", "rb") as f:
+    data = tomllib.load(f)
+name = data.get("project", {}).get("name", "unknown")
+print(f"pyproject.toml OK — project: {name}")
+EOF
+    '
+}
+
+run_deps() {
+    log_step "deps-version-sync: lockfile in sync + clean install"
+    run_in_container bash -c 'uv lock --check && uv sync --locked'
+}
+
+run_security() {
+    log_step "security/dependency-scan: pip-audit + trivy"
+    run_in_container bash -c '
+        uv sync --locked
+        uv run --frozen pip-audit \
+            --ignore-vuln PYSEC-2024-230 \
+            --ignore-vuln CVE-2023-26112 \
+            --ignore-vuln PYSEC-2024-225 \
+            --ignore-vuln CVE-2023-50782 \
+            --ignore-vuln CVE-2024-0727 \
+            --ignore-vuln GHSA-h4gh-qq45-vh27 \
+            --ignore-vuln CVE-2026-26007 \
+            --ignore-vuln CVE-2026-34073 \
+            --ignore-vuln GHSA-537c-gmf6-5ccf \
+            --ignore-vuln PYSEC-2024-60 \
+            --ignore-vuln CVE-2024-22195 \
+            --ignore-vuln CVE-2024-34064 \
+            --ignore-vuln CVE-2024-56326 \
+            --ignore-vuln CVE-2024-56201 \
+            --ignore-vuln CVE-2025-27516 \
+            --ignore-vuln CVE-2025-8869 \
+            --ignore-vuln CVE-2026-1703 \
+            --ignore-vuln CVE-2026-3219 \
+            --ignore-vuln CVE-2026-6357 \
+            --ignore-vuln CVE-2026-30922 \
+            --ignore-vuln CVE-2026-4539 \
+            --ignore-vuln CVE-2026-32597 \
+            --ignore-vuln CVE-2026-27448 \
+            --ignore-vuln CVE-2026-27459 \
+            --ignore-vuln CVE-2024-35195 \
+            --ignore-vuln CVE-2024-47081 \
+            --ignore-vuln CVE-2026-25645 \
+            --ignore-vuln PYSEC-2025-49 \
+            --ignore-vuln CVE-2024-6345 \
+            --ignore-vuln PYSEC-2024-75 \
+            --ignore-vuln CVE-2024-41671 \
+            --ignore-vuln CVE-2026-42304 \
+            --ignore-vuln CVE-2024-37891 \
+            --ignore-vuln CVE-2025-50181 \
+            --ignore-vuln CVE-2025-66418 \
+            --ignore-vuln CVE-2025-66471 \
+            --ignore-vuln CVE-2026-21441 \
+            --ignore-vuln CVE-2026-24049 \
+            --ignore-vuln CVE-2026-44431 \
+            --ignore-vuln CVE-2026-45409 \
+            --ignore-vuln PYSEC-2026-196 \
+            --ignore-vuln PYSEC-2025-183 \
+            --ignore-vuln PYSEC-2026-179 \
+            --ignore-vuln PYSEC-2026-175 \
+            --ignore-vuln PYSEC-2026-2132 \
+            --ignore-vuln PYSEC-2026-3444 \
+            --ignore-vuln PYSEC-2026-3447 \
+            --ignore-vuln PYSEC-2026-177
+        trivy fs --severity HIGH,CRITICAL --exit-code 0 .
+    '
+    log_step "security/secrets-scan: gitleaks"
+    run_in_container bash -c 'gitleaks detect --source . --config .gitleaks.toml --no-git -v'
+}
+
+run_package() {
+    log_step "package: dataset archive + round-trip"
+    run_in_container bash -c '
+        set -euo pipefail
+        mkdir -p dist
+        sha="$(git rev-parse --short HEAD)"
+        archive="dist/myrmidons-dataset-${sha}.tar.gz"
+        tar --sort=name --owner=0 --group=0 --numeric-owner \
+            --mtime="UTC 2020-01-01" \
+            -czf "${archive}" agents/ fleets/ schemas/
+        (cd dist && sha256sum -- *.tar.gz > SHA256SUMS)
+        ls -l dist/
+        workdir="$(mktemp -d)"
+        tar -xzf dist/myrmidons-dataset-*.tar.gz -C "${workdir}"
+        for dir in agents fleets schemas; do
+            diff -r "${dir}" "${workdir}/${dir}"
+        done
+        yaml_count="$(find "${workdir}/agents" -name "*.yaml" | wc -l)"
+        if [ "${yaml_count}" -eq 0 ]; then echo "::error::Packaged archive contains no agent YAMLs"; exit 1; fi
+        (cd dist && sha256sum --check SHA256SUMS)
+        echo "OK: archive round-trips (${yaml_count} agent YAMLs packaged)"
+    '
+}
+
+run_install() {
+    log_step "install: toolchain smoke test + hooks"
+    run_in_container bash -c '
+        set -euo pipefail
+        just --version
+        jq --version
+        yq --version
+        bats --version
+        shellcheck --version
+        uv run --frozen yamllint --version
+        uv run --frozen pre-commit --version
+        just install-hooks
+    '
+}
+
+run_precommit() {
+    log_step "pre-commit: all files (validate.yml parity)"
+    run_in_container bash -c 'uv run --frozen pre-commit run --all-files --show-diff-on-failure'
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+FAILED=()
+
+run_step() {
+    local name="$1"
+    local fn="$2"
+    if ! "${fn}"; then
+        FAILED+=("${name}")
+        log_error "${name} FAILED"
+    fi
+}
+
+detect_engine
+resolve_image
+
+log_info "CI subset: ${SUBSET}"
+log_info "Project root: ${PROJECT_ROOT}"
+
+case "${SUBSET}" in
+    forbid)
+        run_step "forbid-suppressions" run_forbid
+        ;;
+    lint)
+        run_step "lint" run_lint
+        ;;
+    test)
+        run_step "unit-tests" run_test
+        ;;
+    build)
+        run_step "build" run_build
+        ;;
+    typecheck)
+        run_step "typecheck" run_typecheck
+        ;;
+    schema)
+        run_step "schema-validation" run_schema
+        ;;
+    deps)
+        run_step "deps-version-sync" run_deps
+        ;;
+    security)
+        run_step "security" run_security
+        ;;
+    package)
+        run_step "package" run_package
+        ;;
+    install)
+        run_step "install" run_install
+        ;;
+    precommit)
+        run_step "pre-commit" run_precommit
+        ;;
+    all)
+        run_step "forbid-suppressions" run_forbid
+        run_step "lint" run_lint
+        run_step "unit-tests" run_test
+        run_step "build" run_build
+        run_step "typecheck" run_typecheck
+        run_step "schema-validation" run_schema
+        run_step "deps-version-sync" run_deps
+        run_step "security" run_security
+        run_step "package" run_package
+        run_step "install" run_install
+        ;;
+    *)
+        log_error "Unknown subset: ${SUBSET}"
+        log_error "Valid values: all, forbid, lint, test, build, typecheck, schema, deps, security, package, install, precommit"
+        exit 1
+        ;;
+esac
+
+echo ""
+if [ "${#FAILED[@]}" -eq 0 ]; then
+    log_info "All CI checks passed."
+else
+    log_error "Failed: ${FAILED[*]}"
+    exit 1
+fi

--- a/scripts/validate-agent-schemas.py
+++ b/scripts/validate-agent-schemas.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Validate all agent YAML definitions against the agent-v1 schema.
+
+Used by the `build` job in .github/workflows/_required.yml, the merge-queue
+smoke workflow, and scripts/run_ci_local.sh. Exits non-zero on any YAML parse
+error or schema violation.
+
+Dependencies: pyyaml, jsonschema (uv-managed dev group).
+"""
+
+import glob
+import json
+import sys
+
+import jsonschema
+import yaml
+
+SCHEMA_PATH = "schemas/agent-v1.schema.json"
+
+
+def main() -> int:
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+
+    agent_files = glob.glob("agents/**/*.yaml", recursive=True)
+    errors = []
+    for filepath in sorted(agent_files):
+        with open(filepath) as f:
+            try:
+                doc = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                errors.append(f"YAML parse error in {filepath}: {e}")
+                continue
+        try:
+            jsonschema.validate(doc, schema)
+        except jsonschema.ValidationError as e:
+            errors.append(f"Schema error in {filepath}: {e.message}")
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(agent_files)} agent definitions — all OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Podman-by-default CI

Containerize CI toolchains so every repo runs its CI jobs inside a container image instead of native execution:

- `ci/Containerfile` — pinned, reproducible CI image (toolchain + deps)
- `scripts/run_ci_local.sh` — run the exact CI jobs locally under podman (rootless, `--userns=keep-id`)
- Workflows rewritten to run all jobs `container:`-based via podman on ubuntu-24.04 runners
- Merge-queue smoke gate preserved

Validated locally: full `run_ci_local.sh all` (or the repo's CI subset) passes under podman.